### PR TITLE
config_tools: remove some useless tags in hybrid.xml

### DIFF
--- a/misc/config_tools/data/ehl-crb-b/hybrid.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid.xml
@@ -98,9 +98,6 @@
             <kern_type>KERNEL_ELF</kern_type>
             <kern_mod>Zephyr_ElfImage</kern_mod>
             <ramdisk_mod/>
-            <bootargs></bootargs>
-            <kern_load_addr>0x1000</kern_load_addr>
-            <kern_entry_addr>0x1000</kern_entry_addr>
         </os_config>
         <legacy_vuart id="0">
             <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/generic_board/hybrid.xml
+++ b/misc/config_tools/data/generic_board/hybrid.xml
@@ -88,9 +88,6 @@
       <kern_type>KERNEL_ELF</kern_type>
       <kern_mod>Zephyr_ElfImage</kern_mod>
       <ramdisk_mod></ramdisk_mod>
-      <bootargs/>
-      <kern_load_addr>0x8000</kern_load_addr>
-      <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid.xml
@@ -88,9 +88,6 @@
       <kern_type>KERNEL_ELF</kern_type>
       <kern_mod>Zephyr_ElfImage</kern_mod>
       <ramdisk_mod></ramdisk_mod>
-      <bootargs/>
-      <kern_load_addr>0x8000</kern_load_addr>
-      <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/nuc7i7dnb/hybrid.xml
+++ b/misc/config_tools/data/nuc7i7dnb/hybrid.xml
@@ -85,9 +85,6 @@
         <kern_type>KERNEL_ELF</kern_type>
         <kern_mod>Zephyr_ElfImage</kern_mod>
         <ramdisk_mod/>
-        <bootargs>reboot=acpi</bootargs>
-        <kern_load_addr>0x8000</kern_load_addr>
-        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
         <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/tgl-rvp/hybrid.xml
+++ b/misc/config_tools/data/tgl-rvp/hybrid.xml
@@ -93,9 +93,6 @@
         <kern_type>KERNEL_ELF</kern_type>
         <kern_mod>Zephyr_ElfImage</kern_mod>
         <ramdisk_mod/>
-        <bootargs>reboot=acpi</bootargs>
-        <kern_load_addr>0x8000</kern_load_addr>
-        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
         <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -85,9 +85,6 @@
         <kern_type>KERNEL_ELF</kern_type>
         <kern_mod>Zephyr_ElfImage</kern_mod>
         <ramdisk_mod/>
-        <bootargs>reboot=acpi</bootargs>
-        <kern_load_addr>0x8000</kern_load_addr>
-        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
         <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/whl-ipc-i7/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i7/hybrid.xml
@@ -85,9 +85,6 @@
         <kern_type>KERNEL_ELF</kern_type>
         <kern_mod>Zephyr_ElfImage</kern_mod>
         <ramdisk_mod/>
-        <bootargs>reboot=acpi</bootargs>
-        <kern_load_addr>0x8000</kern_load_addr>
-        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
         <type>VUART_LEGACY_PIO</type>


### PR DESCRIPTION
remove some useless tags in hybrid.xml files for all flatforms.

Tracked-On: #6384
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>