### PR TITLE
config_tools: update vTPM2 revision to 4

### DIFF
--- a/misc/config_tools/acpi_gen/bin_gen.py
+++ b/misc/config_tools/acpi_gen/bin_gen.py
@@ -77,7 +77,7 @@ def tpm2_acpi_gen(acpi_bin, board_etree, scenario_etree, allocation_etree):
             ctype_data = acpiparser.tpm2.TPM2(_data)
             ctype_data.header.signature = "TPM2".encode()
             ctype_data.header.length = _data_len
-            ctype_data.header.revision = 0x3
+            ctype_data.header.revision = 4
             ctype_data.header.oemid = "ACRN  ".encode()
             ctype_data.header.oemtableid = "ACRNTPM2".encode()
             ctype_data.header.oemrevision = 0x1


### PR DESCRIPTION
According to TCG ACPI specification (version 1.2), the current revision of
TPM2 table, which has the optional log area fields, is 4. This patch
updates the revision of vTPM2 accordingly.

Tracked-On: #6288
Signed-off-by: Junjie Mao <junjie.mao@intel.com>