### PR TITLE
config_tools: remove the log of sucessfully generating board XML

### DIFF
--- a/misc/config_tools/board_inspector/legacy/board_parser.py
+++ b/misc/config_tools/board_inspector/legacy/board_parser.py
@@ -113,5 +113,3 @@ if __name__ == '__main__':
 
     with open(BOARD_INFO, 'a+') as f:
         print("</acrn-config>", file=f)
-
-    print("{} has been generated successfully!".format(BOARD_INFO))


### PR DESCRIPTION
remove the log "<board>.xml has been generated successfully!" in
board_parser.py, because it only mean that the board xml file have
been created sucessfully here, not the all data have been appended
successfully and pretty formatted.

Tracked-On: #6315
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>