### PR TITLE
config-tools: refine log area start address allocation

### DIFF
--- a/misc/config_tools/static_allocators/gpa.py
+++ b/misc/config_tools/static_allocators/gpa.py
@@ -357,13 +357,14 @@ def allocate_log_area(board_etree, scenario_etree, allocation_etree):
 
     if common.get_node("//capability[@id='log_area']", board_etree) is not None:
         # VIRT_ACPI_DATA_ADDR
+        log_area_min_len = int(common.get_node(f"//log_area_minimum_length/text()", board_etree), 16)
         log_area_end_address = 0x7FFF0000
-        log_area_start_address = log_area_end_address - LOG_AREA_MIN_LEN
+        log_area_start_address = log_area_end_address - log_area_min_len
         allocation_vm_node = common.get_node(f"/acrn-config/vm[@id = '0']", allocation_etree)
         if allocation_vm_node is None:
             allocation_vm_node = common.append_node("/acrn-config/vm", None, allocation_etree, id = '0')
         common.append_node("./log_area_start_address", hex(log_area_start_address).upper(), allocation_vm_node)
-        common.append_node("./log_area_minimum_length", hex(LOG_AREA_MIN_LEN).upper(), allocation_vm_node)
+        common.append_node("./log_area_minimum_length", hex(log_area_min_len).upper(), allocation_vm_node)
 
 """
             Pre-launched VM gpa layout:


### PR DESCRIPTION
Allocates the log area start address using the same size as native environment.

Tracked-On: #6320
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>