### PR TITLE
config-tools: Kernel load and entry address accept empty string

### DIFF
--- a/misc/config_tools/data/ehl-crb-b/fusa_partition.xml
+++ b/misc/config_tools/data/ehl-crb-b/fusa_partition.xml
@@ -100,8 +100,6 @@
             <kern_mod>Zephyr_ElfImage</kern_mod>
             <ramdisk_mod/>
             <bootargs/>
-            <kern_load_addr>0x1000</kern_load_addr>
-            <kern_entry_addr>0x1000</kern_entry_addr>
         </os_config>
         <legacy_vuart id="0">
             <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/ehl-crb-b/hybrid.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid.xml
@@ -100,8 +100,6 @@
             <kern_mod>Zephyr_ElfImage</kern_mod>
             <ramdisk_mod/>
             <bootargs></bootargs>
-            <kern_load_addr>0x1000</kern_load_addr>
-            <kern_entry_addr>0x1000</kern_entry_addr>
         </os_config>
         <legacy_vuart id="0">
             <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/generic_board/hybrid.xml
+++ b/misc/config_tools/data/generic_board/hybrid.xml
@@ -90,8 +90,6 @@
       <kern_mod>Zephyr_ElfImage</kern_mod>
       <ramdisk_mod></ramdisk_mod>
       <bootargs/>
-      <kern_load_addr>0x8000</kern_load_addr>
-      <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid.xml
@@ -90,8 +90,6 @@
       <kern_mod>Zephyr_ElfImage</kern_mod>
       <ramdisk_mod></ramdisk_mod>
       <bootargs/>
-      <kern_load_addr>0x8000</kern_load_addr>
-      <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/nuc7i7dnb/hybrid.xml
+++ b/misc/config_tools/data/nuc7i7dnb/hybrid.xml
@@ -87,8 +87,6 @@
         <kern_mod>Zephyr_ElfImage</kern_mod>
         <ramdisk_mod/>
         <bootargs>reboot=acpi</bootargs>
-        <kern_load_addr>0x8000</kern_load_addr>
-        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
         <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/tgl-rvp/hybrid.xml
+++ b/misc/config_tools/data/tgl-rvp/hybrid.xml
@@ -95,8 +95,6 @@
         <kern_mod>Zephyr_ElfImage</kern_mod>
         <ramdisk_mod/>
         <bootargs>reboot=acpi</bootargs>
-        <kern_load_addr>0x8000</kern_load_addr>
-        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
         <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -87,8 +87,6 @@
         <kern_mod>Zephyr_ElfImage</kern_mod>
         <ramdisk_mod/>
         <bootargs>reboot=acpi</bootargs>
-        <kern_load_addr>0x8000</kern_load_addr>
-        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
         <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/whl-ipc-i7/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i7/hybrid.xml
@@ -87,8 +87,6 @@
         <kern_mod>Zephyr_ElfImage</kern_mod>
         <ramdisk_mod/>
         <bootargs>reboot=acpi</bootargs>
-        <kern_load_addr>0x8000</kern_load_addr>
-        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
         <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -180,12 +180,12 @@ must exactly match the module tag in the GRUB multiboot cmdline.</xs:documentati
         <xs:documentation>Configurable boot argument for pre-launched VM of hybrid or hybrid_rt mode.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="kern_load_addr" type="HexFormat" minOccurs="0">
+    <xs:element name="kern_load_addr" type="KernLoadAddr" minOccurs="0">
       <xs:annotation>
         <xs:documentation>The loading address in host memory for the VM kernel.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="kern_entry_addr" type="HexFormat" minOccurs="0">
+    <xs:element name="kern_entry_addr" type="KernEntryAddr" minOccurs="0">
       <xs:annotation>
         <xs:documentation>The entry address in host memory for the VM kernel.</xs:documentation>
       </xs:annotation>

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -40,6 +40,20 @@
   <xs:union memberTypes="None HexFormat" />
 </xs:simpleType>
 
+<xs:simpleType name="KernLoadAddr">
+  <xs:annotation>
+    <xs:documentation>Either empty, or an Integer value in hexadecimal format.</xs:documentation>
+  </xs:annotation>
+  <xs:union memberTypes="None HexFormat" />
+</xs:simpleType>
+
+<xs:simpleType name="KernEntryAddr">
+  <xs:annotation>
+    <xs:documentation>Either empty, or an Integer value in hexadecimal format.</xs:documentation>
+  </xs:annotation>
+  <xs:union memberTypes="None HexFormat" />
+</xs:simpleType>
+
 <xs:simpleType name="MaxMsixTableNumType">
   <xs:annotation>
     <xs:documentation>Integer from 1 to 2048.</xs:documentation>

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -168,10 +168,10 @@
     <xsl:value-of select="acrn:initializer('kernel_type', kern_type)" />
     <xsl:value-of select="acrn:initializer('kernel_mod_tag', concat($quot, kern_mod, $quot))" />
     <xsl:value-of select="acrn:initializer('ramdisk_mod_tag', concat($quot, ramdisk_mod, $quot))" />
-    <xsl:if test="kern_load_addr">
+    <xsl:if test="kern_load_addr/text()">
       <xsl:value-of select="acrn:initializer('kernel_load_addr', kern_load_addr)" />
     </xsl:if>
-    <xsl:if test="kern_entry_addr">
+    <xsl:if test="kern_entry_addr/text()">
       <xsl:value-of select="acrn:initializer('kernel_entry_addr', kern_entry_addr)" />
     </xsl:if>
     <xsl:if test="normalize-space(bootargs)">


### PR DESCRIPTION
Allow the kern_load_addr and kern_entry_addr take empty string.

Tracked-On: #6461
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>