### PR TITLE
hv: debug: add debug command inj_guest_exp

### DIFF
--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -107,6 +107,10 @@ struct shell {
 #define SHELL_CMD_WRMSR_HELP		"Write value (in hexadecimal) to the MSR at msr_index (in hexadecimal) for CPU"\
 					" ID pcpu_id"
 
+#define SHELL_CMD_INJ_GUEST_EXP		"inj_guest_exp"
+#define SHELL_CMD_INJ_GUEST_EXP_PARAM	"<vm id, vcpu id, exception_num>"
+#define SHELL_CMD_INJ_GUEST_EXP_HELP	"Inject an exception to a specific vCPU"
+
 #define SHELL_CMD_VMEXIT		"vmexit"
 #define SHELL_CMD_VMEXIT_PARAM		NULL
 #define SHELL_CMD_VMEXIT_HELP	"show vmexit profiling, use: vmexit [clear | enable | disable] enabled by default"

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -329,6 +329,11 @@ struct guest_mem_dump {
 	uint64_t len;
 };
 
+struct vcpu_inject_exception {
+	struct acrn_vcpu *vcpu;
+	uint32_t exception;
+};
+
 static inline bool is_vcpu_bsp(const struct acrn_vcpu *vcpu)
 {
 	return (vcpu->vcpu_id == BSP_CPU_ID);


### PR DESCRIPTION
inj_guest_exp can be used to inject a virtual exception to a
specified vcpu of a vm. The command format is as follows:
inj_guest_exp <vm id, vcpu id, exception_num>

Tracked-On: #6468
Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>