### PR TITLE
hv: minor cleanup of hv_main.c

### DIFF
--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -18,7 +18,6 @@
 void vcpu_thread(struct thread_object *obj)
 {
 	struct acrn_vcpu *vcpu = container_of(obj, struct acrn_vcpu, thread_obj);
-	uint32_t basic_exit_reason = 0U;
 	int32_t ret = 0;
 
 	do {
@@ -55,10 +54,7 @@ void vcpu_thread(struct thread_object *obj)
 			/* Fatal error happened (resume vcpu failed). Stop the vcpu running. */
 			continue;
 		}
-		basic_exit_reason = vcpu->arch.exit_reason & 0xFFFFU;
-		TRACE_2L(TRACE_VM_EXIT, basic_exit_reason, vcpu_get_rip(vcpu));
-
-		vcpu->arch.nrexits++;
+		TRACE_2L(TRACE_VM_EXIT, vcpu->arch.exit_reason, vcpu_get_rip(vcpu));
 
 		profiling_pre_vmexit_handler(vcpu);
 
@@ -69,7 +65,7 @@ void vcpu_thread(struct thread_object *obj)
 		ret = vmexit_handler(vcpu);
 		if (ret < 0) {
 			pr_fatal("dispatch VM exit handler failed for reason"
-				" %d, ret = %d!", basic_exit_reason, ret);
+				" %d, ret = %d!", vcpu->arch.exit_reason, ret);
 			vcpu_inject_gp(vcpu, 0U);
 			continue;
 		}

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -254,7 +254,6 @@ struct acrn_vcpu_arch {
 	bool irq_window_enabled;
 	bool emulating_lock;
 	bool xsave_enabled;
-	uint32_t nrexits;
 
 	/* VCPU context state information */
 	uint32_t exit_reason;


### PR DESCRIPTION
- remove vcpu->arch.nrexits which is useless.
- record full 32 bits of exit_reason to TRACE_2L(). Make the code simpler.

Tracked-On: #6289
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>