### PR TITLE
ACRN:hv: Fix vcpu_dumpreg command hang issue

### DIFF
--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -834,6 +834,12 @@ static int32_t shell_vcpu_dumpreg(int32_t argc, char **argv)
 		goto out;
 	}
 
+	if (is_lapic_pt_enabled(vcpu)) {
+		shell_puts("Please switch to vlapic mode for vcpu register dump!\r\n");
+		status = 0;
+		goto out;
+	}
+
 	pcpu_id = pcpuid_from_vcpu(vcpu);
 	dump.vcpu = vcpu;
 	dump.str = shell_log_buf;


### PR DESCRIPTION
In ACRN RT VM if the lapic is passthrough to the guest, the ipi can't
trigger VM_EXIT and the vNMI is just for notification, it can't handle
the smp_call function. Modify vcpu_dumpreg function prompt user switch
to vLAPIC mode for vCPU register dump.

Tracked-On: #6473
Signed-off-by: Liu Long <long.liu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>