### PR TITLE
doc: Add bc to build dependencies

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -134,7 +134,8 @@ To set up the ACRN build environment on the development computer:
            flex \
            bison \
            xsltproc \
-           clang-format
+           clang-format \
+           bc
 
 #. Install Python package dependencies:
 


### PR DESCRIPTION
When I follow the GSG, I got a error at the build process.
```
/bin/sh: 1: bc: not found
```
 So, I added bc to dependencies.