### PR TITLE
hv: simplify is_lapic_pt_enabled()

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -256,6 +256,7 @@ static void vcpu_reset_internal(struct acrn_vcpu *vcpu, enum reset_mode mode)
 
 	vcpu->arch.exception_info.exception = VECTOR_INVALID;
 	vcpu->arch.cur_context = NORMAL_WORLD;
+	vcpu->arch.lapic_pt_enabled = false;
 	vcpu->arch.irq_window_enabled = false;
 	vcpu->arch.emulating_lock = false;
 	(void)memset((void *)vcpu->arch.vmcs, 0U, PAGE_SIZE);
@@ -967,20 +968,6 @@ uint64_t vcpumask2pcpumask(struct acrn_vm *vm, uint64_t vdmask)
 	}
 
 	return dmask;
-}
-
-/*
- * @brief Check if vCPU uses LAPIC in x2APIC mode and the VM, vCPU belongs to, is configured for
- * LAPIC Pass-through
- *
- * @pre vcpu != NULL
- *
- * @return true, if vCPU LAPIC is in x2APIC mode and VM, vCPU belongs to, is configured for
- *				LAPIC Pass-through
- */
-bool is_lapic_pt_enabled(struct acrn_vcpu *vcpu)
-{
-	return ((is_x2apic_enabled(vcpu_vlapic(vcpu))) && (is_lapic_pt_configured(vcpu->vm)));
 }
 
 /*

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1702,6 +1702,7 @@ int32_t vlapic_set_apicbase(struct acrn_vlapic *vlapic, uint64_t new)
 				if (is_lapic_pt_configured(vcpu->vm)) {
 					/* vlapic need to be reset to make sure it is in correct state */
 					vlapic_reset(vlapic, &ptapic_ops, SOFTWARE_RESET);
+					vcpu->arch.lapic_pt_enabled = true;
 				}
 				vlapic->msr_apicbase = new;
 				vlapic_build_x2apic_id(vlapic);

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -250,7 +250,7 @@ struct acrn_vcpu_arch {
 		uint32_t error;
 	} exception_info;
 
-	uint8_t lapic_mask;
+	bool lapic_pt_enabled;
 	bool irq_window_enabled;
 	bool emulating_lock;
 	bool xsave_enabled;
@@ -729,7 +729,20 @@ int32_t prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id);
  * @return The physical destination CPU mask
  */
 uint64_t vcpumask2pcpumask(struct acrn_vm *vm, uint64_t vdmask);
-bool is_lapic_pt_enabled(struct acrn_vcpu *vcpu);
+
+/*
+ * @brief Check if vCPU uses LAPIC in x2APIC mode and the VM, vCPU belongs to, is configured for
+ * LAPIC Pass-through
+ *
+ * @pre vcpu != NULL
+ *
+ * @return true, if vCPU LAPIC is in x2APIC mode and VM, vCPU belongs to, is configured for
+ *				LAPIC Pass-through
+ */
+static inline bool is_lapic_pt_enabled(struct acrn_vcpu *vcpu)
+{
+	return vcpu->arch.lapic_pt_enabled;
+}
 
 /**
  * @brief handle posted interrupts


### PR DESCRIPTION
is_lapic_pt_enabled() is called at least twice in one loop of the vCPU
thread, and it's called in vmexit_handler() frequently if LAPIC is not
pass-through.  Thus the efficiency of this function has direct
impact to the system performance.

Since the LAPIC mode is not changed in run time, we don't have to
calculate it on the fly in is_lapic_pt_enabled().

BTW, removed the unused lapic_mask from struct acrn_vcpu_arch.

Tracked-On: #6289
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>