### PR TITLE
ACRN:DM: Add pointer check before use the erst

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -1817,6 +1817,11 @@ pci_xhci_insert_event(struct pci_xhci_vdev *xdev,
 	int erdp_idx;
 
 	rts = &xdev->rtsregs;
+	if (rts->erstba_p == NULL) {
+		UPRINTF(LFTL, "Invalid Event Ring Segment Table base address!\r\n");
+		return -EINVAL;
+	}
+
 	erdp = rts->intrreg.erdp & ~0xF;
 	erst = &rts->erstba_p[rts->er_enq_seg];
 	erdp_idx = (erdp - erst->qwRingSegBase) / sizeof(struct xhci_trb);


### PR DESCRIPTION
The event ring segment table  pointer may be NULL when get the address
from guest, add pointer check before use it.

Tracked-On: #6476
Signed-off-by: Liu Long <long.liu@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>