### PR TITLE
doc: remove hld-vsbl.rst Virtual Slim-Bootloader HLD

### DIFF
--- a/doc/developer-guides/hld/hld-vsbl.rst
+++ b/doc/developer-guides/hld/hld-vsbl.rst
@@ -1,4 +1,0 @@
-.. _hld-vsbl:
-
-Virtual Slim-Bootloader High-Level Design
-#########################################

--- a/doc/developer-guides/hld/index.rst
+++ b/doc/developer-guides/hld/index.rst
@@ -25,5 +25,4 @@ system.
    Virtio Devices <hld-virtio-devices>
    Power Management <hld-power-management>
    Tracing and Logging <hld-trace-log>
-   Virtual Bootloader <hld-vsbl>
    Security <hld-security>


### PR DESCRIPTION
Per Nanlin, we don't need this document.

It is blank and never contained content.

Signed-off-by: amyreye <amy.reyes@intel.com>