### PR TITLE
config-tools: assign a fixed address to log area start address

### DIFF
--- a/misc/config_tools/static_allocators/gpa.py
+++ b/misc/config_tools/static_allocators/gpa.py
@@ -358,8 +358,7 @@ def allocate_log_area(board_etree, scenario_etree, allocation_etree):
     if common.get_node("//capability[@id='log_area']", board_etree) is not None:
         # VIRT_ACPI_DATA_ADDR
         log_area_min_len = int(common.get_node(f"//log_area_minimum_length/text()", board_etree), 16)
-        log_area_end_address = 0x7FFF0000
-        log_area_start_address = log_area_end_address - log_area_min_len
+        log_area_start_address = 0x7FFB0000
         allocation_vm_node = common.get_node(f"/acrn-config/vm[@id = '0']", allocation_etree)
         if allocation_vm_node is None:
             allocation_vm_node = common.append_node("/acrn-config/vm", None, allocation_etree, id = '0')


### PR DESCRIPTION
Allocate the log area start address at fixed gpa 0x7FFB0000.

Tracked-On: #6320
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>