### PR TITLE
ACRN:DM: Fix the bug introduced by 977da8f

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -1817,7 +1817,7 @@ pci_xhci_insert_event(struct pci_xhci_vdev *xdev,
 	int erdp_idx;
 
 	rts = &xdev->rtsregs;
-	if (&rts->erstba_p == NULL) {
+	if (rts->erstba_p == NULL) {
 		UPRINTF(LFTL, "Invalid Event Ring Segment Table base address!\r\n");
 		return -EINVAL;
 	}


### PR DESCRIPTION
Fix the bug introduced by 977da8f08. There had a typo that added the "&" by mistake.

Tracked-On: #6476
Signed-off-by: Liu Long <long.liu@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>