### PR TITLE
config_tools: update the logic of getting gpu bdf

### DIFF
--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -224,14 +224,15 @@ def interrupt_storm(pt_sel, config):
 def gvt_arg_set(dm, vmid, uos_type, config):
 
     gvt_args = dm['gvt_args'][vmid]
-    if gvt_args == "gvtd":
-        bus = int(launch_cfg_lib.GPU_BDF.split(':')[0], 16)
-        dev = int(launch_cfg_lib.GPU_BDF.split('.')[0].split(':')[1], 16)
-        fun = int(launch_cfg_lib.GPU_BDF.split('.')[1], 16)
+    gpu_bdf = launch_cfg_lib.get_gpu_bdf()
+
+    if gvt_args == "gvtd" and gpu_bdf is not None:
+        bus = int(gpu_bdf[0:2], 16)
+        dev = int(gpu_bdf[3:5], 16)
+        fun = int(gpu_bdf[6:7], 16)
         print('   -s 2,passthru,{}/{}/{},gpu  \\'.format(bus, dev, fun), file=config)
     elif gvt_args:
         print('   -s 2,pci-gvt -G "$2"  \\', file=config)
-
 
 def log_level_set(uos_type, config):
 
@@ -603,14 +604,14 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
     # set logger_setting for all VMs
     print("   $logger_setting \\", file=config)
 
+    # GVT args set
+    gvt_arg_set(dm, vmid, uos_type, config)
+
     # XHCI args set
     xhci_args_set(dm, vmid, config)
 
     # VIRTIO args set
     virtio_args_set(dm, virt_io, vmid, config)
-
-    # GVT args set
-    gvt_arg_set(dm, vmid, uos_type, config)
 
     # vbootloader setting
     vboot_arg_set(dm, vmid, config)

--- a/misc/config_tools/launch_config/pt.py
+++ b/misc/config_tools/launch_config/pt.py
@@ -253,7 +253,8 @@ def gen_pt_head(names, dm, sel, vmid, config):
             continue
         print('["{}"]="0000:{}"'.format(pt_dev, sel.bdf[pt_dev][vmid]), file=config)
     if dm['gvt_args'][vmid] == "gvtd":
-        print('["gpu"]="0000:{}"'.format(launch_cfg_lib.GPU_BDF), file=config)
+        gpu_bdf = launch_cfg_lib.get_gpu_bdf()
+        print('["gpu"]="0000:{}"'.format(gpu_bdf), file=config)
     print(')', file=config)
 
     print("", file=config)

--- a/misc/config_tools/library/launch_cfg_lib.py
+++ b/misc/config_tools/library/launch_cfg_lib.py
@@ -57,7 +57,6 @@ PM_CHANNEL_DIC = {
 }
 
 MOUNT_FLAG_DIC = {}
-GPU_BDF = "00:02.0"
 
 
 def usage(file_name):
@@ -506,12 +505,24 @@ def bdf_duplicate_check(bdf_dic):
                 bdf_used.append(dev_bdf)
 
 
+def get_gpu_bdf():
+
+    pci_lines = board_cfg_lib.get_info(common.BOARD_INFO_FILE, "<PCI_DEVICE>", "</PCI_DEVICE>")
+
+    for line in pci_lines:
+        if "VGA compatible controller" in line:
+            global gpu_bdf
+            gpu_bdf = line.split('\t')[1]
+            gpu_bdf = gpu_bdf[0:7]
+    return gpu_bdf
+
 def get_gpu_vpid():
 
     vpid = ''
     vpid_lines = board_cfg_lib.get_info(common.BOARD_INFO_FILE, "<PCI_VID_PID>", "</PCI_VID_PID>")
+    gpu_bdf = get_gpu_bdf()
     for vpid_line in vpid_lines:
-        if GPU_BDF in vpid_line:
+        if gpu_bdf in vpid_line:
             vpid = " ".join(vpid_line.split()[2].split(':'))
     return vpid
 


### PR DESCRIPTION
The bdf of gpu is not 00:02.0 for the new platform icx-rvp,
it is 05:00.0 now, so we remove the hardcode 00:02.0;
And change to get the gpu bdf from board.xml.

Tracked-On: #6357
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>