### PR TITLE
release_2.6: hv: Add check to ensure vcpu_make_request and signal_event are consistent

### DIFF
--- a/hypervisor/arch/x86/guest/lock_instr_emul.c
+++ b/hypervisor/arch/x86/guest/lock_instr_emul.c
@@ -45,7 +45,7 @@ void vcpu_kick_lock_instr_emulation(struct acrn_vcpu *cur_vcpu)
 		get_vm_lock(cur_vcpu->vm);
 
 		foreach_vcpu(i, cur_vcpu->vm, other) {
-			if (other != cur_vcpu) {
+			if ((other != cur_vcpu) && (other->state == VCPU_RUNNING)) {
 				vcpu_make_request(other, ACRN_REQUEST_SPLIT_LOCK);
 			}
 		}
@@ -59,7 +59,7 @@ void vcpu_complete_lock_instr_emulation(struct acrn_vcpu *cur_vcpu)
 
 	if (cur_vcpu->vm->hw.created_vcpus > 1U) {
 		foreach_vcpu(i, cur_vcpu->vm, other) {
-			if (other != cur_vcpu) {
+			if ((other != cur_vcpu) && (other->state == VCPU_RUNNING)) {
 				signal_event(&other->events[VCPU_EVENT_SPLIT_LOCK]);
 			}
 		}

--- a/hypervisor/include/common/event.h
+++ b/hypervisor/include/common/event.h
@@ -4,7 +4,7 @@
 
 struct sched_event {
 	spinlock_t lock;
-	int8_t nqueued;
+	int32_t nqueued;
 	struct thread_object* waiting_thread;
 };
 


### PR DESCRIPTION
Currently the vcpu_make_request and signal_event in vcpu_lock_instr_emulation
does not check whether target VCPU is up and running. This can cause
problems because when VCPU is created but not launched,
vcpu_make_request will not trigger wait_event on target VCPU, but
signal_event may still execute to reduce the counter.

This patch adds a check before vcpu_make_request and signal_event to
make sure the request and signal are issued after target VCPU is up.

Tracked-On: #6502
Signed-off-by: Yifan Liu <yifan1.liu@intel.com>