### PR TITLE
config-tools: refine misc_cfg.h.xsl and lib.xsl

### DIFF
--- a/misc/config_tools/xforms/lib.xsl
+++ b/misc/config_tools/xforms/lib.xsl
@@ -392,8 +392,8 @@
   </func:function>
 
   <func:function name="acrn:is-rdt-supported">
-    <xsl:variable name="rdt_resource" select="substring-before(substring-after(//CLOS_INFO, 'rdt resources supported:'), 'rdt resource clos max:')" />
-    <xsl:variable name="rdt_res_clos_max" select="substring-before(substring-after(//CLOS_INFO, 'rdt resource clos max:'), 'rdt resource mask max:')" />
+    <xsl:variable name="rdt_resource" select="acrn:get-normalized-closinfo-rdt-res-str()" />
+    <xsl:variable name="rdt_res_clos_max" select="acrn:get-normalized-closinfo-rdt-clos-max-str()" />
     <xsl:choose>
       <xsl:when test="$rdt_resource and $rdt_res_clos_max">
         <func:result select="true()" />
@@ -635,5 +635,18 @@
     <func:result select="concat($bus, ':', $dev, '.', $func)" />
   </func:function>
   <!-- End of scenario-specific functions-->
+
+  <!-- Board-specific functions-->
+  <func:function name="acrn:get-normalized-closinfo-rdt-res-str">
+    <xsl:variable name="rdt_resource" select="translate(substring-before(substring-after(//CLOS_INFO, 'rdt resources supported:'), 'rdt resource clos max:'), '&#x9;&#xa;&#xd;&#x20;', '')" />
+    <func:result select="$rdt_resource" />
+  </func:function>
+
+  <func:function name="acrn:get-normalized-closinfo-rdt-clos-max-str">
+    <xsl:variable name="rdt_res_clos_max" select="translate(substring-before(substring-after(//CLOS_INFO, 'rdt resource clos max:'), 'rdt resource mask max:'), '&#x9;&#xa;&#xd;&#x20;', '')" />
+    <func:result select="$rdt_res_clos_max" />
+  </func:function>
+
+  <!-- End of board-specific functions-->
 
 </xsl:stylesheet>

--- a/misc/config_tools/xforms/lib.xsl
+++ b/misc/config_tools/xforms/lib.xsl
@@ -149,7 +149,7 @@
     <xsl:param name="list" />
     <xsl:param name="delimar" />
     <func:result>
-      <xsl:value-of select="acrn:find-list-min-aux($list, $delimar, '')" />
+      <xsl:value-of select="acrn:find-list-min-aux($list, $delimar, '1000000000000000000000000000000000000000')" />
     </func:result>
   </func:function>
 

--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -145,8 +145,8 @@
 <!-- MAX_CACHE_CLOS_NUM_ENTRIES:
   Max number of MBA delay entries corresponding to each CLOS. -->
 <xsl:template name="rdt">
-  <xsl:variable name="rdt_resource" select="translate(normalize-space(substring-before(substring-after(//CLOS_INFO, 'rdt resources supported:'), 'rdt resource clos max:')), ' ', '')" />
-  <xsl:variable name="rdt_res_clos_max" select="translate(normalize-space(substring-before(substring-after(//CLOS_INFO, 'rdt resource clos max:'), 'rdt resource mask max:')), ' ', '')" />
+  <xsl:variable name="rdt_resource" select="acrn:get-normalized-closinfo-rdt-res-str()" />
+  <xsl:variable name="rdt_res_clos_max" select="acrn:get-normalized-closinfo-rdt-clos-max-str()" />
   <xsl:variable name="common_clos_max" select="acrn:get-common-clos-max('', $rdt_resource, $rdt_res_clos_max)"/>
   <xsl:choose>
     <xsl:when test="acrn:is-cdp-enabled()">

--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -145,8 +145,8 @@
 <!-- MAX_CACHE_CLOS_NUM_ENTRIES:
   Max number of MBA delay entries corresponding to each CLOS. -->
 <xsl:template name="rdt">
-  <xsl:variable name="rdt_resource" select="normalize-space(substring-before(substring-after(//CLOS_INFO, 'rdt resources supported:'), 'rdt resource clos max:'))" />
-  <xsl:variable name="rdt_res_clos_max" select="normalize-space(substring-before(substring-after(//CLOS_INFO, 'rdt resource clos max:'), 'rdt resource mask max:'))" />
+  <xsl:variable name="rdt_resource" select="translate(normalize-space(substring-before(substring-after(//CLOS_INFO, 'rdt resources supported:'), 'rdt resource clos max:')), ' ', '')" />
+  <xsl:variable name="rdt_res_clos_max" select="translate(normalize-space(substring-before(substring-after(//CLOS_INFO, 'rdt resource clos max:'), 'rdt resource mask max:')), ' ', '')" />
   <xsl:variable name="common_clos_max" select="acrn:get-common-clos-max('', $rdt_resource, $rdt_res_clos_max)"/>
   <xsl:choose>
     <xsl:when test="acrn:is-cdp-enabled()">


### PR DESCRIPTION
The whitespaces between delimar saperated elemnts of a list causes
acrn:get-common-clos-max and acrn:find-list-min returns unexpected
numbers. Add translate to remove the whitspaces.

Initialize the minimum value to an extreme large value to avoid the
return value of acrn:find-list-min is empty.

Tracked-On: #6515
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>