### PR TITLE
config_tools: update scenario xml files on tgl-rvp platform

### DIFF
--- a/misc/config_tools/data/tgl-rvp/hybrid.xml
+++ b/misc/config_tools/data/tgl-rvp/hybrid.xml
@@ -17,7 +17,7 @@
         <MULTIBOOT2>y</MULTIBOOT2>
         <ENFORCE_TURNOFF_AC>y</ENFORCE_TURNOFF_AC>
         <ENFORCE_TURNOFF_GP>n</ENFORCE_TURNOFF_GP>
-        <SECURITY_VM_FIXUP>y</SECURITY_VM_FIXUP>
+        <SECURITY_VM_FIXUP>n</SECURITY_VM_FIXUP>
         <RDT>
             <RDT_ENABLED>n</RDT_ENABLED>
             <CDP_ENABLED>n</CDP_ENABLED>
@@ -71,7 +71,7 @@
     <vm_type>SAFETY_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM0</name>
     <guest_flags>
-        <guest_flag>GUEST_FLAG_SECURITY_VM</guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>3</pcpu_id>

--- a/misc/config_tools/data/tgl-rvp/hybrid_rt.xml
+++ b/misc/config_tools/data/tgl-rvp/hybrid_rt.xml
@@ -17,7 +17,7 @@
         <MULTIBOOT2>y</MULTIBOOT2>
         <ENFORCE_TURNOFF_AC>y</ENFORCE_TURNOFF_AC>
         <ENFORCE_TURNOFF_GP>n</ENFORCE_TURNOFF_GP>
-        <SECURITY_VM_FIXUP>n</SECURITY_VM_FIXUP>
+        <SECURITY_VM_FIXUP>y</SECURITY_VM_FIXUP>
         <RDT>
             <RDT_ENABLED>n</RDT_ENABLED>
             <CDP_ENABLED>y</CDP_ENABLED>
@@ -76,6 +76,7 @@
     <guest_flags>
         <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
         <guest_flag>GUEST_FLAG_RT</guest_flag>
+        <guest_flag>GUEST_FLAG_SECURITY_VM</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>2</pcpu_id>


### PR DESCRIPTION
For SMBIOS and TPM, enable SECURITY_VM_FIXUP and add GUEST_FLAG_SECURITY_VM
flag in TGL hybrid_rt.xml. Then disable SECURITY_VM_FIXUP in TGL hybrid.xml
because it’s previously enabled in hybrid.xml instead of hybrid_rt.xml by
mistake.

Tracked-On: #6320
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>