### PR TITLE
hv: initialize host IA32_PAT MSR

### DIFF
--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -155,6 +155,9 @@ void enable_paging(void)
 {
 	uint64_t tmp64 = 0UL;
 
+	/* Initialize IA32_PAT according to ISDM 11.12.4 Programming the PAT */
+	msr_write(MSR_IA32_PAT, PAT_POWER_ON_VALUE);
+
 	/*
 	 * Enable MSR IA32_EFER.NXE bit,to prevent
 	 * instruction fetching from pages with XD bit set.


### PR DESCRIPTION
Currently ACRN assumes firmware setup IA32_PAT correctly.  This patch
explicitly initializes host IA32_PAT MSR according to ISDM Table 11-12.
Memory Type Setting of PAT Entries Following a Power-up or Reset.

ACRN creates host page tables based on PAT0 (WB) and PAT3 (UC).

Tracked-On: #6289
Signed-off-by: Zide Chen <zide.chen@intel.com>