### PR TITLE
config_tools: update scenario xml file on ehl-crb-b platform

### DIFF
--- a/misc/config_tools/data/ehl-crb-b/hybrid.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid.xml
@@ -179,7 +179,7 @@
             <pci_dev/>
         </pci_devs>
         <board_private>
-            <rootfs>/dev/sda3</rootfs>
+            <rootfs>/dev/nvme0n1p3</rootfs>
             <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 swiotlb=131072


### PR DESCRIPTION
for ehl-crb-b platform, update sos rootfs from "dev/sda3"
to "/dev/nvme0n1p3" in hybrid.xml file.

Tracked-On: #6530
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>