### PR TITLE
ACRN:DM Release resource when destroy the device

### DIFF
--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -1119,6 +1119,24 @@ errout:
 }
 
 void
+usb_dev_free_request(void *pdata)
+{
+	struct libusb_transfer *trn;
+
+	trn = pdata;
+	libusb_free_transfer(trn);
+}
+
+void
+usb_dev_cancel_request(void *pdata)
+{
+	struct libusb_transfer *trn;
+
+	trn = pdata;
+	libusb_cancel_transfer(trn);
+}
+
+void
 usb_dev_deinit(void *pdata)
 {
 	int rc = 0;

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -115,6 +115,8 @@ struct usb_devemu {
 	int	(*ue_reset)(void *sc);
 	int	(*ue_remove)(void *sc);
 	int	(*ue_stop)(void *sc);
+	void    (*ue_cancel_req)(void *pdata);
+	void	(*ue_free_req)(void *pdata);
 	void	(*ue_deinit)(void *pdata);
 };
 #define	USB_EMUL_SET(x)	DATA_SET(usb_emu_set, x)

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -129,4 +129,6 @@ int usb_dev_info(void *pdata, int type, void *value, int size);
 int usb_dev_request(void *pdata, struct usb_xfer *xfer);
 int usb_dev_reset(void *pdata);
 int usb_dev_data(void *pdata, struct usb_xfer *xfer, int dir, int epctx);
+void usb_dev_cancel_request(void *pdata);
+void usb_dev_free_request(void *pdata);
 #endif


### PR DESCRIPTION
When destroy the usb device release the resource allocate for transfer
in case cause the memory leak issue. Add the release and cancel
transfer request call back for the emulation device, use the emulation
device call back in xHCI controller emulation.

Tracked-On: #6533
Signed-off-by: Liu Long <long.liu@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>