### PR TITLE
crashlog: fix build issue with e2fsprogs v1.46.2

### DIFF
--- a/misc/debug_tools/acrn_crashlog/acrnprobe/loop.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/loop.c
@@ -231,7 +231,7 @@ int loopdev_check_parname(const char *loopdev, const char *parname)
 		/* only look into the primary super block */
 		if (super.s_volume_name[0]) {
 			close(fd);
-			return !strcmp((const char *)super.s_volume_name, parname);
+			return !strncmp((const char *)super.s_volume_name, parname, EXT2_LABEL_LEN);
 		}
 		break;
 	}


### PR DESCRIPTION
In e2fsprogs v1.46.2, s_volume_name is defined with attribute
nonstring. According to gcc doc, nostring defined string may
not contain a terminating NULL. So array safed function should
be used.

We use strncmp instead of strcmp to do comparing here.

Tracked-On: #6494
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>