### PR TITLE
config_tools: support SRIOV based GPU sharing in launch script

### DIFF
--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -220,19 +220,23 @@ def interrupt_storm(pt_sel, config):
     print('intr_storm_monitor="--intr_monitor 10000,10,1,100"', file=config)
     print("", file=config)
 
-
 def gvt_arg_set(dm, vmid, uos_type, config):
 
     gvt_args = dm['gvt_args'][vmid]
     gpu_bdf = launch_cfg_lib.get_gpu_bdf()
 
-    if gvt_args == "gvtd" and gpu_bdf is not None:
+    if gpu_bdf is not None:
         bus = int(gpu_bdf[0:2], 16)
         dev = int(gpu_bdf[3:5], 16)
         fun = int(gpu_bdf[6:7], 16)
-        print('   -s 2,passthru,{}/{}/{},gpu  \\'.format(bus, dev, fun), file=config)
-    elif gvt_args:
-        print('   -s 2,pci-gvt -G "$2"  \\', file=config)
+        if gvt_args == "gvtd":
+            print('   -s 2,passthru,{}/{}/{},gpu  \\'.format(bus, dev, fun), file=config)
+        elif gvt_args == "sriov" and uos_type in launch_cfg_lib.LINUX_LIKE_OS and uos_type != "PREEMPT-RT LINUX":
+            print('   -s 2,passthru,{}/{}/1,gpu  \\'.format(bus, dev), file=config)
+        elif gvt_args == "sriov" and uos_type == "WINDOWS":
+            print('   -s 2,passthru,{}/{}/2,igd-vf  \\'.format(bus, dev), file=config)
+        elif gvt_args:
+            print('   -s 2,pci-gvt -G "$2"  \\', file=config)
 
 def log_level_set(uos_type, config):
 

--- a/misc/config_tools/launch_config/pt.py
+++ b/misc/config_tools/launch_config/pt.py
@@ -242,7 +242,7 @@ def gen_pt_head(names, dm, sel, vmid, config):
         if not sel.vpid[pt_dev] or not sel.vpid[pt_dev][vmid]:
             continue
         print('["{}"]="{}"'.format(pt_dev, sel.vpid[pt_dev][vmid]), file=config)
-    if dm['gvt_args'][vmid] == "gvtd":
+    if dm['gvt_args'][vmid] == "gvtd" or dm['gvt_args'][vmid] == "sriov":
         gpu_vpid = launch_cfg_lib.get_gpu_vpid()
         print('["gpu"]="{}"'.format(gpu_vpid), file=config)
     print(')', file=config)
@@ -252,9 +252,13 @@ def gen_pt_head(names, dm, sel, vmid, config):
         if not sel.bdf[pt_dev] or not sel.bdf[pt_dev][vmid]:
             continue
         print('["{}"]="0000:{}"'.format(pt_dev, sel.bdf[pt_dev][vmid]), file=config)
+    gpu_bdf = launch_cfg_lib.get_gpu_bdf()
     if dm['gvt_args'][vmid] == "gvtd":
-        gpu_bdf = launch_cfg_lib.get_gpu_bdf()
         print('["gpu"]="0000:{}"'.format(gpu_bdf), file=config)
+    elif uos_type in launch_cfg_lib.LINUX_LIKE_OS and uos_type != "PREEMPT-RT LINUX" and dm['gvt_args'][vmid] == "sriov":
+        print('["gpu"]="0000:{}.1"'.format(gpu_bdf[0:5]), file=config)
+    elif dm['gvt_args'][vmid] == "sriov" and uos_type == "WINDOWS":
+        print('["gpu"]="0000:{}.2"'.format(gpu_bdf[0:5]), file=config)
     print(')', file=config)
 
     print("", file=config)


### PR DESCRIPTION
We will use SRIOV based GPU sharing to replace default GVT-d config
on adl-s-crb platform. So add the logic of passthru gpu VF,
If the string "sriov" is found in launch xml, we will hardcode
different value to gpu VF and set different parameter for WaaG and
LaaG in launch script.

The relevant line in the generated launch script will look like this:
Laag: "-s 2,passthru,0/2/1,gpu  \"
WaaG: "-s 2,passthru,0/2/2,igd-vf  \"

Tracked-On: #6290
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>