### PR TITLE
[release 2.5]board_inspector/cli: export PATH to the legacy board parser

### DIFF
--- a/misc/config_tools/board_inspector/cli.py
+++ b/misc/config_tools/board_inspector/cli.py
@@ -19,7 +19,7 @@ def main(board_name, board_xml, args):
     try:
         # First invoke the legacy board parser to create the board XML ...
         legacy_parser = os.path.join(script_dir, "legacy", "board_parser.py")
-        env = { "PYTHONPATH": script_dir }
+        env = { "PYTHONPATH": script_dir, "PATH": os.environ["PATH"] }
         subprocess.run([sys.executable, legacy_parser, args.board_name, "--out", board_xml], check=True, env=env)
 
         # ... then load the created board XML and append it with additional data by invoking the extractors.


### PR DESCRIPTION
Customized environment variables are not inherited to child processes
created by the subprocess module. As a result the legacy board parser may
not be able to locate the prerequisite utilities if they can be found only
with the customized PATH.

This patch passes the PATH of cli.py to the legacy parser so that both
scripts use the same PATH to search for utilities.

This patch is added in v2 of the series.

Tracked-On: #6287
Signed-off-by: Junjie Mao <junjie.mao@intel.com>