### PR TITLE
release_2.6: hv: mmiodev: a minor bug fix about refine acrn_mmiodev data structure

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -302,8 +302,8 @@ static void prepare_prelaunched_vm_memmap(struct acrn_vm *vm, const struct acrn_
 		(void)assign_mmio_dev(vm, &vm_config->mmiodevs[i]);
 
 #ifdef P2SB_VGPIO_DM_ENABLED
-		if ((vm_config->pt_p2sb_bar) && (vm_config->mmiodevs[i].base_hpa == P2SB_BAR_ADDR)) {
-			register_vgpio_handler(vm, &vm_config->mmiodevs[i]);
+		if ((vm_config->pt_p2sb_bar) && (vm_config->mmiodevs[i].res[0].host_pa == P2SB_BAR_ADDR)) {
+			register_vgpio_handler(vm, &vm_config->mmiodevs[i].res[0]);
 		}
 #endif
 	}

--- a/hypervisor/dm/vgpio.c
+++ b/hypervisor/dm/vgpio.c
@@ -129,17 +129,17 @@ static int32_t vgpio_mmio_handler(struct io_request *io_req, void *data)
 }
 
 /**
- * @pre vm != NULL && mmiodev != NULL
+ * @pre vm != NULL && res != NULL
  */
-void register_vgpio_handler(struct acrn_vm *vm, const struct acrn_mmiodev *mmiodev)
+void register_vgpio_handler(struct acrn_vm *vm, const struct acrn_mmiores *res)
 {
 	uint64_t gpa_start, gpa_end, gpio_pcr_sz;
 	uint64_t base_hpa;
 
-	gpa_start   = mmiodev->user_vm_pa + (P2SB_BASE_GPIO_PORT_ID << P2SB_PORTID_SHIFT);
+	gpa_start   = res->user_vm_pa + (P2SB_BASE_GPIO_PORT_ID << P2SB_PORTID_SHIFT);
 	gpio_pcr_sz = P2SB_PCR_SPACE_SIZE_PER_AGENT * P2SB_MAX_GPIO_COMMUNITIES;
 	gpa_end     = gpa_start + gpio_pcr_sz;
-	base_hpa    = mmiodev->host_pa + (P2SB_BASE_GPIO_PORT_ID << P2SB_PORTID_SHIFT);
+	base_hpa    = res->host_pa + (P2SB_BASE_GPIO_PORT_ID << P2SB_PORTID_SHIFT);
 
 	/* emulate MMIO access to the GPIO private configuration space registers */
 	set_paging_supervisor((uint64_t)hpa2hva(base_hpa), gpio_pcr_sz);

--- a/hypervisor/include/dm/vgpio.h
+++ b/hypervisor/include/dm/vgpio.h
@@ -7,6 +7,6 @@
 #ifndef VGPIO_H
 #define VGPIO_H
 
-void register_vgpio_handler(struct acrn_vm *vm, const struct acrn_mmiodev *mmiodev);
+void register_vgpio_handler(struct acrn_vm *vm, const struct acrn_mmiores *res);
 
 #endif /* MMIO_DEV_H */


### PR DESCRIPTION
Rename base_hpa to host_pa in acrn_mmiodev data structure.

Tracked-On: #6366
Signed-off-by: Fei Li <fei1.li@intel.com>