### PR TITLE
doc: fix broken links to network scripts in HLD

### DIFF
--- a/doc/developer-guides/hld/virtio-net.rst
+++ b/doc/developer-guides/hld/virtio-net.rst
@@ -426,11 +426,10 @@ our case, we use systemd to automatically create the network by default.
 You can check the files with prefix 50- in the Service VM
 ``/usr/lib/systemd/network/``:
 
-- :acrn_raw:`50-acrn.netdev <misc/acrnbridge/acrn.netdev>`
-- :acrn_raw:`50-acrn.netdev <misc/acrnbridge/acrn.netdev>`
-- :acrn_raw:`50-acrn.network <misc/acrnbridge/acrn.network>`
-- :acrn_raw:`50-tap0.netdev <misc/acrnbridge/tap0.netdev>`
-- :acrn_raw:`50-eth.network <misc/acrnbridge/eth.network>`
+- :acrn_raw:`50-acrn.netdev <misc/services/acrn_bridge/acrn.netdev>`
+- :acrn_raw:`50-acrn.network <misc/services/acrn_bridge/acrn.network>`
+- :acrn_raw:`50-tap0.netdev <misc/services/acrn_bridge/tap0.netdev>`
+- :acrn_raw:`50-eth.network <misc/services/acrn_bridge/eth.network>`
 
 When the Service VM is started, run ``ifconfig`` to show the devices created by
 this systemd configuration:


### PR DESCRIPTION
Fix broken links in the Virtio-Net HLD that point at the network
scripts in the source code repository.

Tracked-On: #6542
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>