### PR TITLE
hv: v2.5: enable CAT for tgl-rvp

### DIFF
--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -321,13 +321,9 @@ static void prepare_auto_msr_area (struct acrn_vcpu *vcpu)
 
 	/* only load/restore MSR IA32_PQR_ASSOC when hv and guest have differnt settings */
 	if (is_platform_rdt_capable() && (vcpu_clos != hv_clos)) {
-		vcpu->arch.msr_area.guest[MSR_AREA_IA32_PQR_ASSOC].msr_index = MSR_IA32_PQR_ASSOC;
-		vcpu->arch.msr_area.guest[MSR_AREA_IA32_PQR_ASSOC].value = clos2pqr_msr(vcpu_clos);
-		vcpu->arch.msr_area.host[MSR_AREA_IA32_PQR_ASSOC].msr_index = MSR_IA32_PQR_ASSOC;
-		vcpu->arch.msr_area.host[MSR_AREA_IA32_PQR_ASSOC].value = clos2pqr_msr(hv_clos);
-		vcpu->arch.msr_area.count++;
-		pr_acrnlog("switch clos for VM %u vcpu_id %u, host 0x%x, guest 0x%x",
-			vcpu->vm->vm_id, vcpu->vcpu_id, hv_clos, vcpu_clos);
+		msr_write_pcpu(MSR_IA32_PQR_ASSOC, clos2pqr_msr(vcpu_clos), pcpuid_from_vcpu(vcpu));
+		pr_acrnlog("switch clos for VM %u vcpu_id %u: 0x%x",
+			vcpu->vm->vm_id, vcpu->vcpu_id, vcpu_clos);
 	}
 }
 

--- a/hypervisor/arch/x86/rdt.c
+++ b/hypervisor/arch/x86/rdt.c
@@ -114,7 +114,11 @@ void init_rdt_info(void)
 	uint8_t i;
 	uint32_t eax = 0U, ebx = 0U, ecx = 0U, edx = 0U;
 
-	if (pcpu_has_cap(X86_FEATURE_RDT_A)) {
+	if (MAX_CACHE_CLOS_NUM_ENTRIES > 0) {
+		pr_acrnlog("LLC CAT enabled.");
+		res_cap_info[RDT_RESOURCE_L3].clos_max = MAX_CACHE_CLOS_NUM_ENTRIES;
+
+	} else if (pcpu_has_cap(X86_FEATURE_RDT_A)) {
 		cpuid_subleaf(CPUID_RDT_ALLOCATION, 0U, &eax, &ebx, &ecx, &edx);
 
 		/* If HW supports L3 CAT, EBX[1] is set */

--- a/misc/config_tools/data/tgl-rvp/industry.xml
+++ b/misc/config_tools/data/tgl-rvp/industry.xml
@@ -15,16 +15,12 @@
       <MULTIBOOT2>y</MULTIBOOT2>
       <ENFORCE_TURNOFF_AC>y</ENFORCE_TURNOFF_AC>
       <RDT>
-        <RDT_ENABLED>n</RDT_ENABLED>
-        <CDP_ENABLED>y</CDP_ENABLED>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
+            <RDT_ENABLED>y</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+                <CLOS_MASK>0x0ff</CLOS_MASK>
+                <CLOS_MASK>0xf00</CLOS_MASK>
+                <CLOS_MASK>0x0ff</CLOS_MASK>
+                <CLOS_MASK>0x0ff</CLOS_MASK>
       </RDT>
       <NVMX_ENABLED>n</NVMX_ENABLED>
       <HYPERV_ENABLED>y</HYPERV_ENABLED>
@@ -159,8 +155,8 @@
       <pcpu_id>3</pcpu_id>
     </cpu_affinity>
     <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
+        <vcpu_clos>0</vcpu_clos>
+        <vcpu_clos>1</vcpu_clos>
     </clos>
     <epc_section>
       <base>0</base>

--- a/misc/config_tools/data/tgl-rvp/tgl-rvp.xml
+++ b/misc/config_tools/data/tgl-rvp/tgl-rvp.xml
@@ -258,9 +258,9 @@
 	TPM2
 	</TPM_INFO>
   <CLOS_INFO>
-	rdt resources supported: L2
-	rdt resource clos max: 8
-	rdt resource mask max: '0xfffff'
+	rdt resources supported: L3
+	rdt resource clos max: 4
+	rdt resource mask max: '0xfff'
 	</CLOS_INFO>
   <IOMEM_INFO>
 	00000000-00000fff : Reserved


### PR DESCRIPTION
enable CAT for tgl-rvp on release-v2.5

Configure LLC CAT rt-core: 0xf00, others: 0x0ff

Tracked-On: #6547
Signed-off-by: Minggui Cao <minggui.cao@intel.com>