### PR TITLE
config_tools: rename UI menu

### DIFF
--- a/misc/config_tools/config_app/templates/base.html
+++ b/misc/config_tools/config_app/templates/base.html
@@ -45,7 +45,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h4 class="modal-title" id="loadScenarioModalLabel">Load Scenario Setting</h4>
+                <h4 class="modal-title" id="loadScenarioModalLabel">Load Default Scenario Settings</h4>
             </div>
             <div class="modal-body">
                 <div class="form-group row">
@@ -81,7 +81,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h4 class="modal-title" id="loadLaunchModalLabel">Load Launch setting</h4>
+                <h4 class="modal-title" id="loadLaunchModalLabel">Load Default Launch Settings</h4>
             </div>
             <div class="modal-body">
                 <div class="form-group row">
@@ -116,12 +116,12 @@
 <nav class="navbar navbar-inverse">
     <div class="container-fluid">
         <div class="navbar-header">
-            <a class="navbar-brand" href="{{ url_for('CONFIG_APP.scenarios') }}">ACRN Config</a>
+            <a class="navbar-brand" href="{{ url_for('CONFIG_APP.scenarios') }}">ACRN Configurator</a>
         </div>
         <ul class="nav navbar-nav">
             <li class="dropdown">
                 <a href="{{ url_for('CONFIG_APP.scenarios') }}">
-                    Scenario Setting <span class="caret"></span></a>
+                    Scenario Settings<span class="caret"></span></a>
                 <ul class="dropdown-menu">
                     {% if board_info %}
                         <li><a href="" data-toggle="modal" data-target="#create_modal"  class="create_menu"
@@ -140,7 +140,7 @@
                 </ul>
             </li>
             <li class="dropdown">
-                <a href="{{ url_for('CONFIG_APP.launches') }}">Launch Setting <span
+                <a href="{{ url_for('CONFIG_APP.launches') }}">Launch Settings <span
                         class="caret"></span></a>
                 <ul class="dropdown-menu">
                     {% if board_info %}
@@ -186,7 +186,7 @@
                 <label for="board_info_file" class="custom-file-upload btn btn-primary" id="board_info_file2"
                        style="border: 1px solid #ccc; display: inline-block; padding: 6px 12px;
                            cursor: pointer; border-radius:5px; ">
-                    Import Board info</label>
+                    Import Board XML</label>
                 <input type="file" name="file" id="board_info_file" class="col-sm-6 btn btn-primary"
                        style="display: none;">
             </form>

--- a/misc/config_tools/config_app/templates/launch.html
+++ b/misc/config_tools/config_app/templates/launch.html
@@ -7,11 +7,11 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title" id="myModalLabel">Save as</h4>
+                <h4 class="modal-title" id="myModalLabel">Save Launch XML</h4>
             </div>
             <div class="modal-body">
                 <div class="form-group row">
-                    <label for="new_launch_name" class="col-sm-3 control-label">XML Name: </label>
+                    <label for="new_launch_name" class="col-sm-3 control-label">Launch XML Name: </label>
                     <div class="col-sm-6">
                         <input type="text" class="form-control" id="new_launch_name"
                                value={{launch}}>
@@ -21,7 +21,7 @@
                     <label for="src_path" class="col-sm-3 control-label"
                         title="the path to save config xmls; if no path is specified,
 the launch scripts will be generated into misc/acrn-config/xmls/config-xmls/[board]/output and overwirte the previous files.">
-                        Source Path: </label>
+                        Launch XML Path: </label>
                     <div class="col-sm-9">
                         <input type="text" class="form-control" id="src_path" value=""
                                placeholder="[acrn-hypervisor]/../user_config/">

--- a/misc/config_tools/config_app/templates/scenario.html
+++ b/misc/config_tools/config_app/templates/scenario.html
@@ -7,11 +7,11 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title" id="myModalLabel">Save as</h4>
+                <h4 class="modal-title" id="myModalLabel">Save Scenario XML</h4>
             </div>
             <div class="modal-body">
                 <div class="form-group row">
-                    <label for="new_scenario_name" class="col-sm-3 control-label">XML Name: </label>
+                    <label for="new_scenario_name" class="col-sm-3 control-label">Scenario XML Name: </label>
                     <div class="col-sm-6">
                         <input type="text" class="form-control" id="new_scenario_name"
                                value={{ scenario }}>


### PR DESCRIPTION
1. For initial UI, rename "ACRN Config" to "ACRN Configurator",
rename "Scenario Setting" to "Scenario Settings", rename "Launch Setting"
to "Launch Settings", and rename "Import Board info" to "Import Board XML";
2. For UI scenario selection, change title "Load Scenario Setting" to
"Load Default Scenario Settings", Change title "Save as" to "Save Scenario XML",
and rename "XML Name" to "Scenario XML Name";
7. For UI launch selection, rename "Load Launch setting" to
"Load Default Launch Settings", change title "Save as" to "Save Launch XML",
change "XML Name" to "Launch XML Name" and Change "Source Path" to "Launch XML Path".

Tracked-On: #6417
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>