### PR TITLE
release_2.6: dm: pci: minor bug fix about uninitialized local variable

### DIFF
--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -179,7 +179,7 @@ static inline int ptdev_msix_pba_bar(struct passthru_dev *ptdev)
 static int
 cfginitbar(struct vmctx *ctx, struct passthru_dev *ptdev)
 {
-	int i, error;
+	int i, error = 0;
 	struct pci_vdev *dev;
 	struct pci_bar_io bar;
 	enum pcibar_type bartype;

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -391,7 +391,7 @@ static inline bool is_pci_vendor_valid(uint32_t vendor_id)
 
 static inline bool is_pci_cfg_multifunction(uint8_t header_type)
 {
-	return ((header_type & PCIM_MFDEV) == PCIM_MFDEV);
+	return ((header_type != 0xffU) && ((header_type & PCIM_MFDEV) == PCIM_MFDEV));
 }
 
 static inline bool pci_is_valid_access_offset(uint32_t offset, uint32_t bytes)


### PR DESCRIPTION
'error' might be used uninitialized in cfginitbar. So initialize it to zero
at the beginning.

Tracked-On: #6284
Signed-off-by: Fei Li <fei1.li@intel.com>