### PR TITLE
dm: pci: destory reseverd PIO BAR when deinit passthrough PCI device

### DIFF
--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -771,6 +771,7 @@ passthru_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		vm_unmap_ptdev_mmio(ctx, 0, 2, 0, gpu_opregion_gpa, GPU_OPREGION_SIZE, gpu_opregion_hpa);
 	}
 
+	destory_mmio_rsvd_rgns(dev);
 	pcidev.virt_bdf = PCI_BDF(dev->bus, dev->slot, dev->func);
 	pcidev.phys_bdf = ptdev->phys_bdf;
 	pciaccess_cleanup();


### PR DESCRIPTION
Destory reseverd PIO BAR when deinit passthrough PCI device to free
reserved_bar_regions.

Tracked-On: #6508
Signed-off-by: Fei Li <fei1.li@intel.com>