### PR TITLE
doc: Remove empty section marked "TBD"

### DIFF
--- a/doc/developer-guides/hld/hv-ioc-virt.rst
+++ b/doc/developer-guides/hld/hv-ioc-virt.rst
@@ -613,7 +613,4 @@ for TTY line discipline in User VM::
    -l com2,/run/acrn/ioc_$vm_name
 
 
-Porting and Adaptation to Different Platforms
-*********************************************
 
-TBD


### PR DESCRIPTION
Removed the Porting and Adaptation to Different Platforms section in hv-ioc-virt.rst, because it was blank.

Signed-off-by: Amy Reyes <amy.reyes@intel.com>