### PR TITLE
hv: pci: fix a minor bug about is_pci_cfg_multifunction

### DIFF
--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -391,7 +391,7 @@ static inline bool is_pci_vendor_valid(uint32_t vendor_id)
 
 static inline bool is_pci_cfg_multifunction(uint8_t header_type)
 {
-	return ((header_type & PCIM_MFDEV) == PCIM_MFDEV);
+	return ((header_type != 0xffU) && ((header_type & PCIM_MFDEV) == PCIM_MFDEV));
 }
 
 static inline bool pci_is_valid_access_offset(uint32_t offset, uint32_t bytes)


### PR DESCRIPTION
Before checking whether a PCI device is a Multi-Function Device or not, we need
make sure this PCI device is a valid PCI device. For a valid PCI device, the
'Header Layout' field in Header Type Register must be 000 0000b (Type 0 PCI device)
or 000 0001b (Type 1 PCI device).

So for a valid PCI device, the Header Type can't be 0xff.

Tracked-On: #4134
Signed-off-by: Fei Li <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>