### PR TITLE
misc: acrn_trace: enlarge DEV_PATH_LEN

### DIFF
--- a/misc/debug_tools/acrn_trace/acrntrace.h
+++ b/misc/debug_tools/acrn_trace/acrntrace.h
@@ -20,7 +20,7 @@
 #define TRACE_FILE_NAME_LEN	32
 #define TRACE_FILE_DIR_LEN	(TRACE_FILE_NAME_LEN - 3)
 #define TRACE_FILE_ROOT		"acrntrace/"
-#define DEV_PATH_LEN		18
+#define DEV_PATH_LEN		20
 #define TIME_STR_LEN		16
 #define CMD_MAX_LEN		48
 


### PR DESCRIPTION
Now ACRN support platform which CPU numbers are large than 10. So the old value
for DEV_PATH_LEN is not enough (18 is not enough for /dev/acrn_trace_xx).

Tracked-On: #6572
Signed-off-by: Fei Li <fei1.li@intel.com>