### PR TITLE
Doc: launch L2 guest with ovmf for ACRN on QEMU

### DIFF
--- a/doc/tutorials/acrn_on_qemu.rst
+++ b/doc/tutorials/acrn_on_qemu.rst
@@ -217,61 +217,27 @@ Install ACRN Hypervisor
 Bring-Up User VM (L2 Guest)
 ***************************
 
-1. Build the ACRN User VM kernel.
+1. Build the User VM disk image (``UserVM.img``) following :ref:`build-the-ubuntu-kvm-image` and copy it to the ACRNSOS (L1 Guest).
+   Alternatively you can also use an `Ubuntu Desktop ISO image <https://ubuntu.com/#download>`_.
+   Rename the downloaded ISO image to ``UserVM.iso``.
 
-   .. code-block:: none
-
-      cd ~/acrn-kernel
-      cp kernel_config_uos .config
-      make olddefconfig
-      make
-
-#. Copy the User VM kernel to your home folder, we will use it to launch the User VM (L2 guest)
-
-   .. code-block:: none
-
-      cp arch/x86/boot/bzImage ~/bzImage_uos
-
-#. Build the User VM disk image (``UOS.img``) following :ref:`build-the-ubuntu-kvm-image` and copy it to the ACRNSOS (L1 Guest).
-   Alternatively you can also use ``virt-install`` **in the host environment** to create a User VM image similarly to how we built ACRNSOS previously.
-
-   .. code-block:: none
-
-      virt-install \
-      --name UOS \
-      --ram 1024 \
-      --disk path=/var/lib/libvirt/images/UOS.img,size=8,format=raw \
-      --vcpus 2 \
-      --virt-type kvm \
-      --os-type linux \
-      --os-variant ubuntu18.04 \
-      --graphics none \
-      --location 'http://archive.ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/' \
-      --extra-args "console=tty0 console=ttyS0,115200n8"
-
-#. Transfer the ``UOS.img`` User VM disk image to the Service VM (L1 guest).
-
-   .. code-block::
-
-      sudo scp /var/lib/libvirt/images/UOS.img <username>@<IP address>
-
-  Where ``<username>`` is your username in the Service VM and ``<IP address>`` its IP address.
+#. Transfer the ``UserVM.img``  or ``UserVM.iso`` User VM disk image to the Service VM (L1 guest).
 
 #. Launch User VM using the ``launch_ubuntu.sh`` script.
 
    .. code-block:: none
 
       cp ~/acrn-hypervisor/misc/config_tools/data/samples_launch_scripts/launch_ubuntu.sh ~/
+      cp ~/acrn-hypervisor/devicemodel/bios/OVMF.fd ~/
 
-#. Update the script to use your disk image and kernel
+#. Update the script to use your disk image (``UserVM.img or ``UserVM.iso``).
 
    .. code-block:: none
 
       acrn-dm -A -m $mem_size -s 0:0,hostbridge \
-      -s 3,virtio-blk,~/UOS.img \
+      -s 3,virtio-blk,~/UserVM.img \
       -s 4,virtio-net,tap0 \
       -s 5,virtio-console,@stdio:stdio_port \
-      -k ~/bzImage_uos \
-      -B "earlyprintk=serial,ttyS0,115200n8 consoleblank=0 root=/dev/vda1 rw rootwait maxcpus=1 nohpet console=tty0 console=hvc0 console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M tsc=reliable" \
+      --ovmf ~/OVMF.fd \
       $logger_setting \
       $vm_name


### PR DESCRIPTION
ACRN will not maintain User VM kernel config any more;
ovmf will be used to launch L2 guest by default.

Signed-off-by: fuzhongl <fuzhong.liu@eintel.com>