### PR TITLE
doc: update documentation and grub file

### DIFF
--- a/0001-doc-update-documentation-and-grub-file.patch
+++ b/0001-doc-update-documentation-and-grub-file.patch
@@ -1,0 +1,69 @@
+From efb74a8044a20b1b9b7dd373e4b1ef94d21955a7 Mon Sep 17 00:00:00 2001
+From: "zhongzhenx.liu" <zhongzhenx.liu@intel.com>
+Date: Wed, 15 Sep 2021 08:25:02 -0400
+Subject: [PATCH] doc: update documentation and grub file
+
+1. ACRN official documentation getting started guide. doc 6 Install ACRN->3 step>b
+link needs to modify  and because the grap file syntax cannot be recognized <> .
+The correct way to modify is to mislead the user to modify it to <> Correctly
+modify it to UUID and PARTUUDI.
+2. Because there is a problem with the user adding GRUB_CMDLINE_LINUX=text
+parameter, delete this parameter.
+3. The script generation of launch_uos_id3.sh does not match the GitHub and doc,
+modify the parameters
+
+Signed-off-by: zhongzhenx.liu <zhongzhenx.liu@intel.com>
+---
+ doc/getting-started/getting-started.rst | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/doc/getting-started/getting-started.rst b/doc/getting-started/getting-started.rst
+index 50755b8db..5668c63e8 100644
+--- a/doc/getting-started/getting-started.rst
++++ b/doc/getting-started/getting-started.rst
+@@ -626,8 +626,8 @@ In the following steps, you will configure GRUB on the target system.
+ 
+          sudo vi /etc/grub.d/40_custom
+ 
+-   #. Add the following text at the end of the file. Replace ``<UUID>`` and
+-      ``<PARTUUID>`` with the output from the previous step.
++   #. Add the following text at the end of the file. Replace ``"UUID"`` and
++      ``"PARTUUID"`` with the output from the previous step.
+ 
+       .. code-block:: bash
+          :emphasize-lines: 6,8
+@@ -637,9 +637,9 @@ In the following steps, you will configure GRUB on the target system.
+            insmod gzio
+            insmod part_gpt
+            insmod ext2
+-           search --no-floppy --fs-uuid --set <UUID>
++           search --no-floppy --fs-uuid --set "UUID"
+            echo 'loading ACRN...'
+-           multiboot2 /boot/acrn/acrn.bin  root=PARTUUID=<PARTUUID>
++           multiboot2 /boot/acrn/acrn.bin  root=PARTUUID="PARTUUID"
+            module2 /boot/vmlinuz-5.10.52-acrn-sos Linux_bzImage
+          }
+ 
+@@ -660,9 +660,9 @@ In the following steps, you will configure GRUB on the target system.
+       .. code-block:: bash
+ 
+          GRUB_DEFAULT=ubuntu-service-vm
++         GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
+          #GRUB_TIMEOUT_STYLE=hidden
+          GRUB_TIMEOUT=5
+-         GRUB_CMDLINE_LINUX="text"
+ 
+    #. Save and close the file.
+ 
+@@ -752,7 +752,7 @@ Launch the User VM
+          -s 8,virtio-net,tap_YaaG3 \
+          -s 6,virtio-console,@stdio:stdio_port \
+          --ovmf /usr/share/acrn/bios/OVMF.fd \
+-         -s 31:0,lpc \
++         -s 1:0,lpc \
+          $vm_name
+ 
+ #. Save and close the file.
+-- 
+2.30.2
+

--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -626,8 +626,8 @@ In the following steps, you will configure GRUB on the target system.
 
          sudo vi /etc/grub.d/40_custom
 
-   #. Add the following text at the end of the file. Replace ``<UUID>`` and
-      ``<PARTUUID>`` with the output from the previous step.
+   #. Add the following text at the end of the file. Replace ``"UUID"`` and
+      ``"PARTUUID"`` with the output from the previous step.
 
       .. code-block:: bash
          :emphasize-lines: 6,8
@@ -637,9 +637,9 @@ In the following steps, you will configure GRUB on the target system.
            insmod gzio
            insmod part_gpt
            insmod ext2
-           search --no-floppy --fs-uuid --set <UUID>
+           search --no-floppy --fs-uuid --set "UUID"
            echo 'loading ACRN...'
-           multiboot2 /boot/acrn/acrn.bin  root=PARTUUID=<PARTUUID>
+           multiboot2 /boot/acrn/acrn.bin  root=PARTUUID="PARTUUID"
            module2 /boot/vmlinuz-5.10.52-acrn-sos Linux_bzImage
          }
 
@@ -660,9 +660,9 @@ In the following steps, you will configure GRUB on the target system.
       .. code-block:: bash
 
          GRUB_DEFAULT=ubuntu-service-vm
+         GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
          #GRUB_TIMEOUT_STYLE=hidden
          GRUB_TIMEOUT=5
-         GRUB_CMDLINE_LINUX="text"
 
    #. Save and close the file.
 
@@ -752,7 +752,7 @@ Launch the User VM
          -s 8,virtio-net,tap_YaaG3 \
          -s 6,virtio-console,@stdio:stdio_port \
          --ovmf /usr/share/acrn/bios/OVMF.fd \
-         -s 31:0,lpc \
+         -s 1:0,lpc \
          $vm_name
 
 #. Save and close the file.


### PR DESCRIPTION
1. ACRN official documentation getting started guide. doc 6 Install ACRN->3 step>b
link needs to modify  and because the grup file syntax cannot be recognized <> .
The correct way to modify is to mislead the user to modify it to <> Correctly
modify it to UUID and PARTUUDI.
2. Because there is a problem with the user adding GRUB_CMDLINE_LINUX=text
parameter, delete this parameter.
3. The script generation of launch_uos_id3.sh does not match the GitHub and doc,
modify the parameters

Signed-off-by: zhongzhenx.liu <zhongzhenx.liu@intel.com>