### PR TITLE
doc: Add project CONTRIBUTING repo page

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,39 @@
+Contribution Guidelines
+#######################
+
+As an open-source project, we welcome and encourage the community to submit
+patches directly to the project.  In our collaborative open-source environment,
+standards and methods for submitting changes help reduce the chaos that can result
+from an active development community.
+
+This document briefly summarizes the full `Contribution
+Guidelines <http://projectacrn.github.io/latest/developer-guides/contribute_guidelines.html>`_
+documentation.
+
+* ACRN uses the permissive open source `BSD 3-Clause license`_
+  that allows you to freely use, modify, distribute and sell your own products
+  that include such licensed software.
+
+* There are some imported or reused components of the ACRN project that
+  use other licensing and are clearly identified.
+
+* The Developer Certificate of Origin (DCO) process is followed to
+  ensure developers are following licensing criteria for their
+  contributions, and documented with a ``Signed-off-by`` line in commits.
+
+* ACRN development workflow is supported on Linux.
+
+* Source code for the project is maintained in the GitHub repo:
+  https://github.com/projectacrn/acrn-hypervisor
+
+* Issue and feature tracking is done using GitHub issues in this repo.
+
+* A Continuous Integration (CI) system runs on every Pull Request (PR)
+  to verify several aspects of the PR including Git commit formatting,
+  coding style, sanity-check builds, and documentation builds.
+
+* The `ACRN user mailing list`_ is a great place to engage with the
+  community, ask questions, discuss issues, and help each other.
+
+.. _ACRN user mailing list: https://lists.projectacrn.org/g/acrn-user
+.. _BSD 3-Clause license: https://github.com/projectacrn/acrn-hypervisor/blob/master/LICENSE

--- a/doc/developer-guides/contribute_guidelines.rst
+++ b/doc/developer-guides/contribute_guidelines.rst
@@ -135,6 +135,9 @@ Submitting Issues
 .. _ACRN-dev mailing list:
    https://lists.projectacrn.org/g/acrn-dev
 
+.. _ACRN-users mailing list:
+   https://lists.projectacrn.org/g/acrn-users
+
 .. _ACRN hypervisor issues:
    https://github.com/projectacrn/acrn-hypervisor/issues
 
@@ -143,7 +146,8 @@ GitHub issues in the `ACRN hypervisor issues`_ list. Before submitting a
 bug or enhancement request, first check to see what's already been
 reported, and add to that discussion if you have additional information.
 (Be sure to check both the "open" and "closed" issues.)
-You should also read through discussions in the `ACRN-dev mailing list`_
+You should also read through discussions in the `ACRN-users mailing list`_
+(and the `ACRN-dev mailing list`_)
 to see what's been reported on or discussed.  You may find others that
 have encountered the issue you're finding, or that have similar ideas
 for changes or additions.


### PR DESCRIPTION
Summarize the ACRN contributing guidelines (fully documented in a
separate document) and add to the top level of our project repo (as
expected by GitHub and our Technical Steering Committee)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>