### PR TITLE
use "igd" parameter name when pass-thru IGD

### DIFF
--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -588,7 +588,7 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 			need_reset = false;
 		else if (!strncmp(opt, "d3hot_reset", 11))
 			d3hot_reset = true;
-		else if (!strncmp(opt, "gpu", 3)) {
+		else if (!strncmp(opt, "igd", 3)) {
 			/* Create the dedicated "igd-lpc" on 00:1f.0 for IGD passthrough */
 			if (pci_parse_slot("31,igd-lpc") != 0)
 				pr_warn("faild to create igd-lpc");

--- a/doc/tutorials/gpu-passthru.rst
+++ b/doc/tutorials/gpu-passthru.rst
@@ -89,7 +89,7 @@ Passthrough the GPU to Guest
      echo "0000:00:02.0" > /sys/bus/pci/devices/0000:00:02.0/driver/unbind
      echo "0000:00:02.0" > /sys/bus/pci/drivers/pci-stub/bind
 
-   Replace ``-s 2,pci-gvt -G "$2" \`` with ``-s 2,passthru,0/2/0,gpu \``
+   Replace ``-s 2,pci-gvt -G "$2" \`` with ``-s 2,passthru,0/2/0,igd \``
 
 4. Run ``launch_win.sh``.
 

--- a/doc/tutorials/using_windows_as_uos.rst
+++ b/doc/tutorials/using_windows_as_uos.rst
@@ -104,7 +104,7 @@ Prepare the Script to Create an Image
    #for memsize setting
    mem_size=4096M
    acrn-dm -A -m $mem_size -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
-     -s 2,passthru,0/2/0,gpu \
+     -s 2,passthru,0/2/0,igd \
      -s 8,virtio-net,tap0 \
      -s 4,virtio-blk,/home/acrn/work/win10-ltsc.img
      -s 5,ahci,cd:/home/acrn/work/Windows10.iso \
@@ -262,7 +262,7 @@ Explanation for acrn-dm Popular Command Lines
 .. note:: Use these acrn-dm command line entries according to your
    real requirements.
 
-* ``-s 2,passthru,0/2/0,gpu``:
+* ``-s 2,passthru,0/2/0,igd``:
   This is GVT-d to passthrough the VGA controller to Windows.
   You may need to change 0/2/0 to match the bdf of the VGA controller on your platform.
 

--- a/misc/config_tools/data/sample_launch_scripts/nuc/launch_win.sh
+++ b/misc/config_tools/data/sample_launch_scripts/nuc/launch_win.sh
@@ -97,7 +97,7 @@ acrn-dm -A -m $mem_size -s 0:0,hostbridge -U d2795438-25d6-11e8-864e-cb7a18b3464
    $logger_setting \
    -s 6,virtio-blk,./win10-ltsc.img \
    -s 7,virtio-net,tap_WaaG \
-   -s 2,passthru,0/2/0,gpu  \
+   -s 2,passthru,0/2/0,igd  \
    --ovmf /usr/share/acrn/bios/OVMF.fd \
    $intr_storm_monitor \
    -s 31:0,lpc \

--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -230,7 +230,7 @@ def gvt_arg_set(dm, vmid, uos_type, config):
         bus = int(gpu_bdf[0:2], 16)
         dev = int(gpu_bdf[3:5], 16)
         fun = int(gpu_bdf[6:7], 16)
-        print('   -s 2,passthru,{}/{}/{},gpu  \\'.format(bus, dev, fun), file=config)
+        print('   -s 2,passthru,{}/{}/{},igd  \\'.format(bus, dev, fun), file=config)
     elif gvt_args:
         print('   -s 2,pci-gvt -G "$2"  \\', file=config)
 


### PR DESCRIPTION
    The term of "gpu" is too common that might mislead end-users
    that it is a "must have" parameter to pass though any graphics card.
    Actually the parameter is used for Intel graphics only(bdf@00:02.0).
    We met this problem when we try to pass through
    a third party graphics card (bdf@00:05.0),
    people don't know whether need to add "gpu" parameter.
