### PR TITLE
    doc: update documentation and grub file

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -637,9 +637,9 @@ In the following steps, you will configure GRUB on the target system.
            insmod gzio
            insmod part_gpt
            insmod ext2
-           search --no-floppy --fs-uuid --set <UUID>
+           search --no-floppy --fs-uuid --set "3cac5675-e329-4cal-b346-0a3e65f99016"
            echo 'loading ACRN...'
-           multiboot2 /boot/acrn/acrn.bin  root=PARTUUID=<PARTUUID>
+           multiboot2 /boot/acrn/acrn.bin  root=PARTUUID="03db7f45-8a6c-454b-adf7-30343d82c4f4"
            module2 /boot/vmlinuz-5.10.52-acrn-sos Linux_bzImage
          }
 
@@ -662,7 +662,6 @@ In the following steps, you will configure GRUB on the target system.
          GRUB_DEFAULT=ubuntu-service-vm
          #GRUB_TIMEOUT_STYLE=hidden
          GRUB_TIMEOUT=5
-         GRUB_CMDLINE_LINUX="text"
 
    #. Save and close the file.
 
@@ -752,7 +751,7 @@ Launch the User VM
          -s 8,virtio-net,tap_YaaG3 \
          -s 6,virtio-console,@stdio:stdio_port \
          --ovmf /usr/share/acrn/bios/OVMF.fd \
-         -s 31:0,lpc \
+         -s 1:0,lpc \
          $vm_name
 
 #. Save and close the file.

--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -637,13 +637,28 @@ In the following steps, you will configure GRUB on the target system.
            insmod gzio
            insmod part_gpt
            insmod ext2
+           search --no-floppy --fs-uuid --set "UUID"
+           echo 'loading ACRN...'
+           multiboot2 /boot/acrn/acrn.bin  root=PARTUUID="PARTUUID"
+           module2 /boot/vmlinuz-5.10.52-acrn-sos Linux_bzImage
+         }
+
+   #. Save and close the file.
+   
+   #. Correct example image
+
+      .. code-block:: console
+
+         menuentry "ACRN Multiboot Ubuntu Service VM" --id ubuntu-service-vm {
+           load_video
+           insmod gzio
+           insmod part_gpt
+           insmod ext2
            search --no-floppy --fs-uuid --set "3cac5675-e329-4cal-b346-0a3e65f99016"
            echo 'loading ACRN...'
            multiboot2 /boot/acrn/acrn.bin  root=PARTUUID="03db7f45-8a6c-454b-adf7-30343d82c4f4"
            module2 /boot/vmlinuz-5.10.52-acrn-sos Linux_bzImage
          }
-
-   #. Save and close the file.
 
 #. Make the GRUB menu visible when
    booting and make it load the Service VM kernel by default:


### PR DESCRIPTION
1. Because the < > in the document will mislead users to copy and paste directly,
    modify the < > to " ".
2. Add sample diagrams for user reference.
3. Because there is a problem with the user adding the GRUB_CMDLINE_LINUX=text
    parameter, delete this parameter.
4. The script generation of launch_uos_id3.sh does not match the GitHub and doc,
    modify the parameters.


    Signed-off-by: zhongzhenx.liu <zhongzhenx.liu@intel.com>