### PR TITLE
doc: add virtio input element in config doc

### DIFF
--- a/doc/tutorials/acrn_configuration_tool.rst
+++ b/doc/tutorials/acrn_configuration_tool.rst
@@ -369,6 +369,10 @@ current scenario has:
   Input format:
   ``[@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]``.
 
+``input`` (a child node of ``virtio_devices``):
+  The virtio input device setting.
+  Input format: ``/dev/input/eventX[,serial]``.
+
 ``cpu_affinity``:
   List of pCPU that this VM's vCPUs are pinned to.
 


### PR DESCRIPTION
add virtio input element in the description of elements for
launch XMLs in config doc.

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>