### PR TITLE
Makefile: fix wrong reference to board XML and skip binary in diffconfig

### DIFF
--- a/hypervisor/scripts/makefile/config.mk
+++ b/hypervisor/scripts/makefile/config.mk
@@ -254,7 +254,8 @@ showconfig:
 
 diffconfig:
 	@rm -rf $(HV_CONFIG_A_DIR) $(HV_CONFIG_B_DIR)
-	@sh $(BASEDIR)/scripts/genconf.sh $(BASEDIR) $(BOARD_FILE) $(HV_SCENARIO_XML) $(HV_CONFIG_A_DIR) $(HV_UNIFIED_XML)
+	@sh $(BASEDIR)/scripts/genconf.sh $(BASEDIR) $(HV_BOARD_XML) $(HV_SCENARIO_XML) $(HV_CONFIG_A_DIR) $(HV_UNIFIED_XML)
+	@find $(HV_CONFIG_A_DIR) -name '*.aml' -delete
 	@cd $(HV_CONFIG_DIR) && find . -name '*.c' -or -name '*.h' -or -name '*.config' -or -name '*.asl' | while read f; do \
 	  nf=$(HV_CONFIG_B_DIR)/$${f}; mkdir -p `dirname $${nf}` && cp $${f} $${nf}; \
 	done


### PR DESCRIPTION
The current config.mk uses the variable BOARD_FILE as the path to the board
XML when generating an unmodified copy of configuration files for
comparison, which is incorrect. The right variable is HV_BOARD_XML which is
the path to the copy of board XML that is actually used for the build.

This patch corrects the bug above.

In addition, this patch also skips binary files (which are not meant to be
edited manually) when calculating the differences.

Tracked-On: #6592
Signed-off-by: Junjie Mao <junjie.mao@intel.com>