### PR TITLE
doc: finish renaming vmh to hsm

### DIFF
--- a/doc/developer-guides/VBSK-analysis.rst
+++ b/doc/developer-guides/VBSK-analysis.rst
@@ -80,14 +80,14 @@ two parts:  kick overhead and notify overhead.
 -  **Kick Overhead**: The User VM gets trapped when it executes sensitive
    instructions that notify the hypervisor first. The notification is
    assembled into an IOREQ, saved in a shared IO page, and then
-   forwarded to the VHM module by the hypervisor. The VHM notifies its
+   forwarded to the HSM module by the hypervisor. The HSM notifies its
    client for this IOREQ, in this case, the client is the vbs-echo
    backend driver. Kick overhead is defined as the interval from the
    beginning of User VM trap to a specific VBS-K driver, e.g. when
    virtio-echo gets notified.
 -  **Notify Overhead**: After the data in virtqueue being processed by the
-   backend driver, vbs-echo calls the VHM module to inject an interrupt
-   into the frontend. The VHM then uses the hypercall provided by the
+   backend driver, vbs-echo calls the HSM module to inject an interrupt
+   into the frontend. The HSM then uses the hypercall provided by the
    hypervisor, which causes a User VM VMEXIT. The hypervisor finally injects
    an interrupt into the vLAPIC of the User VM and resumes it. The User VM
    therefore receives the interrupt notification.  Notify overhead is

--- a/doc/developer-guides/hld/hld-APL_GVT-g.rst
+++ b/doc/developer-guides/hld/hld-APL_GVT-g.rst
@@ -923,14 +923,14 @@ AcrnGT in Kernel
 =================
 
 The AcrnGT module in the Service VM kernel acts as an adaption layer to connect
-between GVT-g in the i915, the VHM module, and the ACRN-DM user space
+between GVT-g in the i915, the HSM module, and the ACRN-DM user space
 application:
 
 -  AcrnGT module implements the MPT interface of GVT-g to provide
    services to it, including set and unset trap areas, set and unset
    write-protection pages, etc.
 
--  It calls the VHM APIs provided by the ACRN VHM module in the Service VM
+-  It calls the HSM APIs provided by the ACRN HSM module in the Service VM
    kernel, to eventually call into the routines provided by ACRN
    hypervisor through hyper-calls.
 

--- a/doc/developer-guides/hld/virtio-net.rst
+++ b/doc/developer-guides/hld/virtio-net.rst
@@ -193,7 +193,7 @@ example, showing the flow through each layer:
 
 .. code-block:: c
 
-   vhm_intr_handler -->                          // HSM interrupt handler
+   hsm_intr_handler -->                          // HSM interrupt handler
        tasklet_schedule -->
            io_req_tasklet -->
                acrn_ioreq_distribute_request --> // ioreq can't be processed in HSM, forward it to device DM
@@ -348,7 +348,7 @@ cases.)
 
 .. code-block:: c
 
-   vhm_dev_ioctl -->                // process the IOCTL and call hypercall to inject interrupt
+   hsm_dev_ioctl -->                // process the IOCTL and call hypercall to inject interrupt
        hcall_inject_msi -->
 
 **ACRN Hypervisor**


### PR DESCRIPTION
Fixed some additional doc references missed in PR #6283

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>