### PR TITLE
config_tools: populate default values to all nodes

### DIFF
--- a/misc/config_tools/scenario_config/default_populator.py
+++ b/misc/config_tools/scenario_config/default_populator.py
@@ -41,8 +41,8 @@ def populate_all(xsd_etree, xsd_all_node, xml_node):
         element_name = element_node.get("name")
         if not element_name:
             continue
-        xml_child_node = xml_node.find(element_name)
-        if xml_child_node is None:
+        xml_child_nodes = xml_node.findall(element_name)
+        if len(xml_child_nodes) == 0:
             element_min_occurs = element_node.get("minOccurs")
             if element_min_occurs == "0":
                 continue
@@ -51,7 +51,8 @@ def populate_all(xsd_etree, xsd_all_node, xml_node):
             xml_node.append(xml_child_node)
             populate(xsd_etree, element_node, xml_child_node, True)
         else:
-            populate(xsd_etree, element_node, xml_child_node, False)
+            for xml_child_node in xml_child_nodes:
+                populate(xsd_etree, element_node, xml_child_node, False)
 
 def populate(xsd_etree, xsd_element_node, xml_node, is_new_node):
     complex_type_node = xsd_element_node.find("xs:complexType", namespaces=xpath_ns)


### PR DESCRIPTION
The default value population algorithm introduced by commit
2bfaa34 ("config_tools: populate default values in scenario XML") only
populates default values to the first occurrence of a tag when the tag is
specified to allow multiple occurrences under an xs:all node. This may lead
to incomplete scenario XML as some of the default values are missed.

This patch fixes this issue by checking **all** nodes having the same tag
under a node specified by an xs:all schema.

Fixes: 2bfaa34 ("config_tools: populate default values in scenario XML")

Tracked-On: #6292
Signed-off-by: Junjie Mao <junjie.mao@intel.com>