### PR TITLE
    doc: Steps to update hybrid and logic_Partition documents

### DIFF
--- a/doc/tutorials/using_hybrid_mode_on_nuc.rst
+++ b/doc/tutorials/using_hybrid_mode_on_nuc.rst
@@ -109,7 +109,7 @@ Perform the following to update Ubuntu GRUB so it can boot the hypervisor and lo
 
       }
 
-
+     
    .. note:: The module ``/boot/zephyr.elf`` is the VM0 (Zephyr) kernel file.
       The param ``xxxxxx`` is VM0's kernel file tag and must exactly match the
       ``kern_mod`` of VM0, which is configured in the ``misc/config_tools/data/nuc7i7dnb/hybrid.xml``
@@ -120,6 +120,26 @@ Perform the following to update Ubuntu GRUB so it can boot the hypervisor and lo
       ``bootargs`` of VM1 in the ``misc/config_tools/data/nuc7i7dnb/hybrid.xml``.
       The module ``/boot/ACPI_VM0.bin`` is the binary of ACPI tables for pre-launched VM0 (Zephyr).
       The parameter ``ACPI_VM0`` is VM0's ACPI tag and should not be modified.
+
+#. Correct example Grub configuration (with ``module2`` image paths set):
+
+   .. code-block:: console
+      :emphasize-lines: 10,11,12
+
+      menuentry 'ACRN hypervisor Hybrid Scenario' --id ACRN_Hybrid --class ubuntu --class gnu-linux --class gnu --class os $menuentry_id_option 'gnulinux-simple-e23c76ae-b06d-4a6e-ad42-46b8eedfd7d3' {
+         recordfail
+         load_video
+         gfxmode $linux_gfx_mode
+         insmod gzio
+         insmod part_gpt
+         insmod ext2
+         echo 'Loading hypervisor Hybrid scenario ...'
+         multiboot2 /boot/acrn.bin
+         module2 /boot/zephyr.elf Zephyr_ElfImage
+         module2 /boot/bzImage Linux_bzImage
+         module2 /boot/ACPI_VM0.bin ACPI_VM0
+         
+      }
 
 #. Modify the ``/etc/default/grub`` file as follows to make the GRUB menu
    visible when booting:
@@ -143,6 +163,9 @@ Perform the following to update Ubuntu GRUB so it can boot the hypervisor and lo
 
 Hybrid Scenario Startup Check
 *****************************
+#. Refer to the **Test the Communication Port** section in the
+   :ref:`connect_serial_port` tutorial.
+
 #. Use these steps to verify that the hypervisor is properly running:
 
    a. Log in to the ACRN hypervisor shell from the serial console.


### PR DESCRIPTION
1. Modify hybrid update ubuntu grub Note: The syntax is easy for users to understand
2. Add to view the serial port number, enter the serial hybrid verification mode
3. Delete the kernel, because the config_uos file has been abandoned for maintenance,
   now the Ubuntu native kernel image is used and added to the document
4. Add to view the serial port number, enter the serial port logic_partition verification method
Signed-off-by: Zhongshan.Liu <zhongzhenx.liu@intel.com>