### PR TITLE
HV: init e820 before init paging

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -156,9 +156,10 @@ void init_pcpu_pre(bool is_bsp)
 
 		load_pcpu_state_data();
 
+		init_e820();
+
 		/* Initialize the hypervisor paging */
 		init_paging();
-		init_e820();
 
 		/*
 		 * Need update uart_base_address here for vaddr2paddr mapping may changed

--- a/hypervisor/boot/boot.c
+++ b/hypervisor/boot/boot.c
@@ -55,8 +55,8 @@ int32_t sanitize_acrn_boot_info(struct acrn_boot_info *abi)
 	}
 
 	printf("%s environment detected.\n", boot_from_uefi(abi) ? "UEFI" : "Non-UEFI");
-	if (boot_from_uefi(abi) && (abi->uefi_info.memmap == 0U) && (abi->uefi_info.memmap_hi == 0U)) {
-		pr_err("no efi memmap found!");
+	if (boot_from_uefi(abi) && ((abi->uefi_info.memmap == 0U) || (abi->uefi_info.memmap_hi != 0U))) {
+		pr_err("no efi memmap found below 4GB space!");
 		abi_status = -EINVAL;
 	}
 

--- a/hypervisor/boot/multiboot/multiboot2.c
+++ b/hypervisor/boot/multiboot/multiboot2.c
@@ -66,6 +66,7 @@ static void mb2_efimmap_to_abi(struct acrn_boot_info *abi,
 	abi->uefi_info.memdesc_version = mb2_tag_efimmap->descr_vers;
 	abi->uefi_info.memmap = (uint32_t)(uint64_t)mb2_tag_efimmap->efi_mmap;
 	abi->uefi_info.memmap_size = mb2_tag_efimmap->size - 16U;
+	/* Per multiboot2 spec, multiboot info is below 4GB space hence memmap_hi must be 0U. */
 	abi->uefi_info.memmap_hi = (uint32_t)(((uint64_t)mb2_tag_efimmap->efi_mmap) >> 32U);
 }
 


### PR DESCRIPTION
In the commit of 4e1deab3d9fbb7ba80e9c6c4cb8e785df33888b1, we changed the
init sequence that init paging first and then init e820 because we worried
about the efi memory map could be beyond 4GB space on some platform.

After we double checked multiboot2 spec, it is guaranteed that the efi memory
map must be under 4GB space. Consider that the page table will be allocated
in free memory space in future, we have to change the init sequence back that
init e820 first and then init paging.

Tracked-On: #5626

Signed-off-by: Victor Sun <victor.sun@intel.com>