### PR TITLE
doc: Update Getting Started Guide documentation

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -284,13 +284,13 @@ Generate a Board Configuration File
 
       .. code-block:: bash
 
-         idle=nomwait intel_idle.max_cstate=0 intel_pstate=disable
+         idle=nomwait iomem=relaxed intel_idle.max_cstate=0 intel_pstate=disable
 
       Example:
 
       .. code-block:: bash
 
-         GRUB_CMDLINE_LINUX_DEFAULT="quiet splash idle=nomwait intel_idle.max_cstate=0 intel_pstate=disable"
+         GRUB_CMDLINE_LINUX_DEFAULT="quiet splash idle=nomwait iomem=relaxed intel_idle.max_cstate=0 intel_pstate=disable"
 
       These settings allow the board inspector tool to
       gather important information about the board.

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -230,9 +230,8 @@ static uint32_t check_vmx_ctrl(uint32_t msr, uint32_t ctrl_req)
 	ctrl |= vmx_msr_low;
 
 	if ((ctrl_req & ~ctrl) != 0U) {
-		pr_err("VMX ctrl 0x%x not fully enabled: "
-			"request 0x%x but get 0x%x\n",
-			msr, ctrl_req, ctrl);
+		pr_info("VMX ctrl 0x%x not fully enabled: current capabilities are 0x%x (full capabilities are 0x%x)\n",
+						msr, ctrl, ctrl_req);
 	}
 
 	return ctrl;
@@ -250,9 +249,8 @@ static uint32_t check_vmx_ctrl_64(uint32_t msr, uint64_t ctrl_req)
 	ctrl &= vmx_msr;
 
 	if ((ctrl_req & ~ctrl) != 0U) {
-		pr_err("VMX ctrl 0x%x not fully enabled: "
-			"request 0x%llx but get 0x%llx\n",
-			msr, ctrl_req, ctrl);
+		pr_info("VMX ctrl 0x%x not fully enabled: current capabilities are 0x%lx (full capabilities are 0x%lx)\n",
+						msr, ctrl, ctrl_req);
 	}
 
 	return ctrl;


### PR DESCRIPTION
Without this kernel parameter the generated board XML
is essentially the same as having “--basic” when executing the board inspector,
i.e. the ACPI namespace will not be parsed. The generated board XML may still work,
but some functionality (e.g. passthru of TPM and other PCI devices that need INTx)
will no longer work due to lack of hardware information.
Signed-off-by: zhongzhenx.liu <zhongzhenx.liu@intel.com>