### PR TITLE
doc: add iomem kernel parameter for board inspector

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -284,13 +284,13 @@ Generate a Board Configuration File
 
       .. code-block:: bash
 
-         idle=nomwait intel_idle.max_cstate=0 intel_pstate=disable
+         idle=nomwait iomem=relaxed intel_idle.max_cstate=0 intel_pstate=disable
 
       Example:
 
       .. code-block:: bash
 
-         GRUB_CMDLINE_LINUX_DEFAULT="quiet splash idle=nomwait intel_idle.max_cstate=0 intel_pstate=disable"
+         GRUB_CMDLINE_LINUX_DEFAULT="quiet splash idle=nomwait iomem=relaxed intel_idle.max_cstate=0 intel_pstate=disable"
 
       These settings allow the board inspector tool to
       gather important information about the board.

--- a/misc/config_tools/board_inspector/README
+++ b/misc/config_tools/board_inspector/README
@@ -10,4 +10,4 @@ Please run this script under native Linux environment with root privilege.
 OS requirement:
 	Release:	Ubuntu 18.04+
 	Tools:		cpuid, rdmsr, lspci, lxml, dmidecode (optional)
-	kernel cmdline: "idle=nomwait intel_idle.max_cstate=0 intel_pstate=disable"
+	kernel cmdline: "idle=nomwait iomem=relaxed intel_idle.max_cstate=0 intel_pstate=disable"


### PR DESCRIPTION
Without this ``iomem=relaxed`` kernel parameter, the generated board XML
is essentially the same as having ``--basic`` when executing the board
inspector, i.e. the ACPI namespace will not be parsed. The generated
board XML may still work, but some functionality (e.g. passthru of TPM
and other PCI devices that need INTx) will no longer work due to lack of
hardware information.

Replacing PR #6618

Signed-off-by: zhongzhenx.liu <zhongzhenx.liu@intel.com>
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>