### PR TITLE
Add the config-tools support for vCAT and amend the struct acrn_vm_config to make it compatible with vCAT

### DIFF
--- a/hypervisor/include/arch/x86/asm/vm_config.h
+++ b/hypervisor/include/arch/x86/asm/vm_config.h
@@ -182,9 +182,25 @@ struct acrn_vm_config {
 	 * SOS can get the vm_configs[] array through hypercall, but SOS may not
 	 * need to parse these members.
 	 */
-	uint16_t clos[MAX_VCPUS_PER_VM];		/* Class of Service, effective only if CONFIG_RDT_ENABLED
-							 * is defined on CAT capable platforms
-							 */
+
+	uint16_t num_pclosids; /* This defines the number of elements in the array pointed to by pclosids */
+	/* pclosids: a pointer to an array of physical CLOSIDs (pCLOSIDs)) that is defined in vm_configurations.c
+	 * by vmconfig,
+	 * applicable only if CONFIG_RDT_ENABLED is defined on CAT capable platforms.
+	 * The number of elements in the array must be equal to the value given by num_pclosids
+	 */
+	uint16_t *pclosids;
+
+	bool vcat_enabled; /* whether or not to enable vCAT for this VM */
+	/* max_type_pcbm (type: l2 or l3) specifies the allocated portion of physical cache
+	 * for the VM and is a contiguous capacity bitmask (CBM) starting at bit position low
+	 * (the lowest assigned physical cache way) and ending at position high
+	 * (the highest assigned physical cache way, inclusive).
+	 * As CBM only allows contiguous '1' combinations, so max_type_pcbm essentially
+	 * is a bitmask that selects/covers all the physical cache ways assigned to the VM.
+	 */
+	uint32_t max_l2_pcbm;
+	uint32_t max_l3_pcbm;
 
 	struct vuart_config vuart[MAX_VUART_NUM_PER_VM];/* vuart configuration for VM */
 

--- a/misc/config_tools/library/common.py
+++ b/misc/config_tools/library/common.py
@@ -11,6 +11,7 @@ import subprocess # nosec
 import defusedxml.ElementTree as ET
 import re
 import lxml
+from lxml import etree
 
 
 ACRN_CONFIG_TARGET = ''
@@ -672,3 +673,16 @@ def get_pt_intx_table(config_file):
             virt_gsi[vm_i].append(b)
 
     return phys_gsi, virt_gsi
+
+def get_xpath(scenario, path):
+    """
+    A wrapper around lxml's xpath().
+    Finds the nodes of matched path using lxml's xpath
+    :param scenario: scenario xml file
+    :param path: tag name or an XPath path.
+    :return: the nodes of found xpath
+    """
+    # create element tree object
+    tree = lxml.etree.parse(scenario)
+
+    return tree.xpath(path)

--- a/misc/config_tools/library/scenario_cfg_lib.py
+++ b/misc/config_tools/library/scenario_cfg_lib.py
@@ -1052,6 +1052,10 @@ def vcpu_clos_check(cpus_per_vm, clos_per_vm, prime_item, item):
     common_clos_max = board_cfg_lib.get_common_clos_max()
 
     for vm_i,vcpus in cpus_per_vm.items():
+        vcat = common.get_xpath(common.SCENARIO_INFO_FILE, "//vm[@id={}]/clos/@vcat".format(vm_i))
+        if vcat and vcat[0] == 'y':
+            continue
+
         clos_per_vm_len = 0
         if vm_i in clos_per_vm:
             clos_per_vm_len = len(clos_per_vm[vm_i])

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -85,12 +85,18 @@ to.</xs:documentation>
   <xs:sequence>
     <xs:element name="vcpu_clos" type="xs:integer" default="0" maxOccurs="unbounded">
       <xs:annotation>
-        <xs:documentation>Configure each CPU in VMs to a desired CLOS ID in the ``VM`` section of the
-scenario file. Follow :ref:`rdt_detection_capabilities`
-to identify the maximum supported CLOS ID that can be used.</xs:documentation>
+        <xs:documentation>If vcat is 'n':
+vcpu_clos is per-CPU and it configures each CPU in VMs to a desired CLOS ID in the ``VM`` section of the
+scenario file. Follow :ref:`rdt_detection_capabilities` to identify the maximum supported CLOS ID that can be used.
+
+If vcat is 'y':
+vcpu_clos is not per-CPU anymore, just a list of physical CLOSIDs (minimum 2) that are assigned to VMs
+for vCAT use. Each vcpu_clos will be mapped to a virtual CLOSID, the first vcpu_clos is mapped to virtual
+CLOSID 0 and the second is mapped to virtual CLOSID 1, etc.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:sequence>
+  <xs:attribute name="vcat" type="Boolean" default="n" use="optional"/>
 </xs:complexType>
 
 <xs:complexType name="EPCSection">

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -492,6 +492,71 @@ to launch post-launched User VMs.</xs:documentation>
       <xs:documentation>Per VM GUEST_FLAG_NVMX_ENABLED can be set only if CONFIG_NVMX_ENABLED is set.</xs:documentation>
     </xs:annotation>
   </xs:assert>
+
+  <xs:assert test="if (//RDT/RDT_ENABLED = 'y')
+                   then not (//RDT/CDP_ENABLED = 'y' and //RDT/VCAT_ENABLED = 'y')
+                   else true()">
+    <xs:annotation>
+      <xs:documentation>vCAT can be enabled only when CDP_ENABLED is 'n'</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="if (//RDT/RDT_ENABLED = 'y' and //RDT/VCAT_ENABLED = 'y')
+                   then count(vm[clos/@vcat = 'y' and count(clos/vcpu_clos[. = 0])]) = 0
+                   else true()">
+    <xs:annotation>
+      <xs:documentation>For a vCAT VM, vcpu_clos cannot be set to CLOSID 0, CLOSID 0 is reserved to be used by hypervisor</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $vm in vm satisfies
+                  (
+                    if (//RDT_ENABLED = 'y' and //RDT/VCAT_ENABLED = 'y' and $vm/clos/@vcat = 'y')
+                    then count($vm/clos/vcpu_clos) > 1
+                    else true()
+                  )
+                  ">
+    <xs:annotation>
+      <xs:documentation>For a vCAT VM, number of clos/vcpu_clos elements must be greater than 1!</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $vm in vm satisfies
+                  (
+                    if (//RDT_ENABLED = 'y' and //RDT/VCAT_ENABLED = 'y' and $vm/clos/@vcat = 'y')
+                    then count($vm[clos/vcpu_clos[. &gt;= count($vm/..//RDT/CLOS_MASK)]]) = 0
+                    else true()
+                  )
+                  ">
+    <xs:annotation>
+      <xs:documentation>For a vCAT VM, each clos/vcpu_clos must be less than L2/L3 COS_MAX!</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $vm in vm satisfies
+                  (
+                    if (//RDT_ENABLED = 'y' and //RDT/VCAT_ENABLED = 'y' and $vm/clos/@vcat = 'y')
+                    then count($vm/clos/vcpu_clos) = count(distinct-values($vm/clos/vcpu_clos))
+                    else true()
+                  )
+                  ">
+    <xs:annotation>
+      <xs:documentation>For a vCAT VM, its clos/vcpu_clos elements cannot contain duplicate values</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $vm1 in vm, $vm2 in $vm1/following-sibling::vm satisfies
+                  (
+                    if (//RDT/RDT_ENABLED = 'y' and //RDT/VCAT_ENABLED = 'y' and ($vm1/clos/@vcat = 'y' or $vm2/clos/@vcat = 'y'))
+                    then count($vm1/clos/vcpu_clos[. = $vm2/clos/vcpu_clos]) = 0
+                    else true()
+                  )
+                  ">
+    <xs:annotation>
+      <xs:documentation>if RDT_ENABLED is 'y', there should not be any CLOS IDs overlap between a vCAT VM and any other VMs</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
 </xs:complexType>
 
 <xs:element name="acrn-config" type="ACRNConfigType" />

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -202,8 +202,14 @@ RDT, setting this option to ``y`` is ignored.</xs:documentation>
       <xs:annotation>
         <xs:documentation>Specify whether to enable Code and Data Prioritization (CDP).
 CDP is an extension of CAT. Set to 'y' to enable the feature or 'n' to disable it.
-The 'y' will be ignored when hardware does not support CDP. Default
-value ``n``.</xs:documentation>
+The 'y' will be ignored when hardware does not support CDP.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="VCAT_ENABLED" type="Boolean" default="n">
+      <xs:annotation>
+        <xs:documentation>Specify whether to enable CAT virtualization (vCAT).
+Set to 'y' to enable the feature or 'n' to disable it.
+The 'y' will be ignored when hardware does not support CAT.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="CLOS_MASK" type="xs:string"  minOccurs="0" maxOccurs="unbounded">

--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -94,10 +94,17 @@
       <xsl:with-param name="value" select="RDT/RDT_ENABLED" />
     </xsl:call-template>
 
-    <xsl:if test="RDT/RDT_ENABLED = 'y'">
+    <xsl:if test="acrn:is-rdt-enabled()">
       <xsl:call-template name="boolean-by-key-value">
-	<xsl:with-param name="key" select="'CDP_ENABLED'" />
-	<xsl:with-param name="value" select="RDT/CDP_ENABLED" />
+        <xsl:with-param name="key" select="'CDP_ENABLED'" />
+        <xsl:with-param name="value" select="RDT/CDP_ENABLED" />
+      </xsl:call-template>
+    </xsl:if>
+
+    <xsl:if test="acrn:is-rdt-enabled()">
+      <xsl:call-template name="boolean-by-key-value">
+        <xsl:with-param name="key" select="'VCAT_ENABLED'" />
+        <xsl:with-param name="value" select="RDT/VCAT_ENABLED" />
       </xsl:call-template>
     </xsl:if>
 

--- a/misc/config_tools/xforms/lib.xsl
+++ b/misc/config_tools/xforms/lib.xsl
@@ -376,6 +376,17 @@
     </xsl:choose>
   </func:function>
 
+  <func:function name="acrn:is-vcat-enabled">
+    <xsl:choose>
+      <xsl:when test="acrn:is-rdt-enabled() and //VCAT_ENABLED = 'y'">
+        <func:result select="true()" />
+      </xsl:when>
+      <xsl:otherwise>
+        <func:result select="false()" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </func:function>
+
   <func:function name="acrn:is-rdt-supported">
     <xsl:variable name="rdt_resource" select="acrn:get-normalized-closinfo-rdt-res-str()" />
     <xsl:variable name="rdt_res_clos_max" select="acrn:get-normalized-closinfo-rdt-clos-max-str()" />

--- a/misc/config_tools/xforms/lib.xsl
+++ b/misc/config_tools/xforms/lib.xsl
@@ -356,7 +356,7 @@
 
   <func:function name="acrn:is-rdt-enabled">
     <xsl:choose>
-      <xsl:when test="//RDT_ENABLED = 'y'">
+      <xsl:when test="acrn:is-rdt-supported() and //RDT_ENABLED = 'y'">
         <func:result select="true()" />
       </xsl:when>
       <xsl:otherwise>

--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -145,12 +145,6 @@
   </xsl:for-each>
 </xsl:template>
 
-<xsl:template name="vcpu_clos">
-  <xsl:for-each select="vm">
-    <xsl:value-of select="acrn:define(concat('VM', @id, '_VCPU_CLOS'), concat('{', acrn:string-join(clos/vcpu_clos, ',', '', 'U'),'}'), '')" />
-  </xsl:for-each>
-</xsl:template>
-
 <!-- HV_SUPPORTED_MAX_CLOS:
   The maximum CLOS that is allowed by ACRN hypervisor.
   Its value is set to be least common Max CLOS (CPUID.(EAX=0x10,ECX=ResID):EDX[15:0])
@@ -195,7 +189,6 @@
     <xsl:for-each select="hv/FEATURES/RDT/CLOS_MASK">
       <xsl:value-of select="acrn:define(concat('CLOS_MASK_', position() - 1), current(), 'U')" />
     </xsl:for-each>
-    <xsl:call-template name="vcpu_clos" />
     <xsl:value-of select="$endif" />
   </xsl:if>
 </xsl:template>

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -37,16 +37,16 @@
 
       <!-- Declaration of pt_intx -->
       <xsl:if test="acrn:is-pre-launched-vm(vm_type)">
-	<xsl:variable name="vm_id" select="@id" />
-	<xsl:variable name="length" select="count(acrn:get-intx-mapping(//vm[@id=$vm_id]//pt_intx))" />
-	<xsl:choose>
-	  <xsl:when test="$length">
+        <xsl:variable name="vm_id" select="@id" />
+        <xsl:variable name="length" select="count(acrn:get-intx-mapping(//vm[@id=$vm_id]//pt_intx))" />
+        <xsl:choose>
+          <xsl:when test="$length">
             <xsl:value-of select="acrn:extern('struct pt_intx_config', concat('vm', @id, '_pt_intx'), concat($length, 'U'))" />
-	  </xsl:when>
-	  <xsl:otherwise>
+          </xsl:when>
+          <xsl:otherwise>
             <xsl:value-of select="acrn:extern('struct pt_intx_config', concat('vm', @id, '_pt_intx'), '1U')" />
-	  </xsl:otherwise>
-	</xsl:choose>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:if>
     </xsl:for-each>
 
@@ -148,13 +148,13 @@
         <xsl:value-of select="acrn:initializer('size', concat('VM', ../@id, '_CONFIG_MEM_SIZE'))" />
         <xsl:value-of select="acrn:initializer('start_hpa2', concat('VM', ../@id, '_CONFIG_MEM_START_HPA2'))" />
         <xsl:value-of select="acrn:initializer('size_hpa2', concat('VM', ../@id, '_CONFIG_MEM_SIZE_HPA2'))" />
-     </xsl:otherwise>
+      </xsl:otherwise>
     </xsl:choose>
     <xsl:text>},</xsl:text>
     <xsl:value-of select="$newline" />
   </xsl:template>
 
-   <xsl:template match="epc_section">
+  <xsl:template match="epc_section">
     <xsl:if test="base != '0' and size != '0'">
     <xsl:value-of select="acrn:initializer('epc', '{', true())" />
       <xsl:value-of select="acrn:initializer('base', base)" />

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -50,6 +50,21 @@
       </xsl:if>
     </xsl:for-each>
 
+    <xsl:if test="acrn:is-rdt-enabled()">
+      <xsl:value-of select="$newline" />
+      <xsl:value-of select="acrn:ifdef('CONFIG_RDT_ENABLED')" />
+
+      <xsl:for-each select="vm">
+          <xsl:value-of select="concat('static uint16_t ', concat('vm', @id, '_vcpu_clos'), '[', count(clos/vcpu_clos), 'U] = {')" />
+          <xsl:value-of select="acrn:string-join(clos/vcpu_clos, ', ', '', 'U')" />
+          <xsl:text>};</xsl:text>
+          <xsl:value-of select="$newline" />
+      </xsl:for-each>
+
+      <xsl:value-of select="$endif" />
+      <xsl:value-of select="$newline" />
+    </xsl:if>
+
     <!-- Definition of vm_configs -->
     <xsl:value-of select="acrn:array-initializer('struct acrn_vm_config', 'vm_configs', 'CONFIG_MAX_VM_NUM')" />
     <xsl:apply-templates select="vm"/>
@@ -70,7 +85,11 @@
     </xsl:if>
     <xsl:value-of select="acrn:initializer('vm_prio', priority)" />
     <xsl:apply-templates select="guest_flags" />
-    <xsl:apply-templates select="clos" />
+
+    <xsl:if test="acrn:is-rdt-enabled()">
+      <xsl:apply-templates select="clos" />
+    </xsl:if>
+
     <xsl:call-template name="cpu_affinity" />
     <xsl:apply-templates select="epc_section" />
     <xsl:apply-templates select="memory" />
@@ -133,7 +152,25 @@
 
   <xsl:template match="clos">
     <xsl:value-of select="acrn:ifdef('CONFIG_RDT_ENABLED')" />
-    <xsl:value-of select="acrn:initializer('clos', concat('VM', ../@id, '_VCPU_CLOS'))" />
+    <xsl:value-of select="acrn:initializer('pclosids', concat('vm', ../@id, '_vcpu_clos'))" />
+
+    <xsl:value-of select="acrn:initializer('num_pclosids', concat(count(vcpu_clos), 'U'))" />
+
+    <xsl:if test="acrn:is-vcat-enabled() and @vcat = 'y'">
+      <xsl:variable name="rdt_res_str" select="acrn:get-normalized-closinfo-rdt-res-str()" />
+      <xsl:variable name="closid" select="vcpu_clos[1]" />
+
+      <xsl:value-of select="acrn:initializer('vcat_enabled', 'true')" />
+
+      <xsl:if test="contains($rdt_res_str, 'L2')">
+        <xsl:value-of select="acrn:initializer('max_l2_pcbm', concat(../../hv/FEATURES/RDT/CLOS_MASK[$closid + 1], 'U'))" />
+      </xsl:if>
+
+      <xsl:if test="contains($rdt_res_str, 'L3')">
+        <xsl:value-of select="acrn:initializer('max_l3_pcbm', concat(../../hv/FEATURES/RDT/CLOS_MASK[$closid + 1], 'U'))" />
+      </xsl:if>
+    </xsl:if>
+
     <xsl:value-of select="$endif" />
   </xsl:template>
 

--- a/misc/hv_prebuild/vm_cfg_checks.c
+++ b/misc/hv_prebuild/vm_cfg_checks.c
@@ -87,10 +87,10 @@ static bool check_vm_clos_config(uint16_t vm_id)
 	uint16_t vcpu_num = bitmap_weight(vm_config->cpu_affinity);
 
 	for (i = 0U; i < vcpu_num; i++) {
-		if (((platform_clos_num != 0U) && (vm_config->clos[i] == platform_clos_num))
-				|| (vm_config->clos[i] > platform_clos_num)) {
+		if (((platform_clos_num != 0U) && (vm_config->pclosids[i] == platform_clos_num))
+				|| (vm_config->pclosids[i] > platform_clos_num)) {
 			printf("vm%u: vcpu%u clos(%u) exceed the max clos(%u).",
-				vm_id, i, vm_config->clos[i], platform_clos_num);
+				vm_id, i, vm_config->pclosids[i], platform_clos_num);
 			ret = false;
 			break;
 		}


### PR DESCRIPTION
Merge two vCAT related patches:

config-tools: add the support for vCAT
hv/config_tools: amend the struct acrn_vm_config to make it compatible with vCAT


Tracked-On: #5917