### PR TITLE
config_tools: schema: revert to old schema

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -400,11 +400,6 @@ Refer SDM 17.19.2 for details, and use with caution.</xs:documentation>
         <xs:documentation>Specify memory information for Service and User VMs.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="priority" type="PriorityType"  default="PRIO_LOW">
-      <xs:annotation>
-        <xs:documentation>Specify the VM vCPU priority for scheduling.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
     <xs:element name="os_config" type="OSConfigurations" minOccurs="0">
       <xs:annotation>
         <xs:documentation>General information for host kernel, boot

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -101,7 +101,7 @@ higher value (lower severity) are discarded.</xs:documentation>
 
 <xs:simpleType name="SchedulerType">
   <xs:annotation>
-    <xs:documentation>Four scheduler options are supported:
+    <xs:documentation>Three scheduler options are supported:
 
 - ``SCHED_NOOP``: The NOOP (No-Operation) scheduler means there is a
   strict 1 to 1 mapping between vCPUs and pCPUs.
@@ -113,8 +113,6 @@ higher value (lower severity) are discarded.</xs:documentation>
   earliest effective virtual time. *TODO: BVT scheduler will be built on
   top of a prioritized scheduling mechanism, i.e. higher priority threads
   get scheduled first, and same priority tasks are scheduled per BVT.*
-- ``SCHED_PRIO``: The priority based scheduler. vCPU scheduling will be based on
-  their pre-configured priorities.
 
 Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:documentation>
   </xs:annotation>
@@ -122,21 +120,6 @@ Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:docu
     <xs:enumeration value="SCHED_NOOP" />
     <xs:enumeration value="SCHED_IORR" />
     <xs:enumeration value="SCHED_BVT" />
-    <xs:enumeration value="SCHED_PRIO" />
-  </xs:restriction>
-</xs:simpleType>
-
-<xs:simpleType name="PriorityType">
-  <xs:annotation>
-    <xs:documentation>Two priorities are supported for priority based scheduler:
-
-- ``PRIO_LOW``: low priority for vCPU scheduling.
-- ``PRIO_HIGH``: high priority for vCPU scheduling.
-    </xs:documentation>
-  </xs:annotation>
-  <xs:restriction base="xs:string">
-    <xs:enumeration value="PRIO_LOW" />
-    <xs:enumeration value="PRIO_HIGH" />
   </xs:restriction>
 </xs:simpleType>
 


### PR DESCRIPTION
Commit e678dc8 ("doc: pick doc updates for v2.6 release") picked the latest
scenario XML schema from the main branch, which includes both documentation
changes and new configuration entries. These new entries cause build
failures of the release branch because those new entries do not exist in
the scenario XMLs of v2.6 and the default value populator is yet to be
added for v2.7.

This patch removes those new entries to unblock the build.

Tracked-On: #5692
Signed-off-by: Junjie Mao <junjie.mao@intel.com>