### PR TITLE
config_tools: update board name in makefile

### DIFF
--- a/hypervisor/scripts/makefile/config.mk
+++ b/hypervisor/scripts/makefile/config.mk
@@ -142,13 +142,6 @@ ifdef RELEASE
   endif
 endif
 
-# Backward-compatibility for BOARD=apl-nuc or BOARD=kbl-nuc
-ifeq ($(BOARD), apl-nuc)
-  override BOARD := nuc6cayh
-else ifeq ($(BOARD), kbl-nuc-i7)
-  override BOARD := nuc7i7dnb
-endif
-
 ifeq ($(findstring $(MAKECMDGOALS),distclean),)
 -include $(HV_CONFIG_MK)
 endif
@@ -187,8 +180,8 @@ endif
 # file. SCENARIO/SCENARIO_FILE are used in the same way. The following block translates the user-visible BOARD/SCENARIO
 # (which is multiplexed) to the internal representation.
 
-$(eval $(call determine_config,BOARD,nuc7i7dnb))
-$(eval $(call determine_config,SCENARIO,industry))
+$(eval $(call determine_config,BOARD,nuc11tnbi5))
+$(eval $(call determine_config,SCENARIO,shared))
 $(eval $(call determine_build_type,n))
 
 $(HV_BOARD_XML):


### PR DESCRIPTION
update board name from nuc7i7dnb to nuc11tnbi5 in makefile because
we have removed the nuc7i7dnb board folder, and also update the
scenario name from industry to shared to fix "make all" build issue.

Tracked-On: #6315
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>