### PR TITLE
doc: update uses of VHM in doxygen comments

### DIFF
--- a/hypervisor/include/arch/x86/asm/guest/guest_memory.h
+++ b/hypervisor/include/arch/x86/asm/guest/guest_memory.h
@@ -56,7 +56,7 @@ void *gpa2hva(struct acrn_vm *vm, uint64_t x);
  * @pre Caller(Guest) should make sure gpa is continuous.
  * - gpa from hypercall input which from kernel stack is gpa continuous, not
  *   support kernel stack from vmap
- * - some other gpa from hypercall parameters, VHM should make sure it's
+ * - some other gpa from hypercall parameters, HSM should make sure it's
  *   continuous
  * @pre Pointer vm is non-NULL
  */
@@ -75,7 +75,7 @@ int32_t copy_from_gpa(struct acrn_vm *vm, void *h_ptr, uint64_t gpa, uint32_t si
  * @pre Caller(Guest) should make sure gpa is continuous.
  * - gpa from hypercall input which from kernel stack is gpa continuous, not
  *   support kernel stack from vmap
- * - some other gpa from hypercall parameters, VHM should make sure it's
+ * - some other gpa from hypercall parameters, HSM should make sure it's
  *   continuous
  * @pre Pointer vm is non-NULL
  */

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -217,7 +217,7 @@ struct acrn_pci_request {
  * |                       |                         |   SOS vCPU 0         |
  * |                       |                         |                      |
  * +-----------------------+-------------------------+----------------------+
- * | VHM:                  |                         |                      |
+ * | HSM:                  |                         |                      |
  * |                       |                         |                      |
  * | - Scan for pending    |                         |                      |
  * |   requests            |                         |                      |
@@ -260,7 +260,7 @@ struct acrn_pci_request {
  *   4. One vCPU cannot trigger another I/O request before the previous one has
  *      completed (i.e. the state switched to FREE)
  *
- * Accesses to the state of a vhm_request shall be atomic and proper barriers
+ * Accesses to the state of a acrn_io_request shall be atomic and proper barriers
  * are needed to ensure that:
  *
  *   1. Setting state to PENDING is the last operation when issuing a request in
@@ -338,7 +338,7 @@ struct acrn_io_request_buffer {
  * @brief Info to create a VM, the parameter for HC_CREATE_VM hypercall
  */
 struct acrn_vm_creation {
-	/** created vmid return to VHM. Keep it first field */
+	/** created vmid return to HSM. Keep it first field */
 	uint16_t vmid;
 
 	/** Reserved */
@@ -435,7 +435,7 @@ struct acrn_regs {
 /**
  * @brief Info to set vcpu state
  *
- * the pamameter for HC_SET_VCPU_STATE
+ * the parameter for HC_SET_VCPU_STATE
  */
 struct acrn_vcpu_regs {
 	/** the virtual CPU ID for the VCPU to set state */

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -16,7 +16,7 @@
 #define ACRN_HV_DEFS_H
 
 /*
- * Common structures for HV/VHM
+ * Common structures for HV/HSM
  */
 
 #define BASE_HC_ID(x, y) (((x)<<24U)|(y))
@@ -329,7 +329,7 @@ struct acrn_platform_info {
 
 		/**
 		 * Address to an array of struct acrn_vm_config, containing all
-		 * the configurations of all VMs. VHM treats it as an opague data
+		 * the configurations of all VMs. HSM treats it as an opaque data
 		 * structure.
 		 *
 		 * The size of one array element is vm_config_entry_size while


### PR DESCRIPTION
PR #6283 updated code and docs to the new kernel HSM driver. Fix
some references to VHM missed in the doxygen comments. Also fixed some
misspellings while in these files.

Tracked-On: #6282

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>