### PR TITLE
hv: operations on vcpu->reg_cached/reg_updated don't need LOCK prefix

### DIFF
--- a/hypervisor/arch/x86/guest/nested.c
+++ b/hypervisor/arch/x86/guest/nested.c
@@ -1338,8 +1338,8 @@ static void set_vmcs01_guest_state(struct acrn_vcpu *vcpu)
 		 */
 		exec_vmwrite(VMX_GUEST_CR0, vmcs12->host_cr0);
 		exec_vmwrite(VMX_GUEST_CR4, vmcs12->host_cr4);
-		bitmap_clear_lock(CPU_REG_CR0, &vcpu->reg_cached);
-		bitmap_clear_lock(CPU_REG_CR4, &vcpu->reg_cached);
+		bitmap_clear_nolock(CPU_REG_CR0, &vcpu->reg_cached);
+		bitmap_clear_nolock(CPU_REG_CR4, &vcpu->reg_cached);
 
 		exec_vmwrite(VMX_GUEST_CR3, vmcs12->host_cr3);
 		exec_vmwrite(VMX_GUEST_DR7, DR7_INIT_VALUE);

--- a/hypervisor/arch/x86/guest/trusty.c
+++ b/hypervisor/arch/x86/guest/trusty.c
@@ -164,12 +164,12 @@ static void load_world_ctx(struct acrn_vcpu *vcpu, const struct ext_context *ext
 	uint32_t i;
 
 	/* mark to update on-demand run_context for efer/rflags/rsp/rip/cr0/cr4 */
-	bitmap_set_lock(CPU_REG_EFER, &vcpu->reg_updated);
-	bitmap_set_lock(CPU_REG_RFLAGS, &vcpu->reg_updated);
-	bitmap_set_lock(CPU_REG_RSP, &vcpu->reg_updated);
-	bitmap_set_lock(CPU_REG_RIP, &vcpu->reg_updated);
-	bitmap_set_lock(CPU_REG_CR0, &vcpu->reg_updated);
-	bitmap_set_lock(CPU_REG_CR4, &vcpu->reg_updated);
+	bitmap_set_nolock(CPU_REG_EFER, &vcpu->reg_updated);
+	bitmap_set_nolock(CPU_REG_RFLAGS, &vcpu->reg_updated);
+	bitmap_set_nolock(CPU_REG_RSP, &vcpu->reg_updated);
+	bitmap_set_nolock(CPU_REG_RIP, &vcpu->reg_updated);
+	bitmap_set_nolock(CPU_REG_CR0, &vcpu->reg_updated);
+	bitmap_set_nolock(CPU_REG_CR4, &vcpu->reg_updated);
 
 	/* VMCS Execution field */
 	exec_vmwrite64(VMX_TSC_OFFSET_FULL, ext_ctx->tsc_offset);

--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -318,7 +318,7 @@ static void vmx_write_cr0(struct acrn_vcpu *vcpu, uint64_t value)
 			exec_vmwrite(VMX_CR0_READ_SHADOW, effective_cr0);
 
 			/* clear read cache, next time read should from VMCS */
-			bitmap_clear_lock(CPU_REG_CR0, &vcpu->reg_cached);
+			bitmap_clear_nolock(CPU_REG_CR0, &vcpu->reg_cached);
 
 			pr_dbg("VMM: Try to write %016lx, allow to write 0x%016lx to CR0", effective_cr0, tmp);
 		}
@@ -420,7 +420,7 @@ static void vmx_write_cr4(struct acrn_vcpu *vcpu, uint64_t cr4)
 			exec_vmwrite(VMX_CR4_READ_SHADOW, cr4);
 
 			/* clear read cache, next time read should from VMCS */
-			bitmap_clear_lock(CPU_REG_CR4, &vcpu->reg_cached);
+			bitmap_clear_nolock(CPU_REG_CR4, &vcpu->reg_cached);
 
 			pr_dbg("VMM: Try to write %016lx, allow to write 0x%016lx to CR4", cr4, tmp);
 		}
@@ -521,7 +521,7 @@ uint64_t vcpu_get_cr0(struct acrn_vcpu *vcpu)
 {
 	struct run_context *ctx = &vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
-	if (bitmap_test_and_set_lock(CPU_REG_CR0, &vcpu->reg_cached) == 0) {
+	if (bitmap_test_and_set_nolock(CPU_REG_CR0, &vcpu->reg_cached) == 0) {
 		ctx->cr0 = (exec_vmread(VMX_CR0_READ_SHADOW) & ~cr0_passthru_mask) |
 			(exec_vmread(VMX_GUEST_CR0) & cr0_passthru_mask);
 	}
@@ -549,7 +549,7 @@ uint64_t vcpu_get_cr4(struct acrn_vcpu *vcpu)
 {
 	struct run_context *ctx = &vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
-	if (bitmap_test_and_set_lock(CPU_REG_CR4, &vcpu->reg_cached) == 0) {
+	if (bitmap_test_and_set_nolock(CPU_REG_CR4, &vcpu->reg_cached) == 0) {
 		ctx->cr4 = (exec_vmread(VMX_CR4_READ_SHADOW) & ~cr4_passthru_mask) |
 			(exec_vmread(VMX_GUEST_CR4) & cr4_passthru_mask);
 	}


### PR DESCRIPTION
In run time, one vCPU won't read or write a register on other vCPUs,
thus we don't need the LOCK prefixed instructions on reg_cached and
reg_updated.

Tracked-On: #6289
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>