### PR TITLE
config-tools: refine xpath to pci host bridge

### DIFF
--- a/misc/config_tools/static_allocators/bdf.py
+++ b/misc/config_tools/static_allocators/bdf.py
@@ -79,7 +79,7 @@ def get_devs_bdf_native(board_etree):
     Get all pci devices' bdf in native environment.
     return: list of pci devices' bdf
     """
-    nodes = board_etree.xpath(f"//bus[@type = 'pci' and @id]/device[@address]")
+    nodes = board_etree.xpath(f"//bus[@type = 'pci' and @address = '0x0']/device[@address]")
     dev_list = []
     for node in nodes:
         address = node.get('address')


### PR DESCRIPTION
Looks for host bridge with address = '0x0'.

This resolve the issue that for the server platform which do not have attribute id of hostbridge.

Tracked-On: #6024
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>