### PR TITLE
hv: remove CONFIG_HV_RAM_SIZE

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -472,7 +472,7 @@ void cpu_dead(void)
 		vmx_off();
 
 		stac();
-		flush_cache_range((void *)get_hv_image_base(), CONFIG_HV_RAM_SIZE);
+		flush_cache_range((void *)get_hv_image_base(), get_hv_ram_size());
 		clac();
 
 		/* Set state to show CPU is dead */

--- a/hypervisor/arch/x86/e820.c
+++ b/hypervisor/arch/x86/e820.c
@@ -34,7 +34,7 @@ static struct e820_entry hv_e820[E820_MAX_ENTRIES];
  * @pre (size_arg & 0xFFFU) == 0U
  * @return base address of the memory region
  */
-uint64_t e820_alloc_memory(uint32_t size_arg, uint64_t max_addr)
+uint64_t e820_alloc_memory(uint64_t size_arg, uint64_t max_addr)
 {
 	int32_t i;
 	uint64_t size = size_arg;

--- a/hypervisor/arch/x86/guest/ve820.c
+++ b/hypervisor/arch/x86/guest/ve820.c
@@ -139,7 +139,7 @@ void create_sos_vm_e820(struct acrn_vm *vm)
 {
 	uint16_t vm_id, i;
 	uint64_t hv_start_pa = hva2hpa((void *)(get_hv_image_base()));
-	uint64_t hv_end_pa  = hv_start_pa + CONFIG_HV_RAM_SIZE;
+	uint64_t hv_end_pa  = hv_start_pa + get_hv_ram_size();
 	uint32_t entries_count = get_e820_entries_count();
 	struct acrn_vm_config *sos_vm_config = get_vm_config(vm->vm_id);
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -434,7 +434,7 @@ static void prepare_sos_vm_memmap(struct acrn_vm *vm)
 	 * will cause EPT violation if sos accesses hv memory
 	 */
 	hv_hpa = hva2hpa((void *)(get_hv_image_base()));
-	ept_del_mr(vm, pml4_page, hv_hpa, CONFIG_HV_RAM_SIZE);
+	ept_del_mr(vm, pml4_page, hv_hpa, get_hv_ram_size());
 	/* unmap prelaunch VM memory */
 	for (vm_id = 0U; vm_id < CONFIG_MAX_VM_NUM; vm_id++) {
 		vm_config = get_vm_config(vm_id);

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -40,6 +40,7 @@
 #include <logmsg.h>
 #include <misc_cfg.h>
 
+static uint32_t hv_ram_size;
 static void *ppt_mmu_pml4_addr;
 static uint8_t sanitized_page[PAGE_SIZE] __aligned(PAGE_SIZE);
 
@@ -151,6 +152,11 @@ void invept(const void *eptp)
 	}
 }
 
+uint32_t get_hv_ram_size(void)
+{
+	return hv_ram_size;
+}
+
 void enable_paging(void)
 {
 	uint64_t tmp64 = 0UL;
@@ -249,6 +255,7 @@ void init_paging(void)
 	const struct abi_mmap *p_mmap = abi->mmap_entry;
 
 	pr_dbg("HV MMU Initialization");
+	hv_ram_size = (uint32_t)(uint64_t)&ld_ram_size;
 
 	init_sanitized_page((uint64_t *)sanitized_page, hva2hpa_early(sanitized_page));
 
@@ -295,7 +302,7 @@ void init_paging(void)
 	 */
 	hv_hva = get_hv_image_base();
 	pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr, hv_hva & PDE_MASK,
-			CONFIG_HV_RAM_SIZE + (((hv_hva & (PDE_SIZE - 1UL)) != 0UL) ? PDE_SIZE : 0UL),
+			hv_ram_size + (((hv_hva & (PDE_SIZE - 1UL)) != 0UL) ? PDE_SIZE : 0UL),
 			PAGE_CACHE_WB, PAGE_CACHE_MASK | PAGE_USER, &ppt_pgtable, MR_MODIFY);
 
 	/*

--- a/hypervisor/bsp/ld/link_ram.ld.in
+++ b/hypervisor/bsp/ld/link_ram.ld.in
@@ -6,7 +6,7 @@ MEMORY
     lowram  :   ORIGIN = 0, LENGTH = CONFIG_LOW_RAM_SIZE
 
     /* 32 MBytes of RAM for HV */
-    ram     :   ORIGIN = CONFIG_HV_RAM_START, LENGTH = CONFIG_HV_RAM_SIZE
+    ram     :   ORIGIN = CONFIG_HV_RAM_START, LENGTH = 0x80000000 - CONFIG_HV_RAM_START
 }
 
 SECTIONS
@@ -98,6 +98,7 @@ SECTIONS
         ld_bss_end = . ;
     } > ram
 
-    _ld_ram_size = LENGTH(ram) ;
-    _ld_ram_end = _ld_ram_size + _ld_ram_start ;
+   . = ALIGN(0x200000) ;
+    _ld_ram_end = . ;
+    ld_ram_size = _ld_ram_end - _ld_ram_start ;
 }

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -760,7 +760,7 @@ static int32_t write_protect_page(struct acrn_vm *vm,const struct wp_data *wp)
 				base_paddr = hva2hpa((void *)(get_hv_image_base()));
 				if (((hpa <= base_paddr) && ((hpa + PAGE_SIZE) > base_paddr)) ||
 						((hpa >= base_paddr) &&
-						 (hpa < (base_paddr + CONFIG_HV_RAM_SIZE)))) {
+						 (hpa < (base_paddr + get_hv_ram_size())))) {
 					pr_err("%s: overlap the HV memory region.", __func__);
 				} else {
 					prot_set = (wp->set != 0U) ? 0UL : EPT_WR;

--- a/hypervisor/include/arch/x86/asm/boot/ld_sym.h
+++ b/hypervisor/include/arch/x86/asm/boot/ld_sym.h
@@ -14,5 +14,6 @@ extern uint8_t		ld_entry_end;
 extern const uint8_t	ld_trampoline_load;
 extern uint8_t		ld_trampoline_start;
 extern uint8_t		ld_trampoline_end;
+extern uint8_t		ld_ram_size;
 
 #endif /* LD_SYM_H */

--- a/hypervisor/include/arch/x86/asm/e820.h
+++ b/hypervisor/include/arch/x86/asm/e820.h
@@ -37,7 +37,7 @@ struct mem_range {
 /* HV read multiboot header to get e820 entries info and calc total RAM info */
 void init_e820(void);
 
-uint64_t e820_alloc_memory(uint32_t size_arg, uint64_t max_addr);
+uint64_t e820_alloc_memory(uint64_t size_arg, uint64_t max_addr);
 /* get total number of the e820 entries */
 uint32_t get_e820_entries_count(void);
 

--- a/hypervisor/include/arch/x86/asm/mmu.h
+++ b/hypervisor/include/arch/x86/asm/mmu.h
@@ -183,6 +183,8 @@ void flush_vpid_global(void);
  */
 void invept(const void *eptp);
 
+uint32_t get_hv_ram_size(void);
+
 /* get PDPT address from CR3 vaule in PAE mode */
 static inline uint64_t get_pae_pdpt_addr(uint64_t cr3)
 {


### PR DESCRIPTION
It's difficult to configure CONFIG_HV_RAM_SIZE properly at once. This patch
not only remove CONFIG_HV_RAM_SIZE, but also we use ld linker script to
dynamically get the size of HV RAM size.

Tracked-On: #6663
Signed-off-by: Fei Li <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>