### PR TITLE
config_tools: add Board Inspector tool success message

### DIFF
--- a/misc/config_tools/board_inspector/board_inspector.py
+++ b/misc/config_tools/board_inspector/board_inspector.py
@@ -60,6 +60,7 @@ def main(board_name, board_xml, args):
 
         # Finally overwrite the output with the updated XML
         board_etree.write(board_xml, pretty_print=True)
+        print("{} saved successfully!".format(board_xml))
 
     except subprocess.CalledProcessError as e:
         print(e)


### PR DESCRIPTION
add Board Inspector tool success message after users were successful
creating the board configuration file.

Tracked-On: #6670
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>