### PR TITLE
hv: unmap IOMMU register pages from service VM EPT

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -465,6 +465,15 @@ static void prepare_sos_vm_memmap(struct acrn_vm *vm)
 	 */
 	ept_del_mr(vm, pml4_page, PRE_RTVM_SW_SRAM_BASE_GPA, PRE_RTVM_SW_SRAM_END_GPA - PRE_RTVM_SW_SRAM_BASE_GPA);
 #endif
+
+	/* unmap Intel IOMMU register pages for below reason:
+	 * Service VM can detect IOMMU capability in its ACPI table hence it may access
+	 * IOMMU hardware resources, which is not expected, as IOMMU hardware is owned by hypervisor.
+	 */
+	for (i = 0U; i < plat_dmar_info.drhd_count; i++) {
+		ept_del_mr(vm, pml4_page, plat_dmar_info.drhd_units[i].reg_base_addr, PAGE_SIZE);
+	}
+
 }
 
 /* Add EPT mapping of EPC reource for the VM */


### PR DESCRIPTION
 IOMMU hardware resource is owned by hypervisor, while
 IOMMU capability is reported to service VM in its ACPI
 table. In this case, Service VM may access IOMMU hardware
 resource, which is not expected.

 This patch unmaps all Intel IOMMU register pages for service VM EPT.

Tracked-On: #6677
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Reviewed-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>