### PR TITLE
doc: prepare docs for removal of HV_RAM_SIZE option

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -16,34 +16,3 @@ What Hardware Does ACRN Support?
 ACRN runs on Intel-based boards, as documented in
 our :ref:`hardware` documentation.
 
-.. _config_32GB_memory:
-
-How Do I Configure ACRN's Memory Size?
-**************************************
-
-It's important that the ACRN configuration settings are aligned with the
-physical memory on your platform. Check the documentation for these
-option settings for details:
-
-* :option:`hv.MEMORY.PLATFORM_RAM_SIZE`
-* :option:`hv.MEMORY.HV_RAM_SIZE`
-
-Check the :ref:`acrn_configuration_tool` for more information on how
-to adjust these settings.
-
-Why Does ACRN Need to Know How Much RAM the System Has?
-*******************************************************
-
-Configuring ACRN at compile time with the system RAM size is a tradeoff between
-flexibility and functional safety certification. For server virtualization, one
-binary is typically used for all platforms with flexible configuration options
-given at run time. But, for IoT applications, the image is typically configured
-and built for a particular product platform and optimized for that product.
-
-Important features for ACRN include Functional Safety (FuSa) and real-time
-behavior. FuSa requires a static allocation policy to avoid the potential of
-dynamic allocation failures. Real-time applications similarly benefit from
-static memory allocation. This is why ACRN removed all ``malloc()``-type code,
-and why it needs to pre-identify the size of all buffers and structures used in
-the Virtual Memory Manager. For this reason, knowing the available RAM size at
-compile time is necessary to statically allocate memory usage.

--- a/doc/user-guides/kernel-parameters.rst
+++ b/doc/user-guides/kernel-parameters.rst
@@ -207,8 +207,8 @@ relevant for configuring or debugging ACRN-based systems.
        from the guest VM.
 
        If hypervisor relocation is disabled, verify that
-       :option:`hv.MEMORY.HV_RAM_START` and :option:`hv.MEMORY.HV_RAM_SIZE`
-       does not overlap with the hypervisor's reserved buffer space allocated
+       :option:`hv.MEMORY.HV_RAM_START` and the hypervisor RAM size computed by the linker
+       do not overlap with the hypervisor's reserved buffer space allocated
        in the Service VM. Service VM GPA and HPA are a 1:1 mapping.
 
        If hypervisor relocation is enabled, reserve the memory below 256MB,


### PR DESCRIPTION
HV_RAM_SIZE will be eliminated as a configuration option so we'll need
to remove references to it in the documentation.

See PR #6664 and PR #6681

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>