### PR TITLE
dm: pci: minor bug fix about uninitialized local variable

### DIFF
--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -177,7 +177,7 @@ static inline int ptdev_msix_pba_bar(struct passthru_dev *ptdev)
 static int
 cfginitbar(struct vmctx *ctx, struct passthru_dev *ptdev)
 {
-	int i, error;
+	int i, error = 0;
 	struct pci_vdev *dev;
 	struct pci_bar_io bar;
 	enum pcibar_type bartype;


### PR DESCRIPTION
'error' might be used uninitialized in cfginitbar. So initialize it to zero
at the beginning.

Tracked-On: #6284
Signed-off-by: Fei Li <fei1.li@intel.com>