### PR TITLE
dm: TPM passthrough for post-launched VM

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -955,11 +955,11 @@ main(int argc, char *argv[])
 			break;
 		case CMD_OPT_ACPIDEV_PT:
 			/* FIXME: check acpi TPM device rules in acpi device famework init functions */
-			if (vtpm2 || parse_pt_acpidev(optarg) != 0)
+			if (vtpm2 || create_pt_acpidev(optarg) != 0)
 				errx(EX_USAGE, "invalid pt acpi dev param %s", optarg);
 			break;
 		case CMD_OPT_MMIODEV_PT:
-			if (parse_pt_mmiodev(optarg) != 0)
+			if (create_pt_mmiodev(optarg) != 0)
 				errx(EX_USAGE, "invalid pt mmio dev param %s", optarg);
 			break;
 		case CMD_OPT_VTPM2:

--- a/devicemodel/hw/mmio/core.c
+++ b/devicemodel/hw/mmio/core.c
@@ -325,22 +325,6 @@ struct mmio_dev_ops tpm2 = {
 };
 DEFINE_MMIO_DEV(tpm2);
 
-/* @pre (pt_tpm2 == true) */
-uint64_t get_mmio_dev_tpm2_base_gpa(void)
-{
-	int i;
-	uint64_t base_gpa = 0UL;
-
-	for (i = 0; i < mmio_dev_idx; i++) {
-		if (!strcmp(mmio_devs[i].name, "MSFT0101")) {
-			base_gpa = mmio_devs[i].dev.res[0].user_vm_pa;
-			break;
-		}
-	}
-
-	return base_gpa;
-}
-
 struct mmio_dev_ops pt_mmiodev = {
 	.name		= "MMIODEV",
 	/* ToDo: we may allocate the gpa MMIO resource in a reserved MMIO region

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -73,6 +73,7 @@
 #include "log.h"
 #include "rtct.h"
 #include "vmmapi.h"
+#include "mmio_dev.h"
 
 /*
  * Define the base address of the ACPI tables, and the offsets to
@@ -947,6 +948,8 @@ basl_fwrite_dsdt(FILE *fp, struct vmctx *ctx)
 	dsdt_line("      })");
 	dsdt_line("    }");
 	dsdt_line("  }");
+
+	acpi_dev_write_dsdt(ctx);
 
 	pm_write_dsdt(ctx, basl_ncpu);
 

--- a/devicemodel/hw/platform/tpm/tpm.c
+++ b/devicemodel/hw/platform/tpm/tpm.c
@@ -108,3 +108,6 @@ void deinit_vtpm2(struct vmctx *ctx)
 		deinit_tpm_emulator();
 	}
 }
+
+struct acpi_dev_pt_ops pt_tpm2_dev_ops = { 0 };
+DEFINE_ACPI_PT_DEV(pt_tpm2_dev_ops);

--- a/devicemodel/include/acpi.h
+++ b/devicemodel/include/acpi.h
@@ -65,6 +65,9 @@ struct acpi_table_hdr {
 /* All dynamic table entry no. */
 #define NHLT_ENTRY_NO		8
 
+#define EFPRINTF(...) fprintf(__VA_ARGS__)
+#define EFFLUSH(x) fflush(x)
+
 void acpi_table_enable(int num);
 uint32_t get_acpi_base(void);
 uint32_t get_acpi_table_length(void);

--- a/devicemodel/include/mmio_dev.h
+++ b/devicemodel/include/mmio_dev.h
@@ -38,7 +38,6 @@ int init_mmio_devs(struct vmctx *ctx);
 void deinit_mmio_devs(struct vmctx *ctx);
 
 int mmio_dev_alloc_gpa_resource32(uint32_t *addr, uint32_t size_in);
-uint64_t get_mmio_dev_tpm2_base_gpa(void);
 
 #define MMIO_DEV_BASE  0xF0000000U
 #define MMIO_DEV_LIMIT 0xFE000000U

--- a/devicemodel/include/mmio_dev.h
+++ b/devicemodel/include/mmio_dev.h
@@ -8,8 +8,31 @@
 #ifndef _MMIO_DEV_H_
 #define _MMIO_DEV_H_
 
-int parse_pt_acpidev(char *arg);
-int parse_pt_mmiodev(char *arg);
+#include "acrn_common.h"
+
+struct mmio_dev {
+	char name[16];
+	struct acrn_mmiodev dev;
+};
+
+struct acpi_dev_pt_ops {
+	char hid[8];
+	char modalias[32];
+	int (*match)(char *);
+	int (*init)(char *, struct mmio_dev *);
+	void (*write_dsdt)(struct vmctx *);
+	/* TODO: We may add more fields when we support other ACPI dev pt */
+};
+
+#define DEFINE_ACPI_PT_DEV(x) DATA_SET(acpi_dev_pt_ops_set, x);
+
+struct mmio_dev *get_mmiodev(char *name);
+int get_mmio_hpa_resource(char *name, uint64_t *res_start, uint64_t *res_size);
+int get_more_acpi_dev_info(char *hid, uint32_t instance, struct acpi_dev_pt_ops *ops);
+void acpi_dev_write_dsdt(struct vmctx *ctx);
+
+int create_pt_acpidev(char *arg);
+int create_pt_mmiodev(char *arg);
 
 int init_mmio_devs(struct vmctx *ctx);
 void deinit_mmio_devs(struct vmctx *ctx);

--- a/devicemodel/include/tpm.h
+++ b/devicemodel/include/tpm.h
@@ -8,11 +8,26 @@
 #ifndef _TPM_H_
 #define _TPM_H_
 
+#include "mmio_dev.h"
+#include "acpi.h"
+
 #define TPM_CRB_MMIO_ADDR 0xFED40000UL
 #define TPM_CRB_MMIO_SIZE 0x5000U
 
 uint32_t get_vtpm_crb_mmio_addr(void);
 uint32_t get_tpm_crb_mmio_addr(void);
+int basl_fwrite_tpm2(FILE *fp, struct vmctx *ctx);
+
+struct acpi_table_tpm2 {
+	struct acpi_table_hdr header;
+	uint16_t platform_class;
+	uint16_t reserved;
+	uint64_t control_address;
+	uint32_t start_method;
+	uint8_t start_method_spec_para[12];
+	uint32_t laml;
+	uint64_t lasa;
+} __attribute__((packed));
 
 /* TPM CRB registers */
 enum {


### PR DESCRIPTION
This PR enables TPM2 passthrough to post-launched VM with eventlog support.
User starts by providing command line "--acpidev_pt <TPM2_HID>",
of which the <TPM2_HID> will be searched from /proc/iomem for TPM2 buffer
start address and size. Furthermore, If TPM2 eventlog is supported,
TPM2 eventlog information will be retrieved from sysfs TPM2 table and
passed-through as well.