### PR TITLE
config_tools: Fix UI issues

### DIFF
--- a/misc/config_tools/config_app/views.py
+++ b/misc/config_tools/config_app/views.py
@@ -618,7 +618,10 @@ def create_setting():
             template_file_name = 'shared'
             src_file_name = os.path.join(current_app.config.get('DEFAULT_CONFIG_PATH'), 'generic_board', template_file_name + '.xml')
         else: # load
-            src_file_name = os.path.join(current_app.config.get('DEFAULT_CONFIG_PATH'), board_type, default_name + '.xml')
+            src_file_name = os.path.join(current_app.config.get('DEFAULT_CONFIG_PATH'), board_type,
+                                         default_name + '.xml')
+            if not os.path.isfile(src_file_name):
+                src_file_name=os.path.join(current_app.config.get('DEFAULT_CONFIG_PATH'), 'generic_board', default_name + '.xml')
 
         if os.path.isfile(src_file_name):
             xsd_path =  os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'schema', 'config.xsd')

--- a/misc/config_tools/data/generic_board/hybrid_rt.xml
+++ b/misc/config_tools/data/generic_board/hybrid_rt.xml
@@ -1,0 +1,264 @@
+<acrn-config board="generic_board" scenario="hybrid_rt">
+  <hv>
+    <DEBUG_OPTIONS>
+      <RELEASE>n</RELEASE>
+      <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+      <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+      <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+      <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+      <LOG_DESTINATION>7</LOG_DESTINATION>
+      <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
+    </DEBUG_OPTIONS>
+    <FEATURES>
+      <RELOC>y</RELOC>
+      <SCHEDULER>SCHED_BVT</SCHEDULER>
+      <MULTIBOOT2>y</MULTIBOOT2>
+      <ENFORCE_TURNOFF_AC>y</ENFORCE_TURNOFF_AC>
+      <RDT>
+        <RDT_ENABLED>n</RDT_ENABLED>
+        <CDP_ENABLED>n</CDP_ENABLED>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+        <CLOS_MASK>0xfff</CLOS_MASK>
+      </RDT>
+      <NVMX_ENABLED>n</NVMX_ENABLED>
+      <HYPERV_ENABLED>y</HYPERV_ENABLED>
+      <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+      <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+      <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+      <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+      <IVSHMEM>
+        <IVSHMEM_ENABLED>y</IVSHMEM_ENABLED>
+        <IVSHMEM_REGION>hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
+      </IVSHMEM>
+    </FEATURES>
+    <MEMORY>
+      <STACK_SIZE>0x2000</STACK_SIZE>
+      <HV_RAM_SIZE/>
+      <HV_RAM_START/>
+      <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+      <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
+    </MEMORY>
+    <CAPACITIES>
+      <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+      <MAX_EFI_MMAP_ENTRIES>256</MAX_EFI_MMAP_ENTRIES>
+      <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+      <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+      <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+      <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+      <MAX_PT_IRQ_ENTRIES>256</MAX_PT_IRQ_ENTRIES>
+      <MAX_MSIX_TABLE_NUM></MAX_MSIX_TABLE_NUM>
+      <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
+    </CAPACITIES>
+    <MISC_CFG>
+      <GPU_SBDF>0x00000010</GPU_SBDF>
+      <UEFI_OS_LOADER_NAME/>
+    </MISC_CFG>
+  </hv>
+  <vm id="0">
+    <vm_type>PRE_RT_VM</vm_type>
+    <name>PRE_RT_VM0</name>
+    <guest_flags>
+      <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
+      <guest_flag>GUEST_FLAG_RT</guest_flag>
+    </guest_flags>
+    <cpu_affinity>
+      <pcpu_id>2</pcpu_id>
+      <pcpu_id>3</pcpu_id>
+    </cpu_affinity>
+    <clos>
+      <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
+    </clos>
+    <epc_section>
+      <base>0</base>
+      <size>0</size>
+    </epc_section>
+    <memory>
+      <start_hpa>0x100000000</start_hpa>
+      <size>0x40000000</size>
+      <start_hpa2>0x0</start_hpa2>
+      <size_hpa2>0x0</size_hpa2>
+    </memory>
+    <os_config>
+      <name>PREEMPT-RT</name>
+      <kern_type>KERNEL_BZIMAGE</kern_type>
+      <kern_mod>RT_bzImage</kern_mod>
+      <ramdisk_mod/>
+      <bootargs>rw rootwait root=/dev/sda3 no_ipi_broadcast=1 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 reboot=acpi </bootargs>
+    </os_config>
+    <legacy_vuart id="0">
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM1_BASE</base>
+      <irq>COM1_IRQ</irq>
+    </legacy_vuart>
+    <legacy_vuart id="1">
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM2_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <console_vuart id="0">
+      <base>INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+      <base>INVALID_PCI_BASE</base>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
+    </communication_vuart>
+    <pci_devs>
+      <pci_dev>00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</pci_dev>
+      <pci_dev>58:00.0 Ethernet controller: Intel Corporation Device 15f2 (rev 03)</pci_dev>
+    </pci_devs>
+    <mmio_resources>
+      <TPM2>n</TPM2>
+    </mmio_resources>
+  </vm>
+  <vm id="1">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN_SOS_VM</name>
+    <guest_flags>
+      <guest_flag>0</guest_flag>
+    </guest_flags>
+    <cpu_affinity>
+      <pcpu_id>0</pcpu_id>
+      <pcpu_id>1</pcpu_id>
+    </cpu_affinity>
+    <clos>
+      <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
+    </clos>
+    <memory>
+      <start_hpa>0</start_hpa>
+    </memory>
+    <os_config>
+      <name>ACRN Service OS</name>
+      <kern_type>KERNEL_BZIMAGE</kern_type>
+      <kern_mod>Linux_bzImage</kern_mod>
+      <ramdisk_mod/>
+      <bootargs>SOS_VM_BOOTARGS</bootargs>
+    </os_config>
+    <legacy_vuart id="0">
+      <type>VUART_LEGACY_PIO</type>
+      <base>SOS_COM1_BASE</base>
+      <irq>SOS_COM1_IRQ</irq>
+    </legacy_vuart>
+    <legacy_vuart id="1">
+      <type>VUART_LEGACY_PIO</type>
+      <base>SOS_COM2_BASE</base>
+      <irq>SOS_COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <console_vuart id="0">
+      <base>INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+      <base>INVALID_PCI_BASE</base>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
+    </communication_vuart>
+    <pci_devs>
+      <pci_dev/>
+    </pci_devs>
+    <board_private>
+      <rootfs>/dev/nvme0n1p3</rootfs>
+      <bootargs>
+            rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+            i915.nuclear_pageflip=1 swiotlb=131072
+            </bootargs>
+    </board_private>
+  </vm>
+  <vm id="2">
+    <vm_type>POST_STD_VM</vm_type>
+    <name>POST_STD_VM1</name>
+    <guest_flags>
+      <guest_flag>0</guest_flag>
+    </guest_flags>
+    <cpu_affinity>
+      <pcpu_id>0</pcpu_id>
+      <pcpu_id>1</pcpu_id>
+    </cpu_affinity>
+    <clos>
+      <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
+    </clos>
+    <epc_section>
+      <base>0</base>
+      <size>0</size>
+    </epc_section>
+    <legacy_vuart id="0">
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM1_BASE</base>
+      <irq>COM1_IRQ</irq>
+    </legacy_vuart>
+    <legacy_vuart id="1">
+      <type>VUART_LEGACY_PIO</type>
+      <base>INVALID_COM_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <console_vuart id="0">
+      <base>INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+      <base>INVALID_PCI_BASE</base>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
+    </communication_vuart>
+    <PTM>n</PTM>
+  </vm>
+  <vm id="3">
+    <vm_type>POST_STD_VM</vm_type>
+    <name>POST_STD_VM2</name>
+    <guest_flags>
+      <guest_flag>0</guest_flag>
+    </guest_flags>
+    <cpu_affinity>
+      <pcpu_id>1</pcpu_id>
+    </cpu_affinity>
+    <clos>
+      <vcpu_clos>0</vcpu_clos>
+    </clos>
+    <epc_section>
+      <base>0</base>
+      <size>0</size>
+    </epc_section>
+    <legacy_vuart id="0">
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM1_BASE</base>
+      <irq>COM1_IRQ</irq>
+    </legacy_vuart>
+    <legacy_vuart id="1">
+      <type>VUART_LEGACY_PIO</type>
+      <base>INVALID_COM_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <console_vuart id="0">
+      <base>INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+      <base>INVALID_PCI_BASE</base>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
+    </communication_vuart>
+    <PTM>n</PTM>
+  </vm>
+</acrn-config>


### PR DESCRIPTION
1. call default_populator.py to expand the default value in the scenario XML file to fix the issue that doesn't export XML successfully
in UI when the user clicks the 'Export XML' button to export scenario XML file because that the unexpanded XML does not conform to schema check.
2. add hybrid_rt.xml file under the generic_board folder so that UI can call pre_rt_vm type when the user clicks 'Add a VM below'
button to add a new pre_rt_vm.
3. find default scenario file in board_type and generic_board directory path.