### PR TITLE
doc: update to sphinx_rtd_theme 1.0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -158,7 +158,7 @@ else:
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     html_theme_options = {
         'canonical_url': '',
-        'analytics_id': '',
+        'analytics_id': 'UA-831873-64',
         'logo_only': False,
         'display_version': True,
         #'prev_next_buttons_location': 'None',

--- a/doc/scripts/requirements.txt
+++ b/doc/scripts/requirements.txt
@@ -1,5 +1,5 @@
 breathe==4.23.0
 sphinx==3.2.1
 docutils==0.16
-sphinx_rtd_theme==0.5.0
+sphinx_rtd_theme==1.0
 sphinx-tabs==1.3.0

--- a/doc/scripts/show-versions.py
+++ b/doc/scripts/show-versions.py
@@ -32,6 +32,9 @@ for reqs in pkg_resources.parse_requirements(rf):
     try:
         ver = pkg_resources.get_distribution(reqs.project_name).version
         print ("  " + reqs.project_name.ljust(25," ") + " version: " + ver)
+        if not reqs.__contains__(ver):
+            print (color.RED + color.BOLD + "   >>> Warning: Expected version " +
+                    reqs.__str__() + " Python module from scripts/requirements.text." + color.END)
     except:
         print (color.RED + color.BOLD + reqs.project_name + " is missing." + color.END +
                 " (Hint: install all dependencies with " + color.YELLOW +

--- a/doc/static/acrn-custom.js
+++ b/doc/static/acrn-custom.js
@@ -7,9 +7,3 @@ $(document).ready(function(){
    /* open external links in a new tab */
    $('a[class*=external]').attr({target: '_blank', rel: 'noopener'});
 });
-
-/* Global site tag (gtag.js) - Google Analytics */
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'UA-831873-64');


### PR DESCRIPTION
The sphinx_rtd_theme 1.0 includes simplified configuration for Google
analytics, along with general fixes and improvements.

**Anyone publishing project documentation to projectacrn.github.io must be
using this updated sphinx_rtd_theme for Google Analytics data to be
properly collected.**

* Switch to use this new theme version, and clean up the previous method
  of collecting analytics data.
* Update requirements.txt to use this new theme version. Update the
  show-versions.py script (used to report on installed doc building tools)
  to also report if there's a mismatch on which version is expected (in
  requirements.txt) and what's currently installed.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>