### PR TITLE
doc: tweak python requirements for doc building

### DIFF
--- a/doc/scripts/requirements.txt
+++ b/doc/scripts/requirements.txt
@@ -1,5 +1,5 @@
-breathe==4.23.0
-sphinx==3.2.1
+breathe>=4.23.0,<=4.31
+sphinx>=3.2.1,<=3.5.4
 docutils==0.16
 sphinx_rtd_theme==1.0
 sphinx-tabs==1.3.0


### PR DESCRIPTION
Add compatible version ranges for breathe and sphinx to appease check by
show-versions.py

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>