### PR TITLE
Port board inspector fixes on v2.6 release back to mainline

### DIFF
--- a/misc/config_tools/acpi_gen/bin_gen.py
+++ b/misc/config_tools/acpi_gen/bin_gen.py
@@ -77,7 +77,7 @@ def tpm2_acpi_gen(acpi_bin, board_etree, scenario_etree, allocation_etree):
             ctype_data = acpiparser.tpm2.TPM2(_data)
             ctype_data.header.signature = "TPM2".encode()
             ctype_data.header.length = _data_len
-            ctype_data.header.revision = 0x3
+            ctype_data.header.revision = 4
             ctype_data.header.oemid = "ACRN  ".encode()
             ctype_data.header.oemtableid = "ACRNTPM2".encode()
             ctype_data.header.oemrevision = 0x1

--- a/misc/config_tools/board_inspector/extractors/50-acpi.py
+++ b/misc/config_tools/board_inspector/extractors/50-acpi.py
@@ -439,6 +439,12 @@ def fetch_device_info(devices_node, interpreter, namepath, args):
                 hid = "<unknown>"
             add_object_to_device(interpreter, namepath, "_HID", result)
 
+        # Create the XML element for the device and create its ancestors if necessary
+        element = get_device_element(devices_node, namepath, hid)
+        if hid in buses.keys():
+            element.tag = "bus"
+            element.set("type", buses[hid])
+
         # Compatible ID
         cids = []
         if interpreter.context.has_symbol(f"{namepath}._CID"):
@@ -458,13 +464,9 @@ def fetch_device_info(devices_node, interpreter, namepath, args):
                 elif isinstance(cid_datum, datatypes.String):
                     cids.append(cid_datum.get())
 
-        # Create the XML element for the device and create its ancestors if necessary
-        element = get_device_element(devices_node, namepath, hid)
-        if hid in buses.keys():
-            element.tag = "bus"
-            element.set("type", buses[hid])
-        for cid in cids:
-            add_child(element, "compatible_id", cid)
+            for cid in cids:
+                add_child(element, "compatible_id", cid)
+            add_object_to_device(interpreter, namepath, "_CID", cid_object)
 
         # Unique ID
         uid = ""


### PR DESCRIPTION
This PR ports the following fixes to the board inspector & config tools on v2.6 release back to mainline:

* c215229 config_tools: update vTPM2 revision to 4
* 855b0ed board_inspector: add _CID to vACPI device objects

The board XML will be updated accordingly in a later PR.