### PR TITLE
config_tools: skip remapping HW units with no devices under scope

### DIFF
--- a/misc/config_tools/board_inspector/legacy/dmar.py
+++ b/misc/config_tools/board_inspector/legacy/dmar.py
@@ -331,6 +331,11 @@ def walk_dmar_table(dmar_tbl, dmar_hw_list, dmar_dev_list, sysnode):
             dmar_tbl.drhd_offset += dmar_len
             continue
 
+        # Skip remapping hardware units without any device under its scope
+        if dmar_tbl.dmar_drhd.flags == 0 and dmar_len == ctypes.sizeof(DmarHwUnit):
+            dmar_tbl.drhd_offset += dmar_len
+            continue
+
         dmar_hw_list.hw_segment_list.append(dmar_tbl.dmar_drhd.segment)
         dmar_hw_list.hw_flags_list.append(dmar_tbl.dmar_drhd.flags)
         dmar_hw_list.hw_address_list.append(dmar_tbl.dmar_drhd.address)


### PR DESCRIPTION
It is seen on some platforms that the ACPI DMAR tables will report
remapping hardware units that does not have any device under its scope,
which is not expected by the board inspector previously and thus causes the
tool to generate inconsistent configuration data.

This patch makes the board inspector skip such remapping hardware units. It
does not impact the functionality of the hypervisor as no device is managed
by those skipped remapping units.

Tracked-On: #6709
Signed-off-by: Junjie Mao <junjie.mao@intel.com>