### PR TITLE
hv: vMSR: minor fix about rdmsr_vmexit_handler

### DIFF
--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -619,9 +619,11 @@ int32_t rdmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	}
 	}
 
-	/* Store the MSR contents in RAX and RDX */
-	vcpu_set_gpreg(vcpu, CPU_REG_RAX, v & 0xffffffffU);
-	vcpu_set_gpreg(vcpu, CPU_REG_RDX, v >> 32U);
+	if (err == 0) {
+		/* Store the MSR contents in RAX and RDX */
+		vcpu_set_gpreg(vcpu, CPU_REG_RAX, v & 0xffffffffU);
+		vcpu_set_gpreg(vcpu, CPU_REG_RDX, v >> 32U);
+	}
 
 	TRACE_2L(TRACE_VMEXIT_RDMSR, msr, v);
 


### PR DESCRIPTION
Specifying a reserved or unimplemented MSR address in ECX for rdmsr will cause a
general protection exception. In this case, we should not change the contents of
registers EDX:EAX.

Tracked-On: #4550
Signed-off-by: Fei Li <fei1.li@intel.com>