### PR TITLE
config_tools: remove hvlog and memmap parameter in bootargs

### DIFF
--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -167,7 +167,7 @@
         <rootfs>/dev/sda3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
+        i915.nuclear_pageflip=1
         </bootargs>
     </board_private>
   </vm>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
@@ -172,7 +172,7 @@
         <rootfs>/dev/nvme0n1p3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
+        i915.nuclear_pageflip=1
         </bootargs>
     </board_private>
   </vm>

--- a/misc/config_tools/data/whl-ipc-i5/sdc.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc.xml
@@ -104,7 +104,7 @@
         <rootfs>/dev/sda3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
+        i915.nuclear_pageflip=1
         </bootargs>
     </board_private>
   </vm>

--- a/misc/config_tools/data/whl-ipc-i5/shared.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared.xml
@@ -105,7 +105,7 @@
         <rootfs>/dev/sda3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
+        i915.nuclear_pageflip=1
         </bootargs>
     </board_private>
   </vm>


### PR DESCRIPTION
remove hvlog and memmap parameter in bootargs for whl-ipc-i5
scenario xml files.

Tracked-On: #6663
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>