### PR TITLE
config_tools: fix crash in board_inspector if cpuid is missing

### DIFF
--- a/misc/config_tools/board_inspector/legacy/board_parser.py
+++ b/misc/config_tools/board_inspector/legacy/board_parser.py
@@ -18,11 +18,7 @@ import parser_lib
 OUTPUT = "./out/"
 PY_CACHE = "__pycache__"
 
-# This file store information which query from hw board
-BIN_LIST = ['cpuid', 'rdmsr', 'lspci', ' dmidecode', 'blkid', 'stty']
-
 CPU_VENDOR = "GenuineIntel"
-
 
 def check_permission():
     """Check if it is root permission"""
@@ -50,27 +46,6 @@ def check_env():
     if not vendor_check():
         parser_lib.print_red("Please run this tools on {}!".format(CPU_VENDOR))
         sys.exit(1)
-
-    # check if required tools are exists
-    for excute in BIN_LIST:
-        res = subprocess.Popen("which {}".format(excute),
-                               shell=True, stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE, close_fds=True)
-
-        line = res.stdout.readline().decode('ascii')
-        if not line:
-            parser_lib.print_yel("'{}' not found, please install it!".format(excute))
-            sys.exit(1)
-
-        if excute == 'cpuid':
-            res = subprocess.Popen("cpuid -v",
-                                   shell=True, stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE, close_fds=True)
-            line = res.stdout.readline().decode('ascii')
-            version = line.split()[2]
-            if int(version) < 20170122:
-                parser_lib.print_yel("Need CPUID version >= 20170122")
-                sys.exit(1)
 
     if os.path.exists(OUTPUT):
         shutil.rmtree(OUTPUT)


### PR DESCRIPTION
Fix a crash in the 'board_inspector.py' tool in case 'cpuid' is not
installed on the system.

The tools crashes because 'cpuid' is used before the check for
dependencies is done in the code. That check for dependencies is
done in the 'legacy/board_parser.py' file. But the native_check()
function that is called before it also expects the cpuid tool to
be installed.

The fix is to move the check for dependencies in the main
'board_inspector.py' file, before any other operation is done.

Tracked-On: #6719
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>