### PR TITLE
misc: config_tools: add vuart for communication

### DIFF
--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -161,10 +161,24 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>SERVICE_VM_COM2_BASE</base>
-        <irq>SERVICE_VM_COM2_IRQ</irq>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="3">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>3</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -181,7 +195,7 @@
         <rootfs>/dev/nvme0n1p3</rootfs>
         <bootargs>
         rw rootwait console=ttyS0,115200n8 ignore_loglevel no_timer_check
-        hvlog=2M@0xe00000 memmap=0x200000$0xe00000
+        hvlog=2M@0xe00000 memmap=0x200000$0xe00000 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>
@@ -215,6 +229,13 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -254,6 +275,13 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>3</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/cfl-k700-i7/shared.xml
+++ b/misc/config_tools/data/cfl-k700-i7/shared.xml
@@ -86,10 +86,52 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>SERVICE_VM_COM2_BASE</base>
-        <irq>SERVICE_VM_COM2_IRQ</irq>
-        <target_vm_id>2</target_vm_id>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="3">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>3</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="4">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>4</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="5">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>5</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="6">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>6</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="7">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>7</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -106,7 +148,7 @@
         <rootfs>/dev/nvme0n1p3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
+        i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>
@@ -134,7 +176,7 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>INVALID_COM_BASE</base>
+        <base>COM2_BASE</base>
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
@@ -172,10 +214,17 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
+        <base>INVALID_COM_BASE</base>
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -216,6 +265,13 @@
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>3</target_uart_id>
+    </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -254,6 +310,13 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>4</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -294,6 +357,13 @@
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>5</target_uart_id>
+    </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -333,6 +403,13 @@
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>6</target_uart_id>
+    </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -368,6 +445,13 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>7</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/generic_board/hybrid.xml
+++ b/misc/config_tools/data/generic_board/hybrid.xml
@@ -96,11 +96,11 @@
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -150,11 +150,25 @@
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="3">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>3</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -170,7 +184,7 @@
     <board_private>
       <rootfs>/dev/nvme0n1p3</rootfs>
       <bootargs>        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 swiotlb=131072
+        i915.nuclear_pageflip=1 swiotlb=131072 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>
@@ -200,6 +214,13 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -237,6 +258,13 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>3</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/generic_board/hybrid_rt.xml
+++ b/misc/config_tools/data/generic_board/hybrid_rt.xml
@@ -104,11 +104,11 @@
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -156,11 +156,25 @@
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="3">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>3</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -177,7 +191,7 @@
       <rootfs>/dev/nvme0n1p3</rootfs>
       <bootargs>
             rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-            i915.nuclear_pageflip=1 swiotlb=131072
+            i915.nuclear_pageflip=1 swiotlb=131072 8250.nr_uarts=20
             </bootargs>
     </board_private>
   </vm>
@@ -210,6 +224,13 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -248,6 +269,13 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>3</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/generic_board/shared.xml
+++ b/misc/config_tools/data/generic_board/shared.xml
@@ -86,11 +86,53 @@
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>2</target_vm_id>
-      <target_uart_id>1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="3">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>3</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="4">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>4</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="5">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>5</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="6">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>6</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="7">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>7</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -106,7 +148,7 @@
     <board_private>
       <rootfs>/dev/nvme0n1p3</rootfs>
       <bootargs>        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 swiotlb=131072
+        i915.nuclear_pageflip=1 swiotlb=131072 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>
@@ -133,11 +175,11 @@
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -174,10 +216,17 @@
     </legacy_vuart>
     <legacy_vuart id="1">
       <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
+      <base>INVALID_COM_BASE</base>
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -218,6 +267,13 @@
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>3</target_uart_id>
+    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -256,6 +312,13 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>4</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -296,6 +359,13 @@
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>5</target_uart_id>
+    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -335,6 +405,13 @@
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>6</target_uart_id>
+    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -370,6 +447,13 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>7</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid.xml
@@ -96,11 +96,11 @@
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -150,11 +150,25 @@
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="3">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>3</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -170,7 +184,7 @@
     <board_private>
       <rootfs>/dev/nvme0n1p3</rootfs>
       <bootargs>        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 swiotlb=131072
+        i915.nuclear_pageflip=1 swiotlb=131072 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>
@@ -200,6 +214,13 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -237,6 +258,13 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>3</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/nuc11tnbi5/shared.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared.xml
@@ -86,11 +86,53 @@
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>2</target_vm_id>
-      <target_uart_id>1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="3">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>3</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="4">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>4</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="5">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>5</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="6">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>6</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="7">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>7</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -106,7 +148,7 @@
     <board_private>
       <rootfs>/dev/nvme0n1p3</rootfs>
       <bootargs>        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 swiotlb=131072
+        i915.nuclear_pageflip=1 swiotlb=131072 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>
@@ -133,11 +175,11 @@
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -174,10 +216,17 @@
     </legacy_vuart>
     <legacy_vuart id="1">
       <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
+      <base>INVALID_COM_BASE</base>
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -218,6 +267,13 @@
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>3</target_uart_id>
+    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -256,6 +312,13 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>4</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -296,6 +359,13 @@
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>5</target_uart_id>
+    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -335,6 +405,13 @@
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>6</target_uart_id>
+    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -370,6 +447,13 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>7</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/qemu/sdc.xml
+++ b/misc/config_tools/data/qemu/sdc.xml
@@ -85,8 +85,8 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>INVALID_COM_BASE</base>
-        <irq>SERVICE_VM_COM2_IRQ</irq>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
@@ -105,7 +105,7 @@
         <rootfs>/dev/vda1</rootfs>
         <bootargs>
         earlyprintk=serial,ttyS0,115200n8 rw rootwait console=tty0 consoleblank=0 no_timer_check ignore_loglevel
-        ignore_loglevel no_timer_check intel_iommu=off tsc=reliable hvlog=2M@0x1FE00000
+        ignore_loglevel no_timer_check intel_iommu=off tsc=reliable hvlog=2M@0x1FE00000 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>
@@ -131,7 +131,7 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>INVALID_COM_BASE</base>
+        <base>COM2_BASE</base>
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -147,10 +147,17 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>SERVICE_VM_COM2_BASE</base>
-        <irq>SERVICE_VM_COM2_IRQ</irq>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -167,7 +174,7 @@
         <rootfs>/dev/sda3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1
+        i915.nuclear_pageflip=1 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>
@@ -197,6 +204,13 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
@@ -152,10 +152,24 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>SERVICE_VM_COM2_BASE</base>
-        <irq>SERVICE_VM_COM2_IRQ</irq>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="3">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>3</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -172,7 +186,7 @@
         <rootfs>/dev/nvme0n1p3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1
+        i915.nuclear_pageflip=1 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>
@@ -204,6 +218,13 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -241,6 +262,13 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>3</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/whl-ipc-i5/sdc.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc.xml
@@ -84,10 +84,17 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>INVALID_COM_BASE</base>
-        <irq>SERVICE_VM_COM2_IRQ</irq>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -104,7 +111,7 @@
         <rootfs>/dev/sda3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1
+        i915.nuclear_pageflip=1 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>
@@ -132,7 +139,7 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>INVALID_COM_BASE</base>
+        <base>COM2_BASE</base>
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
@@ -170,6 +177,13 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/whl-ipc-i5/shared.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared.xml
@@ -85,10 +85,52 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>SERVICE_VM_COM2_BASE</base>
-        <irq>SERVICE_VM_COM2_IRQ</irq>
-        <target_vm_id>2</target_vm_id>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="3">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>3</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="4">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>4</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="5">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>5</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="6">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>6</target_vm_id>
+        <target_uart_id>2</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="7">
+        <type>VUART_LEGACY_PIO</type>
+        <base>CONFIG_COM_BASE</base>
+        <irq>0</irq>
+        <target_vm_id>7</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -105,7 +147,7 @@
         <rootfs>/dev/sda3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1
+        i915.nuclear_pageflip=1 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>
@@ -133,7 +175,7 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>INVALID_COM_BASE</base>
+        <base>COM2_BASE</base>
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
@@ -171,10 +213,17 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
+        <base>INVALID_COM_BASE</base>
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -215,6 +264,13 @@
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>3</target_uart_id>
+    </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -253,6 +309,13 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>4</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -293,6 +356,13 @@
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>5</target_uart_id>
+    </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -332,6 +402,13 @@
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>6</target_uart_id>
+    </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -367,6 +444,13 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <legacy_vuart id="2">
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>7</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>


### PR DESCRIPTION
In this patch, add vuart configuration in scenario XML of
each board to support communication between service VM and
user VM since system shutdown feature need to send commands
through this vuart communication channel.

The follow changes are made in this patch:
- Add multi legacy vuart for service VM for communication
- Add one legacy vuart for user VM for communication
- Add 8250.nr_uarts parameter in command line of service OS

Tracked-On: #6652
Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>