### PR TITLE
config-tools: allow to configure guest flag for post-launched VM

### DIFF
--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -117,17 +117,15 @@
   </xsl:template>
 
   <xsl:template match="guest_flags">
-    <xsl:if test="not(acrn:is-post-launched-vm(../vm_type))">
-      <xsl:if test="guest_flag">
-        <xsl:choose>
-          <xsl:when test="guest_flag = '' or guest_flag = '0' or guest_flag = '0UL'">
-            <xsl:value-of select="acrn:initializer('guest_flags', '0UL')" />
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:value-of select="acrn:initializer('guest_flags', concat('(', acrn:string-join(guest_flag, '|', '', ''),')'))" />
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:if>
+    <xsl:if test="guest_flag">
+      <xsl:choose>
+        <xsl:when test="guest_flag = '' or guest_flag = '0' or guest_flag = '0UL'">
+          <xsl:value-of select="acrn:initializer('guest_flags', '0UL')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="acrn:initializer('guest_flags', concat('(', acrn:string-join(guest_flag, '|', '', ''),')'))" />
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:if>
   </xsl:template>
 


### PR DESCRIPTION
Remove the if statement that block guest flag configuration for
post-launched VM.

Tracked-On: #5917
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>