### PR TITLE
config_tools: remove hvlog parameter and update HV_RAM_START default address

### DIFF
--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -194,8 +194,7 @@
     <board_private>
         <rootfs>/dev/nvme0n1p3</rootfs>
         <bootargs>
-        rw rootwait console=ttyS0,115200n8 ignore_loglevel no_timer_check
-        hvlog=2M@0xe00000 memmap=0x200000$0xe00000 8250.nr_uarts=20
+        rw rootwait console=ttyS0,115200n8 ignore_loglevel no_timer_check 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>

--- a/misc/config_tools/data/cfl-k700-i7/shared.xml
+++ b/misc/config_tools/data/cfl-k700-i7/shared.xml
@@ -148,7 +148,7 @@
         <rootfs>/dev/nvme0n1p3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000 8250.nr_uarts=20
+        i915.nuclear_pageflip=1 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>

--- a/misc/config_tools/data/qemu/sdc.xml
+++ b/misc/config_tools/data/qemu/sdc.xml
@@ -105,7 +105,7 @@
         <rootfs>/dev/vda1</rootfs>
         <bootargs>
         earlyprintk=serial,ttyS0,115200n8 rw rootwait console=tty0 consoleblank=0 no_timer_check ignore_loglevel
-        ignore_loglevel no_timer_check intel_iommu=off tsc=reliable hvlog=2M@0x1FE00000 8250.nr_uarts=20
+        ignore_loglevel no_timer_check intel_iommu=off tsc=reliable 8250.nr_uarts=20
         </bootargs>
     </board_private>
   </vm>

--- a/misc/config_tools/hv_config/hv_item.py
+++ b/misc/config_tools/hv_config/hv_item.py
@@ -167,6 +167,7 @@ class Memory:
     def check_item(self):
         hv_cfg_lib.hv_size_check(self.stack_size, "MEMORY", "STACK_SIZE")
         hv_cfg_lib.hv_size_check(self.low_ram_size, "MEMORY", "LOW_RAM_SIZE")
+        hv_cfg_lib.hv_ram_start_check(self.hv_ram_start, "MEMORY", "HV_RAM_START")
         hv_cfg_lib.hv_size_check(self.platform_ram_size, "MEMORY", "PLATFORM_RAM_SIZE")
         hv_cfg_lib.ny_support_check(self.ivshmem_enable, "FEATURES", "IVSHMEM", "IVSHMEM_ENABLED")
 

--- a/misc/config_tools/library/hv_cfg_lib.py
+++ b/misc/config_tools/library/hv_cfg_lib.py
@@ -88,6 +88,18 @@ def hv_size_check(str_val, branch_tag, item):
     if not is_numeric_check(str_val, branch_tag, item):
         return
 
+def hv_ram_start_check(hv_ram_start, prime_item, item):
+
+    err_dic = {}
+    if '0x' not in hv_ram_start and '0X' not in hv_ram_start:
+        key = "hv,{},{}".format(prime_item, item)
+        ERR_LIST[key] = "Address should be Hex format"
+
+    to_mb = (int(hv_ram_start, 16) / (1024 * 1024))
+    is_aligned = to_mb % 2
+    if to_mb < 2 or is_aligned != 0:
+        key = "hv,{},{}".format(prime_item, item)
+        ERR_LIST[key] = "Address should be larger than or equal to 2MB and 2MB-aligned."
 
 def ir_entries_check(str_num, cap, cap_ir_entries):
     hv_size_check(str_num, cap, cap_ir_entries)

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -195,7 +195,7 @@ physical core. Each core uses one stack for normal operation and another
 three for specific exceptions.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="HV_RAM_START" type="HexFormat" default="0x00200000">
+    <xs:element name="HV_RAM_START" type="HexFormat" default="0x00400000">
       <xs:annotation>
         <xs:documentation>The 2MB-aligned starting physical address of
 the RAM region used by the hypervisor.</xs:documentation>


### PR DESCRIPTION
1. remove hvlog parameter in bootargs for all platforms.
2. update HV_RAM_START default address from 2MB to 4MB.
3. add the check that the HV_RAM_START value should be larger
than or equal to 2MB and 2MB aligned.

Tracked-On: #6663
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>