### PR TITLE
config_tools: always initialize hw_ignore when parsing DMAR

### DIFF
--- a/misc/config_tools/board_inspector/legacy/dmar.py
+++ b/misc/config_tools/board_inspector/legacy/dmar.py
@@ -244,8 +244,6 @@ def walk_pci_bus(tmp_pdf, dmar_tbl, dmar_hw_list, drhd_cnt):
     :param dmar_hw_list: it is a class to describe hardware scope in DMAR table
     :param drhd_cnt: it is a counter to calculate the DRHD in DMAR table
     """
-    # initialize DRHDx_IGNORE to false
-    dmar_hw_list.hw_ignore[drhd_cnt] = 'false'
     # path offset is in end of device spcope
     dmar_tbl.path_offset = dmar_tbl.dev_scope_offset + ctypes.sizeof(DmarDevScope)
     n_cnt = (dmar_tbl.dmar_dev_scope.scope_length - ctypes.sizeof(DmarDevScope)) // 2
@@ -331,10 +329,8 @@ def walk_dmar_table(dmar_tbl, dmar_hw_list, dmar_dev_list, sysnode):
             dmar_tbl.drhd_offset += dmar_len
             continue
 
-        # Skip remapping hardware units without any device under its scope
-        if dmar_tbl.dmar_drhd.flags == 0 and dmar_len == ctypes.sizeof(DmarHwUnit):
-            dmar_tbl.drhd_offset += dmar_len
-            continue
+        # initialize DRHDx_IGNORE to false
+        dmar_hw_list.hw_ignore[drhd_cnt] = 'false'
 
         dmar_hw_list.hw_segment_list.append(dmar_tbl.dmar_drhd.segment)
         dmar_hw_list.hw_flags_list.append(dmar_tbl.dmar_drhd.flags)


### PR DESCRIPTION
Commit 4a04fcc ("config_tools: skip remapping HW units with no devices under
scope") skips hardware remapping units without any device under its scope in the
config tools, which turns out to only work if the HV is not parsing the DMAR at
runtime.

This patch reverts the previous workaround and fixes the previous issue by
always initializing `dmar_hw_list.hw_ignore` when parsing DMAR. This ensures
that the DRHDx_IGNORE macro will always be emitted while DRHD_COUNT is not
impacted.

Fixes: 4a04fcc ("config_tools: skip remapping HW units with no devices under scope")
Tracked-On: #6709
Signed-off-by: Junjie Mao <junjie.mao@intel.com>