### PR TITLE
doc: correct range of values for the LOGLEVELs

### DIFF
--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -66,7 +66,7 @@
 
 <xs:simpleType name="LogLevelType">
   <xs:annotation>
-    <xs:documentation>An Integer from 0 to 7 representing log message
+    <xs:documentation>An Integer from 1 to 6 representing log message
 severity and intent:
 
 - 1 (LOG_FATAL) system is unusable


### PR DESCRIPTION
Fix the range of values possible for the LOGLEVEL parameters (MEM_LOGLEVEL,
NPK_LOGLEVEL and MEM_LOGLEVEL). The documentation indicates a integer from
0 to 7 but only values from 1 to 6 are decribed.

Tracked-On: #6734
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>