### PR TITLE
doc: tweak CSS for Sphinx/Breathe API documents

### DIFF
--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -150,6 +150,11 @@ th,td {
   padding-left: 0 !important;
 }
 
+/* dbk tweak spacing in breathe api */
+.rst-content dt > span.pre {
+    padding-right: 6px;
+}
+
 /* doxygenXX item color tweaks, light blue background with dark blue top border */
 .rst-content dl:not(.docutils) dl dt {
   background: #e7f2fa !important;


### PR DESCRIPTION
Words in the function prototypes looked run together making it hard to
read, so tweak the CSS to add a bit of padding.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>