### PR TITLE
misc: config_tools: generate serial configuration file

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -399,6 +399,9 @@ install: $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
 	@if [ -e "$(HV_OBJDIR)/acpi" ];then \
 		install -D $(HV_OBJDIR)/acpi/*.bin -t $(DESTDIR)$(libdir)/acrn/acpi/; \
 	fi
+	@if [ -e "$(HV_OBJDIR)/serial.conf" ];then \
+		install -D $(HV_OBJDIR)/serial.conf -t $(DESTDIR)$(libdir)/acrn/; \
+	fi
 
 install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
 	install -D $(HV_OBJDIR)/$(HV_FILE).out $(DESTDIR)$(libdir)/acrn/$(HV_FILE).$(BOARD).$(SCENARIO).out
@@ -411,6 +414,8 @@ pre_build: $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)
 	@$(HV_OBJDIR)/hv_prebuild_check.out
 	@echo "generate the binary of ACPI tables for pre-launched VMs ..."
 	python3 ../misc/config_tools/acpi_gen/bin_gen.py --board $(HV_OBJDIR)/.board.xml --scenario $(HV_OBJDIR)/.scenario.xml --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR)
+	@echo "generate the serial configuration file for service VM ..."
+	python3 ../misc/config_tools/service_vm_config/serial_config.py --allocation $(HV_OBJDIR)/configs/allocation.xml --scenario $(HV_OBJDIR)/.scenario.xml --out $(HV_OBJDIR)/serial.conf
 
 .PHONY: header
 header: $(VERSION) $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)

--- a/misc/config_tools/service_vm_config/README
+++ b/misc/config_tools/service_vm_config/README
@@ -1,0 +1,7 @@
+Please run serial_config.py to generate serial configuration file for service VM.
+
+usage: python3 serial_config.py [h] --allocation <allocation_info_file> --scenario <scenario_info_file> --out <output_file>
+positional arguments:
+  allocation_info_file  : name of the file summarizing resource allocated by config tool
+  scenario_info_file  : file name of the scenario info XML
+  output_file : file name of serial configuration

--- a/misc/config_tools/service_vm_config/serial_config.py
+++ b/misc/config_tools/service_vm_config/serial_config.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 Intel Corporation.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+import argparse
+import lxml.etree
+
+#vuart devices name is configured to start from /dev/ttyS8
+START_VUART_DEV_NAME_NO = 8
+VUART_DEV_NAME_NUM = 8
+stadard_uart_port = {'0x3F8', '0x2F8', '0x3E8', '0x2E8'}
+UART_IRQ_BAUD = " irq 0 uart 16550A baud_base 115200"
+
+def find_non_standard_uart(vm):
+    uart_list = []
+    for vuart in vm.iter(tag = 'legacy_vuart'):
+        base = vuart.find('base').text
+        if base not in stadard_uart_port:
+            uart_list.append(vuart)
+    return uart_list
+
+def main(args):
+    """
+    Generate serial configuration file for service VM
+    :param args: command line args
+    """
+    scenario_etree = lxml.etree.parse(args.scenario)
+    allocation_etree = lxml.etree.parse(args.allocation)
+    vuart_target_vmid = [0] * VUART_DEV_NAME_NUM
+
+    vm_list = scenario_etree.xpath("//vm[vm_type = 'SERVICE_VM']")
+    for vm in vm_list:
+        for legacy_vuart in vm.iter(tag = 'legacy_vuart'):
+            if legacy_vuart.find('target_vm_id') != None:
+                user_vm_id = legacy_vuart.find('target_vm_id').text
+                legacy_vuartid = int(legacy_vuart.attrib["id"])
+                vuart_target_vmid[legacy_vuartid] = user_vm_id
+
+    vm_list = allocation_etree.xpath("//vm[vm_type = 'SERVICE_VM']")
+    for vm in vm_list:
+        vuart_list = find_non_standard_uart(vm)
+        if len(vuart_list) != 0:
+            with open(args.out, "w+") as config_f:
+                for uart_start_num, vuart in enumerate(vuart_list, start=START_VUART_DEV_NAME_NO):
+                    base = " port " + vuart.find('base').text
+                    vuart_id = int(vuart.attrib["id"])
+                    vm_id_note = "# User_VM_id: " + str(vuart_target_vmid[vuart_id]) + '\n'
+                    config_f.write(vm_id_note)
+                    conf = "/dev/ttyS" + str(uart_start_num) + base + UART_IRQ_BAUD + '\n'
+                    config_f.write(conf)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--allocation", help="the XML file summarizing resource allocated by config tool")
+    parser.add_argument("--scenario", help="the XML file specifying the scenario to be set up")
+    parser.add_argument("--out", help="location of the output serial configuration file")
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
Generate serial configuration file for service VM according
to scenario file and vUART ports base address allocated by
config tool.
Currently, some non-standard serial ports are emulated in
hypervisor and will be used to do communication between service
VM and user VM, so need to generate serial configuration file
to configure these serial ports for service VM.

v1-->v2:
	Fix some type issues
	Refine script code format

Tracked-On: #6652

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>