### PR TITLE
config_tools: fix the duplicate PT_SLOT value issue

### DIFF
--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -149,6 +149,7 @@ def generate_script_file(names, pt_sel, virt_io, dm, sriov, vmid, config):
 
     print("{}".format(header_info), file=config)
     com.gen(names, pt_sel, virt_io, dm, sriov, vmid, config)
+    launch_cfg_lib.reset_pt_slot()
     if launch_cfg_lib.ERR_LIST:
         return launch_cfg_lib.ERR_LIST
 

--- a/misc/config_tools/library/launch_cfg_lib.py
+++ b/misc/config_tools/library/launch_cfg_lib.py
@@ -433,6 +433,19 @@ def get_slot(bdf_list, dev):
     return slot_list
 
 
+def reset_pt_slot():
+
+    global PT_SLOT
+
+    PT_SLOT = {
+        "hostbridge":0,
+        "lpc":1,
+        "pci-gvt":2,
+        "virtio-blk":3,
+        "igd-lpc":31,
+    }
+
+
 def get_pt_dev():
     """ Get passthrough device list """
     cap_pt = PASSTHRU_DEVS


### PR DESCRIPTION
When we add two or more virtio block devices and rename them for a VM
in launch xml files, then generate launch scripts through the UI.
After ensuring the devices names are different, we repeat these operations
continuously. Finally we will get the duplicate PT_SLOT value 30 for
different virtio block devices in a launch script. This is wrong.

As a workaround, we reassign PT_SLOT variate to reset it after the launch
script is generated every time.

Tracked-On: #6767
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>