### PR TITLE
config_tools: rename UOS to user vm in UI

### DIFF
--- a/misc/config_tools/config_app/templates/launch.html
+++ b/misc/config_tools/config_app/templates/launch.html
@@ -43,7 +43,7 @@ the launch scripts will be generated into misc/acrn-config/xmls/config-xmls/[boa
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title" id="addlaunchModalLabel">Configure UOS for Post-launched VM</h4>
+                <h4 class="modal-title" id="addlaunchModalLabel">Configure User VM for Post-launched VM</h4>
             </div>
             <div class="modal-body">
                 <div class="form-group row">
@@ -136,7 +136,7 @@ the launch scripts will be generated into misc/acrn-config/xmls/config-xmls/[boa
         <tr>
             <td>
                 <div class="form-group">
-                    <label class="col-sm-3 control-label">UOS: </label>
+                    <label class="col-sm-3 control-label">User VM: </label>
                     <label class="col-sm-1 control-label" id="vm">{{vm.attrib['id']}}</label>
                 </div>
                 <div class="form-group">
@@ -146,7 +146,7 @@ the launch scripts will be generated into misc/acrn-config/xmls/config-xmls/[boa
                 </div>
                 <div class="form-group">
                     <button type="button" class="col-sm-6 btn" id="add_launch_vm" data-id="{{vm.attrib['id']}}" data-toggle="modal"
-                            data-target="#add_launch_modal">Configure an UOS below</button>
+                            data-target="#add_launch_modal">Configure a User VM below</button>
                 </div>
                 <div class="form-group">
                     <button type="button" class="col-sm-6 btn" id="remove_launch_vm" data-id="{{vm.attrib['id']}}">
@@ -394,7 +394,7 @@ the launch scripts will be generated into misc/acrn-config/xmls/config-xmls/[boa
         {% endfor %}
         <tr><td>
             <button type="button" class="btn" id="add_launch_script" data-toggle="modal" data-id="-1"
-                            data-target="#add_launch_modal">Configure an UOS</button>
+                            data-target="#add_launch_modal">Configure a User VM</button>
         </td></tr>
     </table>
     {% else %}


### PR DESCRIPTION
Since PRs #6760 and #6765 have landed,
we also need to rename "UOS" to "user vm" in UI.

Tracked-On: #6744
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>