### PR TITLE
Revert "misc: config_tools: add vuart for communication"

### DIFF
--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -161,24 +161,10 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
+        <base>SERVICE_VM_COM2_BASE</base>
+        <irq>SERVICE_VM_COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>2</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="3">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>3</target_vm_id>
-        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -194,7 +180,7 @@
     <board_private>
         <rootfs>/dev/nvme0n1p3</rootfs>
         <bootargs>
-        rw rootwait console=ttyS0,115200n8 ignore_loglevel no_timer_check 8250.nr_uarts=20
+        rw rootwait console=ttyS0,115200n8 ignore_loglevel no_timer_check
         </bootargs>
     </board_private>
   </vm>
@@ -228,13 +214,6 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -274,13 +253,6 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>3</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/cfl-k700-i7/shared.xml
+++ b/misc/config_tools/data/cfl-k700-i7/shared.xml
@@ -86,52 +86,10 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
+        <base>SERVICE_VM_COM2_BASE</base>
+        <irq>SERVICE_VM_COM2_IRQ</irq>
         <target_vm_id>2</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="3">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>3</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="4">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>4</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="5">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>5</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="6">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>6</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="7">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>7</target_vm_id>
-        <target_uart_id>2</target_uart_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -148,7 +106,7 @@
         <rootfs>/dev/nvme0n1p3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 8250.nr_uarts=20
+        i915.nuclear_pageflip=1
         </bootargs>
     </board_private>
   </vm>
@@ -176,7 +134,7 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
+        <base>INVALID_COM_BASE</base>
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
@@ -214,17 +172,10 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>INVALID_COM_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
         <base>COM2_BASE</base>
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
-        <target_uart_id>2</target_uart_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -265,13 +216,6 @@
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>3</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -310,13 +254,6 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>4</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -357,13 +294,6 @@
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>5</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -403,13 +333,6 @@
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>6</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -445,13 +368,6 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>7</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/generic_board/hybrid.xml
+++ b/misc/config_tools/data/generic_board/hybrid.xml
@@ -96,11 +96,11 @@
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>1</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM2_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -150,25 +150,11 @@
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>2</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="3">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>3</target_vm_id>
-        <target_uart_id>2</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>SERVICE_VM_COM2_BASE</base>
+      <irq>SERVICE_VM_COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -184,7 +170,7 @@
     <board_private>
       <rootfs>/dev/nvme0n1p3</rootfs>
       <bootargs>        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 swiotlb=131072 8250.nr_uarts=20
+        i915.nuclear_pageflip=1 swiotlb=131072
         </bootargs>
     </board_private>
   </vm>
@@ -214,13 +200,6 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -258,13 +237,6 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>3</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/generic_board/hybrid_rt.xml
+++ b/misc/config_tools/data/generic_board/hybrid_rt.xml
@@ -104,11 +104,11 @@
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>1</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM2_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -156,25 +156,11 @@
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>2</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="3">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>3</target_vm_id>
-        <target_uart_id>2</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>SERVICE_VM_COM2_BASE</base>
+      <irq>SERVICE_VM_COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -191,7 +177,7 @@
       <rootfs>/dev/nvme0n1p3</rootfs>
       <bootargs>
             rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-            i915.nuclear_pageflip=1 swiotlb=131072 8250.nr_uarts=20
+            i915.nuclear_pageflip=1 swiotlb=131072
             </bootargs>
     </board_private>
   </vm>
@@ -224,13 +210,6 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -269,13 +248,6 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>3</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/generic_board/shared.xml
+++ b/misc/config_tools/data/generic_board/shared.xml
@@ -86,53 +86,11 @@
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>2</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="3">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>3</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="4">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>4</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="5">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>5</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="6">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>6</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="7">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>7</target_vm_id>
-        <target_uart_id>2</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>SERVICE_VM_COM2_BASE</base>
+      <irq>SERVICE_VM_COM2_IRQ</irq>
+      <target_vm_id>2</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -148,7 +106,7 @@
     <board_private>
       <rootfs>/dev/nvme0n1p3</rootfs>
       <bootargs>        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 swiotlb=131072 8250.nr_uarts=20
+        i915.nuclear_pageflip=1 swiotlb=131072
         </bootargs>
     </board_private>
   </vm>
@@ -175,11 +133,11 @@
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>1</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>INVALID_COM_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -216,17 +174,10 @@
     </legacy_vuart>
     <legacy_vuart id="1">
       <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
+      <base>COM2_BASE</base>
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -267,13 +218,6 @@
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>3</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -312,13 +256,6 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>4</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -359,13 +296,6 @@
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>5</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -405,13 +335,6 @@
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>6</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -447,13 +370,6 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>7</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid.xml
@@ -96,11 +96,11 @@
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>1</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM2_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -150,25 +150,11 @@
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>2</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="3">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>3</target_vm_id>
-        <target_uart_id>2</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>SERVICE_VM_COM2_BASE</base>
+      <irq>SERVICE_VM_COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -184,7 +170,7 @@
     <board_private>
       <rootfs>/dev/nvme0n1p3</rootfs>
       <bootargs>        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 swiotlb=131072 8250.nr_uarts=20
+        i915.nuclear_pageflip=1 swiotlb=131072
         </bootargs>
     </board_private>
   </vm>
@@ -214,13 +200,6 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -258,13 +237,6 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>3</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/nuc11tnbi5/shared.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared.xml
@@ -86,53 +86,11 @@
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>2</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="3">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>3</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="4">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>4</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="5">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>5</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="6">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>6</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="7">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>7</target_vm_id>
-        <target_uart_id>2</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>SERVICE_VM_COM2_BASE</base>
+      <irq>SERVICE_VM_COM2_IRQ</irq>
+      <target_vm_id>2</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -148,7 +106,7 @@
     <board_private>
       <rootfs>/dev/nvme0n1p3</rootfs>
       <bootargs>        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 swiotlb=131072 8250.nr_uarts=20
+        i915.nuclear_pageflip=1 swiotlb=131072
         </bootargs>
     </board_private>
   </vm>
@@ -175,11 +133,11 @@
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>1</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>INVALID_COM_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -216,17 +174,10 @@
     </legacy_vuart>
     <legacy_vuart id="1">
       <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
+      <base>COM2_BASE</base>
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -267,13 +218,6 @@
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>3</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -312,13 +256,6 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>4</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
@@ -359,13 +296,6 @@
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>5</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -405,13 +335,6 @@
       <target_vm_id>0</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>6</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -447,13 +370,6 @@
       <irq>COM2_IRQ</irq>
       <target_vm_id>0</target_vm_id>
       <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>7</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/qemu/sdc.xml
+++ b/misc/config_tools/data/qemu/sdc.xml
@@ -85,8 +85,8 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
+        <base>INVALID_COM_BASE</base>
+        <irq>SERVICE_VM_COM2_IRQ</irq>
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
@@ -105,7 +105,7 @@
         <rootfs>/dev/vda1</rootfs>
         <bootargs>
         earlyprintk=serial,ttyS0,115200n8 rw rootwait console=tty0 consoleblank=0 no_timer_check ignore_loglevel
-        ignore_loglevel no_timer_check intel_iommu=off tsc=reliable 8250.nr_uarts=20
+        ignore_loglevel no_timer_check intel_iommu=off tsc=reliable
         </bootargs>
     </board_private>
   </vm>
@@ -131,7 +131,7 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
+        <base>INVALID_COM_BASE</base>
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -147,17 +147,10 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
+        <base>SERVICE_VM_COM2_BASE</base>
+        <irq>SERVICE_VM_COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>2</target_vm_id>
-        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -174,7 +167,7 @@
         <rootfs>/dev/sda3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 8250.nr_uarts=20
+        i915.nuclear_pageflip=1
         </bootargs>
     </board_private>
   </vm>
@@ -204,13 +197,6 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
@@ -152,24 +152,10 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
+        <base>SERVICE_VM_COM2_BASE</base>
+        <irq>SERVICE_VM_COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>2</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="3">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>3</target_vm_id>
-        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -186,7 +172,7 @@
         <rootfs>/dev/nvme0n1p3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 8250.nr_uarts=20
+        i915.nuclear_pageflip=1
         </bootargs>
     </board_private>
   </vm>
@@ -218,13 +204,6 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -262,13 +241,6 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>3</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/whl-ipc-i5/sdc.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc.xml
@@ -84,17 +84,10 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
+        <base>INVALID_COM_BASE</base>
+        <irq>SERVICE_VM_COM2_IRQ</irq>
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>2</target_vm_id>
-        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -111,7 +104,7 @@
         <rootfs>/dev/sda3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 8250.nr_uarts=20
+        i915.nuclear_pageflip=1
         </bootargs>
     </board_private>
   </vm>
@@ -139,7 +132,7 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
+        <base>INVALID_COM_BASE</base>
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
@@ -177,13 +170,6 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>2</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>

--- a/misc/config_tools/data/whl-ipc-i5/shared.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared.xml
@@ -85,52 +85,10 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
+        <base>SERVICE_VM_COM2_BASE</base>
+        <irq>SERVICE_VM_COM2_IRQ</irq>
         <target_vm_id>2</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="3">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>3</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="4">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>4</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="5">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>5</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="6">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>6</target_vm_id>
-        <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="7">
-        <type>VUART_LEGACY_PIO</type>
-        <base>CONFIG_COM_BASE</base>
-        <irq>0</irq>
-        <target_vm_id>7</target_vm_id>
-        <target_uart_id>2</target_uart_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -147,7 +105,7 @@
         <rootfs>/dev/sda3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 8250.nr_uarts=20
+        i915.nuclear_pageflip=1
         </bootargs>
     </board_private>
   </vm>
@@ -175,7 +133,7 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
+        <base>INVALID_COM_BASE</base>
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
@@ -213,17 +171,10 @@
     </legacy_vuart>
     <legacy_vuart id="1">
         <type>VUART_LEGACY_PIO</type>
-        <base>INVALID_COM_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
         <base>COM2_BASE</base>
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
-        <target_uart_id>2</target_uart_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -264,13 +215,6 @@
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>3</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -309,13 +253,6 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>4</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
@@ -356,13 +293,6 @@
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>5</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -402,13 +332,6 @@
         <target_vm_id>0</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>6</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>
     </console_vuart>
@@ -444,13 +367,6 @@
         <irq>COM2_IRQ</irq>
         <target_vm_id>0</target_vm_id>
         <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>7</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
         <base>INVALID_PCI_BASE</base>


### PR DESCRIPTION
This reverts commit 9e2edd5192d217c8a3eff704d728ae2b9d0085c1.
Because config UI doesn't support multi legacy vuart in current logic,
we need to revert the commit to unblock UI.

Tracked-On: #6652
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>