### PR TITLE
doc: update last updated information on page footers

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -62,6 +62,9 @@ html: content doxy
 	$(Q)./scripts/show-versions.py
 	$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html -d $(BUILDDIR)/doctrees $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(OPTS) >> $(BUILDDIR)/doc.log 2>&1
 	$(Q)./scripts/filter-doc-log.sh $(BUILDDIR)/doc.log
+ifeq ($(BUILDDIR),_build)
+	$(Q)./scripts/fix-git-modified-date.sh
+endif
 
 singlehtml: content doxy
 	$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b singlehtml -d $(BUILDDIR)/doctrees $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(OPTS) >> $(BUILDDIR)/doc.log 2>&1

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,14 +3,10 @@
 Project ACRN Documentation
 ##########################
 
-Welcome to the Project ACRN (version |version|) documentation.  ACRN is
-a flexible, lightweight reference hypervisor, built with real-time and
-safety-criticality in mind, optimized to streamline embedded development
-through an open source platform.
-
-.. comment Add back this note if we need to redirect users to a more stable
-   release.
-   The latest version of ACRN is currently under construction. If necessary, visit ACRN `version 1.5 <https://projectacrn.github.io/1.5/>`_ to view the last stable build.
+Welcome to the Project ACRN (version |version|) documentation published |today|.
+ACRN is a flexible, lightweight reference hypervisor, built with real-time and
+safety-criticality in mind, optimized to streamline embedded development through
+an open source platform.
 
 .. comment The links in this grid display can't use :ref: because we're
    using raw html.  There's a risk of broken links if referenced content is

--- a/doc/scripts/fix-git-modified-date.sh
+++ b/doc/scripts/fix-git-modified-date.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright (C) 2021 Intel Corporation.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Run this script in the _build/html folder after generating the HTML content.
+#
+# Scan through HTML files look for the corresponding .rst file (in doc or misc
+# for ACRN project). Replace the "Last updated" date in the footer with the last
+# commit date for the corresponding .rst file (if we can find it).  Tweak
+# wording to mention Last modified and published dates.
+
+cd _build/html
+
+find -type f -name "*.html" | \
+    while read filename;
+       do
+           f=${filename%.*}.rst
+           [[ -f "../../$f" ]] && prefix="../.."
+           [[ -f "../../../$f" ]] && prefix="../../.."
+           d="$(git log -1 --format="%ad" --date=format:"%b %d, %Y" -- "$prefix/$f")";
+           [[ ! -z "$d" ]] && sed -i "s/\(^ *<span class=\"lastupdated\">\)Last updated on \(.*\)\.$/\1Last modified: $d. Published: \2./" $filename;
+       done

--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -327,3 +327,8 @@ a.reference.external::after {
 img.drop-shadow {
    margin-bottom: 2em !important;
 }
+
+/* tweak last updated section of footer to be right-aligned */
+.lastupdated {
+    float:right;
+}


### PR DESCRIPTION
The "Last Updated" footer shows the date the page was published, not
when the content was last updated. This has caused readers some
confusion.  Update the footer with the date of the git commit that last
updated the document, and clarify with both the last modified and
published dates in the footer, something like this:

   Last modified: Aug 19, 2021. Published: Nov 03, 2021.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>