### PR TITLE
Accumulated fix to coding guideline violations

### DIFF
--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -37,12 +37,12 @@ static uint8_t get_secondary_bus(uint8_t bus, uint8_t dev, uint8_t func)
 	return (data >> 8U) & 0xffU;
 }
 
-static union pci_bdf dmar_path_bdf(int32_t path_len, int32_t busno, const struct acpi_dmar_pci_path *path)
+static union pci_bdf dmar_path_bdf(int32_t path_len, uint8_t busno, const struct acpi_dmar_pci_path *path)
 {
 	int32_t i;
 	union pci_bdf dmar_bdf;
 
-	dmar_bdf.bits.b = (uint8_t)busno;
+	dmar_bdf.bits.b = busno;
 	dmar_bdf.bits.d = path->device;
 	dmar_bdf.bits.f = path->function;
 

--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -29,8 +29,8 @@ static uint8_t get_secondary_bus(uint8_t bus, uint8_t dev, uint8_t func)
 {
 	uint32_t data;
 
-	pio_write32(PCI_CFG_ENABLE | (bus << 16U) | (dev << 11U) |
-		(func << 8U) | 0x18U, PCI_CONFIG_ADDR);
+	pio_write32(PCI_CFG_ENABLE | ((uint32_t)bus << 16U) | ((uint32_t)dev << 11U) |
+		((uint32_t)func << 8U) | 0x18U, PCI_CONFIG_ADDR);
 
 	data = pio_read32(PCI_CONFIG_DATA);
 
@@ -134,8 +134,8 @@ static int32_t handle_one_drhd(struct acpi_dmar_hardware_unit *acpi_drhd, struct
 
 		/* Disable GPU IOMMU due to gvt-d hasn’t been enabled on APL yet. */
 		if (is_apl_platform()) {
-			if (((drhd->segment << 16U) |
-		     	     (dev_scope->bus << 8U) |
+			if ((((uint32_t)drhd->segment << 16U) |
+		     	     ((uint32_t)dev_scope->bus << 8U) |
 		     	     dev_scope->devfun) == CONFIG_GPU_SBDF) {
 				drhd->ignore = true;
 			}

--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -93,8 +93,9 @@ static uint32_t get_drhd_dev_scope_cnt(struct acpi_dmar_hardware_unit *drhd)
 	while (start < end) {
 		scope = (struct acpi_dmar_device_scope *)start;
 		if ((scope->entry_type != ACPI_DMAR_SCOPE_TYPE_NOT_USED) &&
-			(scope->entry_type < ACPI_DMAR_SCOPE_TYPE_RESERVED))
+			(scope->entry_type < ACPI_DMAR_SCOPE_TYPE_RESERVED)) {
 			count++;
+		}
 		start += scope->length;
 	}
 	return count;
@@ -140,8 +141,9 @@ static int32_t handle_one_drhd(struct acpi_dmar_hardware_unit *acpi_drhd, struct
 			}
 		}
 
-		if (consumed <= 0)
+		if (consumed <= 0) {
 			break;
+		}
 
 		remaining -= consumed;
 		/* skip IOAPIC & HPET */

--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -65,9 +65,8 @@ static int32_t handle_dmar_devscope(struct dmar_dev_scope *dev_scope, void *addr
 	if ((remaining >= (int32_t)sizeof(struct acpi_dmar_device_scope)) &&
 	    (remaining >= (int32_t)apci_devscope->length)) {
 		path = (struct acpi_dmar_pci_path *)(apci_devscope + 1);
-		path_len = (apci_devscope->length -
-			    sizeof(struct acpi_dmar_device_scope)) /
-			sizeof(struct acpi_dmar_pci_path);
+		path_len = (int32_t)((apci_devscope->length - sizeof(struct acpi_dmar_device_scope)) /
+				sizeof(struct acpi_dmar_pci_path));
 
 		dmar_bdf = dmar_path_bdf(path_len, apci_devscope->bus, path);
 		dev_scope->id = apci_devscope->enumeration_id;
@@ -122,8 +121,7 @@ static int32_t handle_one_drhd(struct acpi_dmar_hardware_unit *acpi_drhd, struct
 
 	drhd->dev_cnt = dev_count;
 
-	remaining = acpi_drhd->header.length -
-			sizeof(struct acpi_dmar_hardware_unit);
+	remaining = (int32_t)(acpi_drhd->header.length - sizeof(struct acpi_dmar_hardware_unit));
 
 	dev_scope = drhd->devices;
 

--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -16,7 +16,7 @@ static bool is_allocated_to_prelaunched_vm(struct pci_pdev *pdev)
 {
 	bool found = false;
 	uint16_t vmid;
-	uint32_t pci_idx;
+	uint16_t pci_idx;
 	struct acrn_vm_config *vm_config;
 	struct acrn_vm_pci_dev_config *dev_config;
 

--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -189,7 +189,7 @@ bool is_ac_enabled(void)
 {
 	bool ac_enabled = false;
 
-	if (has_core_cap(CORE_CAP_SPLIT_LOCK) && (msr_read(MSR_TEST_CTL) & MSR_TEST_CTL_AC_SPLITLOCK)) {
+	if (has_core_cap(CORE_CAP_SPLIT_LOCK) && ((msr_read(MSR_TEST_CTL) & MSR_TEST_CTL_AC_SPLITLOCK) != 0UL)) {
 		ac_enabled = true;
 	}
 
@@ -200,7 +200,7 @@ bool is_gp_enabled(void)
 {
 	bool gp_enabled = false;
 
-	if (has_core_cap(CORE_CAP_UC_LOCK) && (msr_read(MSR_TEST_CTL) & MSR_TEST_CTL_GP_UCLOCK)) {
+	if (has_core_cap(CORE_CAP_UC_LOCK) && ((msr_read(MSR_TEST_CTL) & MSR_TEST_CTL_GP_UCLOCK) != 0UL)) {
 		gp_enabled = true;
 	}
 

--- a/hypervisor/arch/x86/cpu_state_tbl.c
+++ b/hypervisor/arch/x86/cpu_state_tbl.c
@@ -133,7 +133,7 @@ static struct cpu_state_info cpu_pm_state_info;
 static int32_t get_state_tbl_idx(const char *cpuname)
 {
 	int32_t i;
-	int32_t count = ARRAY_SIZE(cpu_state_tbl);
+	int32_t count = (int32_t)ARRAY_SIZE(cpu_state_tbl);
 	int32_t ret = -1;
 
 	if (cpuname != NULL) {

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -833,7 +833,7 @@ void ptirq_remove_msix_remapping(const struct acrn_vm *vm, uint16_t phys_bdf,
 void ptirq_remove_configured_intx_remappings(const struct acrn_vm *vm)
 {
 	const struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
-	uint32_t i;
+	uint16_t i;
 
 	for (i = 0; i < vm_config->pt_intx_num; i++) {
 		ptirq_remove_intx_remapping(vm, vm_config->pt_intx[i].virt_gsi, false);

--- a/hypervisor/arch/x86/guest/guest_memory.c
+++ b/hypervisor/arch/x86/guest/guest_memory.c
@@ -207,7 +207,7 @@ static int32_t local_gva2gpa_pae(struct acrn_vcpu *vcpu, struct page_walk_info *
 	addr = get_pae_pdpt_addr(pw_info->top_entry);
 	base = (uint64_t *)gpa2hva(vcpu->vm, addr);
 	if (base != NULL) {
-		index = (gva >> 30U) & 0x3UL;
+		index = (uint32_t)gva >> 30U;
 		stac();
 		entry = base[index];
 		clac();

--- a/hypervisor/arch/x86/guest/guest_memory.c
+++ b/hypervisor/arch/x86/guest/guest_memory.c
@@ -198,7 +198,7 @@ static int32_t local_gva2gpa_common(struct acrn_vcpu *vcpu, const struct page_wa
 static int32_t local_gva2gpa_pae(struct acrn_vcpu *vcpu, struct page_walk_info *pw_info,
 	uint64_t gva, uint64_t *gpa, uint32_t *err_code)
 {
-	int32_t index;
+	uint32_t index;
 	uint64_t *base;
 	uint64_t entry;
 	uint64_t addr;

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -1333,7 +1333,7 @@ static int32_t emulate_and(struct acrn_vcpu *vcpu, const struct instr_emul_vie *
 		 * perform the operation with the pre-fetched immediate
 		 * operand and write the result
 		 */
-		result = val1 & vie->immediate;
+		result = val1 & (uint64_t)vie->immediate;
 		vie_mmio_write(vcpu, result);
 		break;
 	default:

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -266,7 +266,7 @@ static inline uint32_t seg_desc_type(uint32_t access)
 	return (access & 0x001fU);
 }
 
-static inline bool seg_desc_present(uint32_t access)
+__unused static inline bool seg_desc_present(uint32_t access)
 {
 	return ((access & 0x0080U) != 0U);
 }
@@ -276,7 +276,7 @@ static inline bool seg_desc_def32(uint32_t access)
 	return ((access & 0x4000U) != 0U);
 }
 
-static inline bool seg_desc_unusable(uint32_t access)
+__unused static inline bool seg_desc_unusable(uint32_t access)
 {
 	return ((access & 0x10000U) != 0U);
 }
@@ -439,7 +439,7 @@ static uint32_t get_vmcs_field(enum cpu_reg_name ident)
 static uint64_t vm_get_register(const struct acrn_vcpu *vcpu, enum cpu_reg_name reg)
 {
 	uint64_t reg_val = 0UL;
-	
+
 	if ((reg >= CPU_REG_GENERAL_FIRST) && (reg <= CPU_REG_GENERAL_LAST)) {
 		reg_val = vcpu_get_gpreg(vcpu, reg);
 	} else if ((reg >= CPU_REG_NONGENERAL_FIRST) &&
@@ -2470,4 +2470,3 @@ bool is_current_opcode_xchg(struct acrn_vcpu *vcpu)
 {
 	return (vcpu->inst_ctxt.vie.op.op_type == VIE_OP_TYPE_XCHG);
 }
-

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -290,7 +290,7 @@ static bool rt_vm_pm1a_io_write(struct acrn_vcpu *vcpu, uint16_t addr, size_t wi
 	if (width != 2U) {
 		pr_dbg("Invalid address (0x%x) or width (0x%x)", addr, width);
 	} else {
-		if ((((v & VIRTUAL_PM1A_SLP_EN) != 0U) && (((v & VIRTUAL_PM1A_SLP_TYP) >> 10U) == 5U)) != 0U) {
+		if (((v & VIRTUAL_PM1A_SLP_EN) != 0U) && (((v & VIRTUAL_PM1A_SLP_TYP) >> 10U) == 5U)) {
 			poweroff_if_rt_vm(vcpu->vm);
 		}
 	}

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -342,7 +342,7 @@ static bool prelaunched_vm_sleep_io_write(struct acrn_vcpu *vcpu, uint16_t addr,
 		 * SLP_TYPx fields programmed with the values from the \_S5 object
 		 */
 		slp_type = (v >> 2U) & 0x7U;
-		slp_en  = (v >> 5U) & 0x1U;
+		slp_en  = ((v >> 5U) & 0x1U) != 0U;
 
 		if (slp_en && (slp_type == 5U)) {
 			get_vm_lock(vm);

--- a/hypervisor/arch/x86/guest/ve820.c
+++ b/hypervisor/arch/x86/guest/ve820.c
@@ -37,7 +37,7 @@ uint64_t find_space_from_ve820(struct acrn_vm *vm, uint32_t size, uint64_t min_a
 		end = round_page_down(entry->baseaddr + entry->length);
 		length = (end > start) ? (end - start) : 0UL;
 
-		if ((entry->type == E820_TYPE_RAM) && (length >= round_size)
+		if ((entry->type == E820_TYPE_RAM) && (length >= (uint64_t)round_size)
 				&& (end > round_min_addr) && (start < round_max_addr)) {
 			if (((start >= min_addr) && ((start + round_size) <= min(end, round_max_addr)))
 				|| ((start < min_addr) && ((min_addr + round_size) <= min(end, round_max_addr)))) {
@@ -137,7 +137,8 @@ static void filter_mem_from_service_vm_e820(struct acrn_vm *vm, uint64_t start_p
  */
 void create_service_vm_e820(struct acrn_vm *vm)
 {
-	uint16_t vm_id, i;
+	uint16_t vm_id;
+	uint32_t i;
 	uint64_t hv_start_pa = hva2hpa((void *)(get_hv_image_base()));
 	uint64_t hv_end_pa  = hv_start_pa + get_hv_ram_size();
 	uint32_t entries_count = get_e820_entries_count();

--- a/hypervisor/arch/x86/guest/ve820.c
+++ b/hypervisor/arch/x86/guest/ve820.c
@@ -169,7 +169,7 @@ void create_service_vm_e820(struct acrn_vm *vm)
 
 	for (i = 0U; i < vm->e820_entry_num; i++) {
 		struct e820_entry *entry = &service_vm_e820[i];
-		if ((entry->type == E820_TYPE_RAM)) {
+		if (entry->type == E820_TYPE_RAM) {
 			service_vm_config->memory.size += entry->length;
 		}
 	}

--- a/hypervisor/arch/x86/guest/ve820.c
+++ b/hypervisor/arch/x86/guest/ve820.c
@@ -292,7 +292,7 @@ void create_prelaunched_vm_e820(struct acrn_vm *vm)
 		hpa1_hi_size = vm_config->memory.size - lowmem_max_length;
 		gpa_start = add_ram_entry((vm->e820_entries + entry_idx), gpa_start, hpa1_hi_size);
 		entry_idx++;
-	} else if (vm_config->memory.size <= MEM_1M + hpa1_part1_max_length + MEM_1M) {
+	} else if (vm_config->memory.size <= (MEM_1M + hpa1_part1_max_length + MEM_1M)) {
 		/*
 		 * In this case, hpa1 is only enough for the first
 		 * 1M + part1 + last 1M (ACPI NVS/DATA), so part2 will be empty.
@@ -310,7 +310,7 @@ void create_prelaunched_vm_e820(struct acrn_vm *vm)
 	hpa2_lo_size = (lowmem_max_length - vm_config->memory.size);
 	gpa_start = vm->e820_entries[ENTRY_HPA1_LOW_PART2].baseaddr + vm->e820_entries[ENTRY_HPA1_LOW_PART2].length;
 
-	if (hpa2_lo_size > 0 && remaining_hpa2_size > 0) {
+	if ((hpa2_lo_size > 0) && (remaining_hpa2_size > 0)) {
 		/* In this case, hpa2 may have some parts to be mapped to lowmem, so we add an entry for hpa2_lo */
 		if (remaining_hpa2_size > hpa2_lo_size) {
 			remaining_hpa2_size -= hpa2_lo_size;

--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -74,7 +74,7 @@ static uint64_t	cr4_trap_and_passthru_mask = CR4_TRAP_AND_PASSTHRU_BITS; /* boun
 #define CR4_EMRSV_BITS_PHYS_VALUE	CR4_VMXE
 
 /* The CR4 value guest expected to see for bits of CR4_EMULATED_RESERVE_BITS */
-#define CR4_EMRSV_BITS_VIRT_VALUE	0
+#define CR4_EMRSV_BITS_VIRT_VALUE	0UL
 static uint64_t cr4_rsv_bits_guest_value;
 
 /*

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -223,7 +223,7 @@ vlapic_timer_divisor_shift(uint32_t dcr)
 	return ((val + 1U) & 0x7U);
 }
 
-static inline bool
+__unused static inline bool
 vlapic_lvtt_oneshot(const struct acrn_vlapic *vlapic)
 {
 	return (((vlapic->apic_page.lvt[APIC_LVT_TIMER].v) & APIC_LVTT_TM)

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -671,8 +671,8 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 	}
 
 	if (status == 0) {
-		uint32_t i;
-		for (i = 0; i < vm_config->pt_intx_num; i++) {
+		uint16_t i;
+		for (i = 0U; i < vm_config->pt_intx_num; i++) {
 			status = ptirq_add_intx_remapping(vm, vm_config->pt_intx[i].virt_gsi,
 								vm_config->pt_intx[i].phys_gsi, false);
 			if (status != 0) {

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -321,9 +321,9 @@ static void prepare_prelaunched_vm_memmap(struct acrn_vm *vm, const struct acrn_
 
 static void deny_pci_bar_access(struct acrn_vm *service_vm, const struct pci_pdev *pdev)
 {
-	uint32_t idx, mask;
+	uint32_t idx;
 	struct pci_vbar vbar = {};
-	uint64_t base = 0UL, size = 0UL;
+	uint64_t base = 0UL, size = 0UL, mask;
 	uint64_t *pml4_page;
 
 	pml4_page = (uint64_t *)service_vm->arch_vm.nworld_eptp;

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -396,7 +396,7 @@ static int32_t xsetbv_vmexit_handler(struct acrn_vcpu *vcpu)
 	uint32_t cpl;
 	uint64_t val64;
 
-	if (vcpu->arch.xsave_enabled && ((vcpu_get_cr4(vcpu) && CR4_OSXSAVE) != 0UL)) {
+	if (vcpu->arch.xsave_enabled && ((vcpu_get_cr4(vcpu) & CR4_OSXSAVE) != 0UL)) {
 		idx = vcpu->arch.cur_context;
 		/* get current privilege level */
 		cpl = exec_vmread32(VMX_GUEST_CS_ATTR);

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -291,7 +291,7 @@ static void enable_msr_interception(uint8_t *bitmap, uint32_t msr_arg, uint32_t 
 		}
 
 		msr &= 0x1FFFU;
-		msr_bit = 1U << (msr & 0x7U);
+		msr_bit = (uint8_t)(1U << (msr & 0x7U));
 		msr_index = msr >> 3U;
 
 		if ((mode & INTERCEPT_READ) == INTERCEPT_READ) {

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -871,6 +871,7 @@ static void set_guest_ia32_misc_enalbe(struct acrn_vcpu *vcpu, uint64_t v)
 {
 	uint32_t eax, ebx = 0U, ecx = 0U, edx = 0U;
 	bool update_vmsr = true;
+	uint64_t effective_guest_msr = v;
 
 	/* According to SDM Vol4 2.1 & Vol 3A 4.1.4,
 	 * EFER.NXE should be cleared if guest disable XD in IA32_MISC_ENABLE
@@ -895,14 +896,14 @@ static void set_guest_ia32_misc_enalbe(struct acrn_vcpu *vcpu, uint64_t v)
 			update_vmsr = false;
 		} else if (vcpu->vm->arch_vm.vm_mwait_cap) {
 			/* guest cpuid.01H will be updated when guest executes 'cpuid' with leaf 01H */
-			v &= ~MSR_IA32_MISC_ENABLE_MONITOR_ENA;
+			effective_guest_msr &= ~MSR_IA32_MISC_ENABLE_MONITOR_ENA;
 		} else {
 			update_vmsr = false;
 		}
 	}
 
 	if (update_vmsr) {
-		vcpu_set_guest_msr(vcpu, MSR_IA32_MISC_ENABLE, v);
+		vcpu_set_guest_msr(vcpu, MSR_IA32_MISC_ENABLE, effective_guest_msr);
 	}
 }
 

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -275,8 +275,8 @@ static inline void fixup_idt(const struct host_idt_descriptor *idtd)
 		entry_hi_32 = idt_desc[i].rsvd;
 		idt_desc[i].rsvd = 0U;
 		idt_desc[i].offset_63_32 = entry_hi_32;
-		idt_desc[i].high32.bits.offset_31_16 = entry_lo_32 >> 16U;
-		idt_desc[i].low32.bits.offset_15_0 = entry_lo_32 & 0xffffUL;
+		idt_desc[i].high32.bits.offset_31_16 = (uint16_t)(entry_lo_32 >> 16U);
+		idt_desc[i].low32.bits.offset_15_0 = (uint16_t)entry_lo_32;
 	}
 }
 

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -108,7 +108,7 @@ static void free_irq_vector(uint32_t irq)
 			vr = irqd->vector;
 			irqd->vector = VECTOR_INVALID;
 
-			if (vr <= NR_MAX_VECTOR && vector_to_irq[vr] == irq) {
+			if ((vr <= NR_MAX_VECTOR) && (vector_to_irq[vr] == irq)) {
 				vector_to_irq[vr] = IRQ_INVALID;
 			}
 		}

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -40,7 +40,7 @@
 #include <logmsg.h>
 #include <misc_cfg.h>
 
-static uint32_t hv_ram_size;
+static uint64_t hv_ram_size;
 static void *ppt_mmu_pml4_addr;
 static uint8_t sanitized_page[PAGE_SIZE] __aligned(PAGE_SIZE);
 
@@ -152,7 +152,7 @@ void invept(const void *eptp)
 	}
 }
 
-uint32_t get_hv_ram_size(void)
+uint64_t get_hv_ram_size(void)
 {
 	return hv_ram_size;
 }
@@ -255,7 +255,7 @@ void init_paging(void)
 	const struct abi_mmap *p_mmap = abi->mmap_entry;
 
 	pr_dbg("HV MMU Initialization");
-	hv_ram_size = (uint32_t)(uint64_t)&ld_ram_size;
+	hv_ram_size = (uint64_t)&ld_ram_size;
 
 	init_sanitized_page((uint64_t *)sanitized_page, hva2hpa_early(sanitized_page));
 

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -16,7 +16,7 @@ struct page *alloc_page(struct page_pool *pool)
 
 	spinlock_obtain(&pool->lock);
 	for (loop_idx = pool->last_hint_id;
-		loop_idx < pool->last_hint_id + pool->bitmap_size; loop_idx++) {
+		loop_idx < (pool->last_hint_id + pool->bitmap_size); loop_idx++) {
 		idx = loop_idx % pool->bitmap_size;
 		if (*(pool->bitmap + idx) != ~0UL) {
 			bit = ffz64(*(pool->bitmap + idx));

--- a/hypervisor/arch/x86/trampoline.c
+++ b/hypervisor/arch/x86/trampoline.c
@@ -63,7 +63,7 @@ static void update_trampoline_code_refs(uint64_t dest_pa)
 {
 	void *ptr;
 	uint64_t val;
-	int32_t i;
+	uint32_t i;
 
 	/*
 	 * calculate the fixup CS:IP according to fixup target address
@@ -88,7 +88,7 @@ static void update_trampoline_code_refs(uint64_t dest_pa)
 	*(uint64_t *)(ptr) += dest_pa;
 
 	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_pdpt_addr));
-	for (i = 0; i < 4; i++) {
+	for (i = 0U; i < 4U; i++) {
 		*(uint64_t *)(ptr + sizeof(uint64_t) * i) += dest_pa;
 	}
 

--- a/hypervisor/arch/x86/tsc_deadline_timer.c
+++ b/hypervisor/arch/x86/tsc_deadline_timer.c
@@ -30,7 +30,7 @@ void init_hw_timer(void)
 	int32_t retval = 0;
 
 	if (get_pcpu_id() == BSP_CPU_ID) {
-		retval = request_irq(TIMER_IRQ, (irq_action_t)timer_expired_handler, NULL, IRQF_NONE);
+		retval = request_irq(TIMER_IRQ, timer_expired_handler, NULL, IRQF_NONE);
 		if (retval < 0) {
 			pr_err("Timer setup failed");
 		}

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -500,7 +500,7 @@ static struct dmar_drhd_rt *ioapic_to_dmaru(uint16_t ioapic_id, union pci_bdf *s
 		dmar_unit = &dmar_drhd_units[j];
 		for (i = 0U; i < dmar_unit->drhd->dev_cnt; i++) {
 			if ((dmar_unit->drhd->devices[i].type == ACPI_DMAR_SCOPE_TYPE_IOAPIC) &&
-					(dmar_unit->drhd->devices[i].id == ioapic_id)) {
+					((uint16_t)dmar_unit->drhd->devices[i].id == ioapic_id)) {
 				sid->fields.devfun = dmar_unit->drhd->devices[i].devfun;
 				sid->fields.bus = dmar_unit->drhd->devices[i].bus;
 				found = true;
@@ -815,7 +815,7 @@ static void dmar_fault_handler(uint32_t irq, void *data)
 {
 	struct dmar_drhd_rt *dmar_unit = (struct dmar_drhd_rt *)data;
 	uint32_t fsr;
-	uint32_t index;
+	uint16_t index;
 	uint32_t record_reg_offset;
 	struct dmar_entry fault_record;
 	int32_t loop = 0;

--- a/hypervisor/boot/boot.c
+++ b/hypervisor/boot/boot.c
@@ -11,7 +11,7 @@
 #include <rtl.h>
 #include <logmsg.h>
 
-static struct acrn_boot_info acrn_bi = { 0U };
+static struct acrn_boot_info acrn_bi = { 0 };
 
 /**
  * @pre (p_start != NULL) && (p_end != NULL)

--- a/hypervisor/boot/guest/bzimage_loader.c
+++ b/hypervisor/boot/guest/bzimage_loader.c
@@ -41,7 +41,7 @@
  * but this should be configurable for different OS. */
 #define DEFAULT_RAMDISK_GPA_MAX		0x37ffffffUL
 
-#define PRE_VM_MAX_RAM_ADDR_BELOW_4GB		(VIRT_ACPI_DATA_ADDR - 1U)
+#define PRE_VM_MAX_RAM_ADDR_BELOW_4GB		(VIRT_ACPI_DATA_ADDR - 1UL)
 
 static void *get_initrd_load_addr(struct acrn_vm *vm, uint64_t kernel_start)
 {
@@ -190,7 +190,7 @@ static uint16_t create_service_vm_efi_mmap_desc(struct acrn_vm *vm, struct efi_m
 	uint16_t i, desc_idx = 0U;
 	const struct efi_memory_desc *hv_efi_mmap_desc = get_efi_mmap_entry();
 
-	for (i = 0U; i < get_efi_mmap_entries_count(); i++) {
+	for (i = 0U; i < (uint16_t)get_efi_mmap_entries_count(); i++) {
 		/* Below efi mmap desc types in native should be kept as original for Service VM */
 		if ((hv_efi_mmap_desc[i].type == EFI_RESERVED_MEMORYTYPE)
 				|| (hv_efi_mmap_desc[i].type == EFI_UNUSABLE_MEMORY)
@@ -210,7 +210,7 @@ static uint16_t create_service_vm_efi_mmap_desc(struct acrn_vm *vm, struct efi_m
 		}
 	}
 
-	for (i = 0U; i < vm->e820_entry_num; i++) {
+	for (i = 0U; i < (uint16_t)vm->e820_entry_num; i++) {
 		/* The memory region with e820 type of RAM could be acted as EFI_CONVENTIONAL_MEMORY
 		 * for Service VM, the region which occupied by HV and pre-launched VM has been filtered
 		 * already, so it is safe for Service VM.

--- a/hypervisor/boot/guest/bzimage_loader.c
+++ b/hypervisor/boot/guest/bzimage_loader.c
@@ -31,10 +31,10 @@
  * should be able to accommodate it and so that avoid the trampoline corruption.
  */
 #define BZIMG_LOAD_PARAMS_SIZE			(MEM_4K * 8)
-#define BZIMG_INITGDT_GPA(load_params_gpa)	(load_params_gpa + 0UL)
-#define BZIMG_ZEROPAGE_GPA(load_params_gpa)	(load_params_gpa + MEM_1K)
-#define BZIMG_CMDLINE_GPA(load_params_gpa)	(load_params_gpa + MEM_1K + MEM_4K)
-#define BZIMG_EFIMMAP_GPA(load_params_gpa)	(load_params_gpa + MEM_1K + MEM_4K + MEM_2K)
+#define BZIMG_INITGDT_GPA(load_params_gpa)	((load_params_gpa) + 0UL)
+#define BZIMG_ZEROPAGE_GPA(load_params_gpa)	((load_params_gpa) + MEM_1K)
+#define BZIMG_CMDLINE_GPA(load_params_gpa)	((load_params_gpa) + MEM_1K + MEM_4K)
+#define BZIMG_EFIMMAP_GPA(load_params_gpa)	((load_params_gpa) + MEM_1K + MEM_4K + MEM_2K)
 
 /* TODO:
  * The value is referenced from Linux boot protocal for old kernels,

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -72,7 +72,7 @@ static int32_t init_vm_kernel_info(struct acrn_vm *vm, const struct abi_module *
 }
 
 /* cmdline parsed from abi module string, for pre-launched VMs and Service VM only. */
-static char mod_cmdline[PRE_VM_NUM + SERVICE_VM_NUM][MAX_BOOTARGS_SIZE] = { '\0' };
+static char mod_cmdline[PRE_VM_NUM + SERVICE_VM_NUM][MAX_BOOTARGS_SIZE] = { 0 };
 
 /**
  * @pre vm != NULL && abi != NULL

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -126,7 +126,7 @@ static void init_vm_bootargs_info(struct acrn_vm *vm, const struct acrn_boot_inf
  */
 struct abi_module *get_mod_by_tag(const struct acrn_boot_info *abi, const char *tag)
 {
-	uint8_t i;
+	uint32_t i;
 	struct abi_module *mod = NULL;
 	struct abi_module *mods = (struct abi_module *)(&abi->mods[0]);
 	uint32_t tag_len = strnlen_s(tag, MAX_MOD_TAG_LEN);

--- a/hypervisor/common/efi_mmap.c
+++ b/hypervisor/common/efi_mmap.c
@@ -10,12 +10,12 @@
 #include <efi_mmap.h>
 #include <logmsg.h>
 
-static uint16_t hv_memdesc_nr;
+static uint32_t hv_memdesc_nr;
 static struct efi_memory_desc hv_memdesc[CONFIG_MAX_EFI_MMAP_ENTRIES];
 
 static void sort_efi_mmap_entries(void)
 {
-	uint32_t i,j;
+	uint32_t i, j;
 	struct efi_memory_desc tmp_memdesc;
 
 	/* Bubble sort */

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -91,7 +91,7 @@ int32_t hcall_service_vm_offline_cpu(struct acrn_vcpu *vcpu, __unused struct acr
 	struct acrn_vcpu *target_vcpu;
 	uint16_t i;
 	int32_t ret = 0;
-	uint64_t lapicid = param1;
+	uint32_t lapicid = (uint32_t)param1;
 
 	pr_info("Service VM offline cpu with lapicid %ld", lapicid);
 
@@ -208,7 +208,7 @@ int32_t hcall_get_platform_info(struct acrn_vcpu *vcpu, __unused struct acrn_vm 
 		get_cache_shift(&pi.hw.l2_cat_shift, &pi.hw.l3_cat_shift);
 
 		for (i = 0U; i < min(pcpu_nums, ACRN_PLATFORM_LAPIC_IDS_MAX); i++) {
-			pi.hw.lapic_ids[i] = per_cpu(lapic_id, i);
+			pi.hw.lapic_ids[i] = (uint8_t)per_cpu(lapic_id, i);
 		}
 
 		pi.hw.cpu_num = pcpu_nums;

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -274,7 +274,7 @@ static inline bool vioapic_need_intr(const struct acrn_single_vioapic *vioapic, 
 	union ioapic_rte rte;
 	bool ret = false;
 
-	if (pin < vioapic->chipinfo.nr_pins) {
+	if ((uint32_t)pin < vioapic->chipinfo.nr_pins) {
 		rte = vioapic->rtbl[pin];
 		lvl = (uint32_t)bitmap_test(pin & 0x3FU, &vioapic->pin_state[pin >> 6U]);
 		ret = !!(((rte.bits.intr_polarity == IOAPIC_RTE_INTPOL_ALO) && (lvl == 0U)) ||

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -99,14 +99,14 @@ vioapic_set_pinstate(struct acrn_single_vioapic *vioapic, uint32_t pin, uint32_t
 			/* clear pin_state and deliver interrupt according to polarity */
 			bitmap_clear_nolock((uint16_t)(pin & 0x3FU), &vioapic->pin_state[pin >> 6U]);
 			if ((rte.bits.intr_polarity == IOAPIC_RTE_INTPOL_ALO)
-				&& old_lvl != level) {
+				&& (old_lvl != level)) {
 				vioapic_generate_intr(vioapic, pin);
 			}
 		} else {
 			/* set pin_state and deliver intrrupt according to polarity */
 			bitmap_set_nolock((uint16_t)(pin & 0x3FU), &vioapic->pin_state[pin >> 6U]);
 			if ((rte.bits.intr_polarity == IOAPIC_RTE_INTPOL_AHI)
-				&& old_lvl != level) {
+				&& (old_lvl != level)) {
 				vioapic_generate_intr(vioapic, pin);
 			}
 		}
@@ -277,8 +277,8 @@ static inline bool vioapic_need_intr(const struct acrn_single_vioapic *vioapic, 
 	if (pin < vioapic->chipinfo.nr_pins) {
 		rte = vioapic->rtbl[pin];
 		lvl = (uint32_t)bitmap_test(pin & 0x3FU, &vioapic->pin_state[pin >> 6U]);
-		ret = !!(((rte.bits.intr_polarity == IOAPIC_RTE_INTPOL_ALO) && lvl == 0U) ||
-			((rte.bits.intr_polarity == IOAPIC_RTE_INTPOL_AHI) && lvl != 0U));
+		ret = !!(((rte.bits.intr_polarity == IOAPIC_RTE_INTPOL_ALO) && (lvl == 0U)) ||
+			((rte.bits.intr_polarity == IOAPIC_RTE_INTPOL_AHI) && (lvl != 0U)));
 	}
 
 	return ret;

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -378,7 +378,7 @@ static void init_bars(struct pci_vdev *vdev, bool is_sriov_bar)
 			pci_pdev_write_cfg(pbdf, offset, 4U, lo);
 
 			vbar->mask = size32 & mask;
-			vbar->bar_type.bits &= (~mask);
+			vbar->bar_type.bits &= (uint32_t)(~mask);
 			vbar->size = (uint64_t)size32 & mask;
 
 			if (is_prelaunched_vm(vpci2vm(vdev->vpci))) {

--- a/hypervisor/dm/vpci/vdev.c
+++ b/hypervisor/dm/vpci/vdev.c
@@ -140,7 +140,7 @@ static void pci_vdev_update_vbar_base(struct pci_vdev *vdev, uint32_t idx)
 			* Currently, we don't support the reprogram of PIO bar of pass-thru devs,
 			* If guest tries to reprogram, hv will inject #GP to guest.
 			*/
-			if ((vdev->pdev != NULL) && ((lo & PCI_BASE_ADDRESS_IO_MASK) != vbar->base_hpa)) {
+			if ((vdev->pdev != NULL) && ((lo & PCI_BASE_ADDRESS_IO_MASK) != (uint32_t)vbar->base_hpa)) {
 				struct acrn_vcpu *vcpu = vcpu_from_pid(vpci2vm(vdev->vpci), get_pcpu_id());
 				if (vcpu != NULL) {
 					vcpu_inject_gp(vcpu, 0U);

--- a/hypervisor/dm/vpci/vmcs9900.c
+++ b/hypervisor/dm/vpci/vmcs9900.c
@@ -49,7 +49,7 @@ static int32_t vmcs9900_mmio_handler(struct io_request *io_req, void *data)
 	struct pci_vbar *vbar = &vdev->vbars[MCS9900_MMIO_BAR];
 	uint16_t offset;
 
-	offset = mmio->address - vbar->base_gpa;
+	offset = (uint16_t)(mmio->address - vbar->base_gpa);
 
 	if (mmio->direction == ACRN_IOREQ_DIR_READ) {
 		mmio->value = vuart_read_reg(vu, offset);
@@ -165,7 +165,7 @@ const struct pci_vdev_ops vmcs9900_ops = {
 
 int32_t create_vmcs9900_vdev(struct acrn_vm *vm, struct acrn_vdev *dev)
 {
-	uint32_t i;
+	uint16_t i;
 	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 	struct acrn_vm_pci_dev_config *dev_config = NULL;
 	int32_t ret = -EINVAL;

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -137,7 +137,7 @@ int32_t add_vmsix_capability(struct pci_vdev *vdev, uint32_t entry_num, uint8_t 
 		(void)memset(&msixcap, 0U, sizeof(struct msixcap));
 
 		msixcap.capid = PCIY_MSIX;
-		msixcap.msgctrl = entry_num - 1U;
+		msixcap.msgctrl = (uint16_t)entry_num - 1U;
 
 		/* - MSI-X table start at offset 0 */
 		msixcap.table_info = bar_num;

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -130,8 +130,9 @@ int32_t add_vmsix_capability(struct pci_vdev *vdev, uint32_t entry_num, uint8_t 
 		vdev->msix.table_count = entry_num;
 
 		/* set mask bit of vector control register */
-		for (i = 0; i < entry_num; i++)
+		for (i = 0; i < entry_num; i++) {
 			vdev->msix.table_entries[i].vector_control |= PCIM_MSIX_VCTRL_MASK;
+		}
 
 		(void)memset(&msixcap, 0U, sizeof(struct msixcap));
 

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -119,15 +119,15 @@ static bool vpci_pio_cfgdata_read(struct acrn_vcpu *vcpu, uint16_t addr, size_t 
 	struct acrn_vpci *vpci = &vm->vpci;
 	union pci_cfg_addr_reg cfg_addr;
 	union pci_bdf bdf;
-	uint16_t offset = addr - PCI_CONFIG_DATA;
 	uint32_t val = ~0U;
 	struct acrn_pio_request *pio_req = &vcpu->req.reqs.pio_request;
 
 	cfg_addr.value = atomic_readandclear32(&vpci->addr.value);
 	if (cfg_addr.bits.enable != 0U) {
-		if (pci_is_valid_access(cfg_addr.bits.reg_num + offset, bytes)) {
+		uint32_t offset = (uint16_t)cfg_addr.bits.reg_num + (addr - PCI_CONFIG_DATA);
+		if (pci_is_valid_access(offset, bytes)) {
 			bdf.value = cfg_addr.bits.bdf;
-			ret = vpci_read_cfg(vpci, bdf, cfg_addr.bits.reg_num + offset, bytes, &val);
+			ret = vpci_read_cfg(vpci, bdf, offset, bytes, &val);
 		}
 	}
 
@@ -152,13 +152,13 @@ static bool vpci_pio_cfgdata_write(struct acrn_vcpu *vcpu, uint16_t addr, size_t
 	struct acrn_vpci *vpci = &vm->vpci;
 	union pci_cfg_addr_reg cfg_addr;
 	union pci_bdf bdf;
-	uint16_t offset = addr - PCI_CONFIG_DATA;
 
 	cfg_addr.value = atomic_readandclear32(&vpci->addr.value);
 	if (cfg_addr.bits.enable != 0U) {
-		if (pci_is_valid_access(cfg_addr.bits.reg_num + offset, bytes)) {
+		uint32_t offset = (uint16_t)cfg_addr.bits.reg_num + (addr - PCI_CONFIG_DATA);
+		if (pci_is_valid_access(offset, bytes)) {
 			bdf.value = cfg_addr.bits.bdf;
-			ret = vpci_write_cfg(vpci, bdf, cfg_addr.bits.reg_num + offset, bytes, val);
+			ret = vpci_write_cfg(vpci, bdf, offset, bytes, val);
 		}
 	}
 
@@ -672,7 +672,7 @@ struct pci_vdev *vpci_init_vdev(struct acrn_vpci *vpci, struct acrn_vm_pci_dev_c
  */
 static int32_t vpci_init_vdevs(struct acrn_vm *vm)
 {
-	uint32_t idx;
+	uint16_t idx;
 	struct acrn_vpci *vpci = &(vm->vpci);
 	const struct acrn_vm_config *vm_config = get_vm_config(vpci2vm(vpci)->vm_id);
 	int32_t ret = 0;
@@ -843,7 +843,7 @@ uint32_t vpci_add_capability(struct pci_vdev *vdev, uint8_t *capdata, uint8_t ca
 #define CAP_START_OFFSET PCI_CFG_HEADER_LENGTH
 
 	uint8_t capoff, reallen;
-	uint16_t sts;
+	uint32_t sts;
 	uint32_t ret = 0U;
 
 	reallen = roundup(caplen, 4U); /* dword aligned */

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -494,8 +494,7 @@ static void write_cfg_header(struct pci_vdev *vdev,
 		 * even this PCI device has no INTx, so emulate INTx Line Register as writable.
 		 */
 		if (offset == PCIR_INTERRUPT_LINE) {
-			val &= 0xfU;
-			pci_vdev_write_vcfg(vdev, offset, bytes, val);
+			pci_vdev_write_vcfg(vdev, offset, bytes, (val & 0xfU));
 		}
 
 	}

--- a/hypervisor/dm/vpci/vroot_port.c
+++ b/hypervisor/dm/vpci/vroot_port.c
@@ -121,7 +121,7 @@ int32_t create_vrp(struct acrn_vm *vm, struct acrn_vdev *dev)
 	struct pci_vdev *vdev;
 	struct vrp_config *vrp_config;
 
-	int i;
+	uint16_t i;
 
 	vrp_config = (struct vrp_config*)dev->args;
 
@@ -134,7 +134,7 @@ int32_t create_vrp(struct acrn_vm *vm, struct acrn_vdev *dev)
 	for (i = 0U; i < vm_config->pci_dev_num; i++) {
 		dev_config = &vm_config->pci_devs[i];
 		if (dev_config->vrp_sec_bus == vrp_config->secondary_bus) {
-			dev_config->vbdf.value = dev->slot;
+			dev_config->vbdf.value = (uint16_t)dev->slot;
 			dev_config->pbdf.value = vrp_config->phy_bdf;
 			dev_config->vrp_max_payload = vrp_config->max_payload;
 			dev_config->vdev_ops = &vrp_ops;

--- a/hypervisor/dm/vpci/vsriov.c
+++ b/hypervisor/dm/vpci/vsriov.c
@@ -114,7 +114,7 @@ static void create_vf(struct pci_vdev *pf_vdev, union pci_bdf vf_bdf, uint16_t v
 		pr_err("PF %x:%x.%x can't creat VF, unset VF_ENABLE",
 			pf_vdev->bdf.bits.b, pf_vdev->bdf.bits.d, pf_vdev->bdf.bits.f);
 	} else {
-		uint16_t bar_idx;
+		uint32_t bar_idx;
 		struct pci_vbar *vf_vbar;
 
 		/* VF bars information from its PF SRIOV capability, no need to access physical device */

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -462,7 +462,7 @@ static int32_t vpic_ocw2(const struct acrn_vpic *vpic, struct i8259_reg_state *i
 
 		/* if level ack PTDEV */
 		if ((i8259->elc & (1U << (isr_bit & 0x7U))) != 0U) {
-			vgsi = vpin_to_vgsi(vm, (primary_pic(vpic, i8259) ? isr_bit : isr_bit + 8U));
+			vgsi = vpin_to_vgsi(vm, (primary_pic(vpic, i8259) ? isr_bit : (isr_bit + 8U)));
 			ptirq_intx_ack(vm, vgsi, INTX_CTLR_PIC);
 		}
 	} else if (((val & OCW2_SL) != 0U) && i8259->rotate) {

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -461,7 +461,7 @@ static void scan_pci_hierarchy(uint8_t bus, uint64_t buses_visited[BUSES_BITMAP_
 					&buses_visited[current_bus_index >> 6U]);
 
 		pbdf.bits.b = current_bus_index;
-		if (pbdf.bits.b < phys_pci_mmcfg.start_bus || pbdf.bits.b > phys_pci_mmcfg.end_bus) {
+		if ((pbdf.bits.b < phys_pci_mmcfg.start_bus) || (pbdf.bits.b > phys_pci_mmcfg.end_bus)) {
 			continue;
 		}
 
@@ -739,8 +739,8 @@ static void pci_enumerate_ext_cap(struct pci_pdev *pdev)
 			pcie_dev_type = (((uint8_t)pci_pdev_read_cfg(pdev->bdf,
 				pdev->pcie_capoff + PCIER_FLAGS, 1)) & PCIEM_FLAGS_TYPE) >> 4;
 
-			if (pcie_dev_type == PCIEM_TYPE_ENDPOINT ||
-					pcie_dev_type == PCIEM_TYPE_ROOT_INT_EP) {
+			if ((pcie_dev_type == PCIEM_TYPE_ENDPOINT) ||
+					(pcie_dev_type == PCIEM_TYPE_ROOT_INT_EP)) {
 				/* No need to enable ptm on ep device.  If a PTM-capable ep pass
 				 * through to guest, guest OS will enable it
 				 */

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -414,7 +414,7 @@ static uint32_t pci_check_override_drhd_index(union pci_bdf pbdf,
 		const struct pci_bdf_mapping_group *const bdfs_from_drhds,
 		uint32_t current_drhd_index)
 {
-	uint16_t bdfi;
+	uint32_t bdfi;
 	uint32_t bdf_drhd_index = current_drhd_index;
 
 	for (bdfi = 0U; bdfi < bdfs_from_drhds->pci_bdf_map_count; bdfi++) {

--- a/hypervisor/include/arch/x86/asm/guest/ept.h
+++ b/hypervisor/include/arch/x86/asm/guest/ept.h
@@ -25,13 +25,13 @@ struct acrn_vm;
  * @brief Check if the GPA range is guest valid GPA or not
  *
  * @param[in] vm the pointer that points to VM data structure
- * @param[in] base The specified start guest physical address of guest
- *                physical memory region
+ * @param[in] mr_base_gpa The specified start guest physical address of guest
+ *                        physical memory region
  * @param[in] size The size of guest physical memory region
  *
  * @retval true if the GPA range is guest valid GPA, false otherwise.
  */
-bool ept_is_valid_mr(struct acrn_vm *vm, uint64_t base, uint64_t size);
+bool ept_is_valid_mr(struct acrn_vm *vm, uint64_t mr_base_gpa, uint64_t size);
 
 /**
  * @brief EPT page tables destroy

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -142,7 +142,7 @@
 	for ((idx) = 0U, (vcpu) = &((vm)->hw.vcpu_array[(idx)]);	\
 		(idx) < (vm)->hw.created_vcpus;			\
 		(idx)++, (vcpu) = &((vm)->hw.vcpu_array[(idx)])) \
-		if (vcpu->state != VCPU_OFFLINE)
+		if ((vcpu)->state != VCPU_OFFLINE)
 
 enum vcpu_state {
 	VCPU_OFFLINE = 0U,

--- a/hypervisor/include/arch/x86/asm/guest/vmcs.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmcs.h
@@ -8,7 +8,7 @@
 #define VMCS_H_
 
 #define VM_SUCCESS	0
-#define VM_FAIL		-1
+#define VM_FAIL		(-1)
 
 #ifndef ASSEMBLER
 #include <types.h>

--- a/hypervisor/include/arch/x86/asm/guest/vmcs.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmcs.h
@@ -41,7 +41,7 @@ static inline uint64_t apic_access_offset(uint64_t qual)
 	return (qual & APIC_ACCESS_OFFSET);
 }
 
-static inline void clear_vmcs_bit(uint32_t vmcs_field, uint32_t bit)
+static inline void clear_vmcs_bit(uint32_t vmcs_field, uint64_t bit)
 {
 	uint64_t val64;
 
@@ -50,7 +50,7 @@ static inline void clear_vmcs_bit(uint32_t vmcs_field, uint32_t bit)
 	exec_vmwrite(vmcs_field, val64);
 }
 
-static inline void set_vmcs_bit(uint32_t vmcs_field, uint32_t bit)
+static inline void set_vmcs_bit(uint32_t vmcs_field, uint64_t bit)
 {
 	uint64_t val64;
 

--- a/hypervisor/include/arch/x86/asm/lib/bits.h
+++ b/hypervisor/include/arch/x86/asm/lib/bits.h
@@ -293,7 +293,7 @@ build_bitmap_testandclear(bitmap32_test_and_clear_lock, "l", uint32_t, BUS_LOCK)
 
 static inline uint16_t bitmap_weight(uint64_t bits)
 {
-	return __builtin_popcountl(bits);
+	return (uint16_t)__builtin_popcountl(bits);
 }
 
 #endif /* BITS_H*/

--- a/hypervisor/include/arch/x86/asm/mmu.h
+++ b/hypervisor/include/arch/x86/asm/mmu.h
@@ -183,7 +183,7 @@ void flush_vpid_global(void);
  */
 void invept(const void *eptp);
 
-uint32_t get_hv_ram_size(void);
+uint64_t get_hv_ram_size(void);
 
 /* get PDPT address from CR3 vaule in PAE mode */
 static inline uint64_t get_pae_pdpt_addr(uint64_t cr3)

--- a/hypervisor/include/arch/x86/asm/msr.h
+++ b/hypervisor/include/arch/x86/asm/msr.h
@@ -596,9 +596,9 @@
 /* 5 high-order bits in every field are reserved */
 #define PAT_FIELD_RSV_BITS			(0xF8UL)
 /* MSR_TEST_CTL bits */
-#define MSR_TEST_CTL_GP_UCLOCK                 (1U << 28U)
-#define MSR_TEST_CTL_AC_SPLITLOCK              (1U << 29U)
-#define MSR_TEST_CTL_DISABLE_LOCK_ASSERTION    (1U << 31U)
+#define MSR_TEST_CTL_GP_UCLOCK                 (1UL << 28U)
+#define MSR_TEST_CTL_AC_SPLITLOCK              (1UL << 29U)
+#define MSR_TEST_CTL_DISABLE_LOCK_ASSERTION    (1UL << 31U)
 
 #ifndef ASSEMBLER
 static inline bool is_pat_mem_type_invalid(uint64_t x)

--- a/hypervisor/include/arch/x86/asm/vtd.h
+++ b/hypervisor/include/arch/x86/asm/vtd.h
@@ -481,7 +481,7 @@ static inline uint16_t dma_frcd_up_sid(uint64_t up_sid)
 
 #define DRHD_FLAG_INCLUDE_PCI_ALL_MASK      (1U)
 
-#define DEVFUN(dev, fun)            (((dev & 0x1FU) << 3U) | ((fun & 0x7U)))
+#define DEVFUN(dev, fun)            ((((dev) & 0x1FU) << 3U) | (((fun) & 0x7U)))
 
 struct dmar_dev_scope {
 	enum acpi_dmar_scope_type type;

--- a/hypervisor/include/common/timer.h
+++ b/hypervisor/include/common/timer.h
@@ -54,7 +54,7 @@ struct hv_timer {
  * @param[in] timer Pointer to timer.
  * @param[in] func irq callback if time reached.
  * @param[in] priv_data func private data.
- * @param[in] fire_tsc tsc deadline to interrupt.
+ * @param[in] timeout tsc deadline to interrupt.
  * @param[in] period_in_cycle period of the periodic timer in unit of TSC cycles.
  *
  * @remark Don't initialize a timer twice if it has been added to the timer list
@@ -64,7 +64,7 @@ struct hv_timer {
  */
 void initialize_timer(struct hv_timer *timer,
 		      timer_handle_t func, void *priv_data,
-		      uint64_t fire_tsc, uint64_t period_in_cycle);
+		      uint64_t timeout, uint64_t period_in_cycle);
 
 /**
  * @brief Check a timer whether expired.

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -137,7 +137,7 @@
 #define PCI_PTM_CAP_LEN				0x04U
 #define PCIR_PTM_CAP				0x04U
 #define PCIM_PTM_CAP_ROOT_CAPABLE	0x4U
-#define PCIM_PTM_GRANULARITY_MASK	0xFF00
+#define PCIM_PTM_GRANULARITY_MASK	0xFF00U
 #define PCIR_PTM_CTRL				0x08U
 #define PCIM_PTM_CTRL_ENABLED		0x1U
 #define PCIM_PTM_CTRL_ROOT_SELECTED	0x2U
@@ -190,11 +190,11 @@
 #define PCIM_PCIE_FLR         (0x1U << 15U)
 
 /* PCI Express Device Type definitions */
-#define PCIER_FLAGS                    0x2
-#define PCIEM_FLAGS_TYPE               0x00F0
-#define PCIEM_TYPE_ENDPOINT            0x0000
-#define PCIEM_TYPE_ROOTPORT            0x0004
-#define PCIEM_TYPE_ROOT_INT_EP         0x0009
+#define PCIER_FLAGS                    0x2U
+#define PCIEM_FLAGS_TYPE               0x00F0U
+#define PCIEM_TYPE_ENDPOINT            0x0000U
+#define PCIEM_TYPE_ROOTPORT            0x0004U
+#define PCIEM_TYPE_ROOT_INT_EP         0x0009U
 
 #define PCIR_PCIE_DEVCAP2     0x24U
 #define PCIM_PCIE_DEVCAP2_ARI (0x1U << 5U)

--- a/hypervisor/include/lib/list.h
+++ b/hypervisor/include/lib/list.h
@@ -156,6 +156,6 @@ hlist_add_head(struct hlist_node *n, struct hlist_head *h)
 #define hlist_entry(ptr, type, member) container_of(ptr,type,member)
 
 #define hlist_for_each(pos, head) \
-	for (pos = (head)->first; (pos) != NULL; pos = (pos)->next)
+	for ((pos) = (head)->first; (pos) != NULL; (pos) = (pos)->next)
 
 #endif /* LIST_H_ */

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -282,7 +282,7 @@ struct hc_api_version {
 	uint32_t minor_version;
 } __aligned(8);
 
-#define ACRN_PLATFORM_LAPIC_IDS_MAX	64
+#define ACRN_PLATFORM_LAPIC_IDS_MAX	64U
 /**
  * Hypervisor API, return it for HC_GET_PLATFORM_INFO hypercall
  */

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -528,7 +528,7 @@ void do_print(const char *fmt_arg, struct print_param *param,
 			else if (ch == 'c') {
 				char c[2];
 
-				c[0] = __builtin_va_arg(args, int32_t);
+				c[0] = (char)__builtin_va_arg(args, int32_t);
 				c[1] = 0;
 				print_string(param, c);
 			}


### PR DESCRIPTION
With the coding guideline scanning tool not properly working for some time, some violations to our coding guideline have been introduced into the code base by recent changes. We'll now switch a customized static checker based on the open source LLVM/Clang framework. After teaching the tools ~70% of our coding guidelines (as well as known deviations to them), we have identified ~100 violations which should be fixed in the code today.

This patch series aims at fixing the identified violations that are straightforward to resolve. Most of them are local and semantic-impact-free, but there are two fixes against apparent anomaly. See patches 01/11 and 11/11 for the changes that has semantic impact.

In addition to those fixed by this series, there are ~30 violations remaining which seem to be non-trivial and requiring full knowledge of the underlying logic. Separate patches will be submitted for them.