### PR TITLE
config_tools: fix UI issue don't expand the default value in xml file

### DIFF
--- a/misc/config_tools/config_app/views.py
+++ b/misc/config_tools/config_app/views.py
@@ -900,6 +900,8 @@ def upload_scenario():
                                         + datetime.now().strftime('%Y%m%d%H%M%S')
                     rename = True
 
+            xsd_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'schema', 'config.xsd')
+            default_populator.main(xsd_path, tmp_scenario_file, tmp_scenario_file)
             os.rename(tmp_scenario_file, os.path.join(current_app.config.get('CONFIG_PATH'),
                                                       board_type, new_scenario_name + '.xml'))
 


### PR DESCRIPTION
When we click the "Import XML" button to import the scenario XML file, then click
the "Export XML" to export the XML files, we will find some errors because
UI doesn't show the default value set in schema.

As a workaround, we call default_populator.py in UI to expand the default value
in the scenario XML file to fix the issue.

Tracked-On: #6292
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>