### PR TITLE
doc: Update VT-d spec link

### DIFF
--- a/doc/developer-guides/hld/hv-vt-d.rst
+++ b/doc/developer-guides/hld/hv-vt-d.rst
@@ -104,7 +104,7 @@ Refer to the `VT-d spec`_ for more details on device-to-domain
 mapping structures.
 
 .. _VT-d spec:
-   https://software.intel.com/content/www/us/en/develop/download/intel-virtualization-technology-for-directed-io-architecture-specification.html
+   https://cdrdv2.intel.com/v1/dl/getContent/671081
 
 Address Translation Structures
 ==============================


### PR DESCRIPTION
Publisher of this document confirmed that VT-d spec link should be updated, and the existing link will be EOL.

Signed-off-by: Amy Reyes <amy.reyes@intel.com>