### PR TITLE
config_tool: update cpu affinity data load and check

### DIFF
--- a/misc/config_tools/launch_config/launch_item.py
+++ b/misc/config_tools/launch_config/launch_item.py
@@ -26,6 +26,14 @@ class AcrnDmArgs:
         self.args["cpu_sharing"] = common.get_hv_item_tag(self.scenario_info, "FEATURES", "SCHEDULER")
         self.args["pm_channel"] = common.get_leaf_tag_map(self.launch_info, "poweroff_channel")
         self.args["cpu_affinity"] = common.get_leaf_tag_map(self.launch_info, "cpu_affinity", "pcpu_id")
+        # get default cpu_affinity from scenario file
+        scenario_cpu_aff = common.get_leaf_tag_map(self.scenario_info, "cpu_affinity", "pcpu_id")
+        for vm_id, cpu_ids in self.args["cpu_affinity"].items():
+            cpu_ids = [x for x in cpu_ids if x is not None]
+            if cpu_ids:
+                continue
+            self.args["cpu_affinity"][vm_id] = scenario_cpu_aff[vm_id]
+
         self.args["shm_enabled"] = common.get_hv_item_tag(self.scenario_info, "FEATURES", "IVSHMEM", "IVSHMEM_ENABLED")
         self.args["shm_regions"] = common.get_leaf_tag_map(self.launch_info, "shm_regions", "shm_region")
         for vmid, shm_regions in self.args["shm_regions"].items():
@@ -49,10 +57,10 @@ class AcrnDmArgs:
         launch_cfg_lib.args_aval_check(self.args["enable_ptm"], "enable_ptm", launch_cfg_lib.y_n)
         launch_cfg_lib.args_aval_check(self.args["allow_trigger_s5"], "allow_trigger_s5", launch_cfg_lib.y_n)
         cpu_affinity = launch_cfg_lib.user_vm_cpu_affinity(self.args["cpu_affinity"])
-        err_dic = scenario_cfg_lib.vm_cpu_affinity_check(self.launch_info, cpu_affinity, "pcpu_id")
+        err_dic = scenario_cfg_lib.vm_cpu_affinity_check(self.scenario_info, cpu_affinity)
         launch_cfg_lib.ERR_LIST.update(err_dic)
         launch_cfg_lib.check_shm_regions(self.args["shm_regions"], self.scenario_info)
-        launch_cfg_lib.check_console_vuart(self.args["console_vuart"],self.args["vuart0"], self.scenario_info)
+        launch_cfg_lib.check_console_vuart(self.args["console_vuart"], self.args["vuart0"], self.scenario_info)
         launch_cfg_lib.check_communication_vuart(self.args["communication_vuarts"], self.scenario_info)
         launch_cfg_lib.check_enable_ptm(self.args["enable_ptm"], self.scenario_info)
 

--- a/misc/config_tools/library/scenario_cfg_lib.py
+++ b/misc/config_tools/library/scenario_cfg_lib.py
@@ -361,7 +361,7 @@ def vm_cpu_affinity_check(scenario_file, cpu_affinity):
     for vm_i,cpu in cpu_affinity.items():
         if cpu is not None and cpu in use_cpus and not cpu_sharing_enabled:
             key = "vm:id={},{}".format(vm_i, 'pcpu_id')
-            err_dic[key] = "The same pcpu was configurated in <pcpu_id>/<cpu_affinity>, but CPU sharing is disabled by 'SCHED_NOOP'. Please re-configurate them!"
+            err_dic[key] = "The same pCPU was configured in <pcpu_id>/<cpu_affinity>, but CPU sharing is disabled by 'SCHED_NOOP'. Please enable CPU sharing or update your CPU affinity configuration."
             return err_dic
         else:
             use_cpus.append(cpu)

--- a/misc/config_tools/library/scenario_cfg_lib.py
+++ b/misc/config_tools/library/scenario_cfg_lib.py
@@ -333,10 +333,10 @@ def guest_flag_check(guest_flags, branch_tag, leaf_tag):
                 ERR_LIST[key] = "Unknow guest flag"
 
 
-def vm_cpu_affinity_check(config_file, id_cpus_per_vm_dic, item):
+def vm_cpu_affinity_check(scenario_file, cpu_affinity):
     """
     Check cpu number of per vm
-    :param item: vm pcpu_id item in xml
+    :param : vm cpu_affinity item in xml
     :return: error informations
     """
     err_dic = {}
@@ -347,37 +347,46 @@ def vm_cpu_affinity_check(config_file, id_cpus_per_vm_dic, item):
     if cpu_sharing == "SCHED_NOOP":
         cpu_sharing_enabled = False
 
-    cpu_affinity = common.get_leaf_tag_map(config_file, "cpu_affinity", "pcpu_id")
-    for vm_i in id_cpus_per_vm_dic.keys():
-        for cpu in id_cpus_per_vm_dic[vm_i]:
-            if cpu is not None and cpu in use_cpus and not cpu_sharing_enabled:
-                key = "vm:id={},{}".format(vm_i, item)
-                err_dic[key] = "The same pcpu was configurated in <pcpu_id>/<cpu_affinity>, but CPU sharing is disabled by 'SCHED_NOOP'. Please re-configurate them!"
-                return err_dic
-            else:
-                use_cpus.append(cpu)
+    # validate cpu_affinity config with scenario file
+    scenario_cpu_aff = common.get_leaf_tag_map(scenario_file, "cpu_affinity", "pcpu_id")
+    for vm_id, cpu_ids in cpu_affinity.items():
+        for vm_cpu in cpu_ids:
+            if vm_cpu not in scenario_cpu_aff[vm_id]:
+                key = "vm:id={},{}".format(vm_id, 'pcpu_id')
+                err_dic[key] = "This pcpu is not configured in this vm's scenario file. Please re-configurate them!"
+
+    if err_dic:
+        return err_dic
+
+    for vm_i,cpu in cpu_affinity.items():
+        if cpu is not None and cpu in use_cpus and not cpu_sharing_enabled:
+            key = "vm:id={},{}".format(vm_i, 'pcpu_id')
+            err_dic[key] = "The same pcpu was configurated in <pcpu_id>/<cpu_affinity>, but CPU sharing is disabled by 'SCHED_NOOP'. Please re-configurate them!"
+            return err_dic
+        else:
+            use_cpus.append(cpu)
 
     sos_vm_cpus = []
     pre_launch_cpus = []
     post_launch_cpus = []
     for vm_i, vm_type in common.VM_TYPES.items():
-        if vm_i not in id_cpus_per_vm_dic.keys():
+        if vm_i not in cpu_affinity.keys():
             continue
         elif VM_DB[vm_type]['load_type'] == "PRE_LAUNCHED_VM":
-            cpus = [x for x in id_cpus_per_vm_dic[vm_i] if not None]
+            cpus = [x for x in cpu_affinity[vm_i] if not None]
             pre_launch_cpus.extend(cpus)
         elif VM_DB[vm_type]['load_type'] == "POST_LAUNCHED_VM":
-            cpus = [x for x in id_cpus_per_vm_dic[vm_i] if not None]
+            cpus = [x for x in cpu_affinity[vm_i] if not None]
             post_launch_cpus.extend(cpus)
         elif VM_DB[vm_type]['load_type'] == "SERVICE_VM":
-            cpus = [x for x in id_cpus_per_vm_dic[vm_i] if not None]
+            cpus = [x for x in cpu_affinity[vm_i] if not None]
             sos_vm_cpus.extend(cpus)
 
         # duplicate cpus assign the same VM check
-        cpus_vm_i = id_cpus_per_vm_dic[vm_i]
+        cpus_vm_i = cpu_affinity[vm_i]
         for cpu_id in cpus_vm_i:
             if cpus_vm_i.count(cpu_id) >= 2:
-                key = "vm:id={},{}".format(vm_i, item)
+                key = "vm:id={},{}".format(vm_i, 'pcpu_id')
                 err_dic[key] = "VM should not use the same pcpu id:{}".format(cpu_id)
                 return err_dic
 

--- a/misc/config_tools/library/scenario_cfg_lib.py
+++ b/misc/config_tools/library/scenario_cfg_lib.py
@@ -353,7 +353,7 @@ def vm_cpu_affinity_check(scenario_file, cpu_affinity):
         for vm_cpu in cpu_ids:
             if vm_cpu not in scenario_cpu_aff[vm_id]:
                 key = "vm:id={},{}".format(vm_id, 'pcpu_id')
-                err_dic[key] = "This pcpu is not configured in this vm's scenario file. Please re-configurate them!"
+                err_dic[key] = "This pCPU is not included in this VM's allowed CPU pool. Please update your scenario file accordingly or remove it from this list."
 
     if err_dic:
         return err_dic

--- a/misc/config_tools/scenario_config/scenario_item.py
+++ b/misc/config_tools/scenario_config/scenario_item.py
@@ -399,7 +399,7 @@ class VmInfo:
         scenario_cfg_lib.vm_name_check(self.name, "name")
         scenario_cfg_lib.load_vm_check(self.load_vm, "load_vm")
         scenario_cfg_lib.guest_flag_check(self.guest_flags, "guest_flags", "guest_flag")
-        err_dic = scenario_cfg_lib.vm_cpu_affinity_check(self.scenario_info, self.cpus_per_vm, "pcpu_id")
+        err_dic = scenario_cfg_lib.vm_cpu_affinity_check(self.scenario_info, self.cpus_per_vm)
         scenario_cfg_lib.vcpu_clos_check(self.cpus_per_vm, self.clos_per_vm, self.guest_flags, "clos", "vcpu_clos")
 
         self.mem_info.check_item()


### PR DESCRIPTION
config_tool: add cpu affinity check
1. ensure cpu affinity in launch xml is subset of its scenario settings.
2. cpu_affinity is a must have parameter for acrn_dm, if the user did not provide cpu affinity in launch xml, load it from scenario settings.

[External_System_ID] ACRN-7453
Tracked-On: #6724
Signed-off-by: Weiyi Feng <weiyix.feng@intel.com>
