### PR TITLE
deb-pkg: update deb configuration to install serial.conf

### DIFF
--- a/.deb.conf
+++ b/.deb.conf
@@ -55,6 +55,10 @@
 			"source":"acrn-hypervisor/misc/packaging/100_ACRN",
 			"target":"etc/grub.d/"
 			},
+"serial.conf":{
+			"source":"acrn-hypervisor/build/hypervisor/serial.conf",
+			"target":"etc/"
+			},
 "50-acrn.netdev":{
 			"source":"acrn-hypervisor/misc/packaging/50-acrn.netdev",
 			"target":"usr/lib/systemd/network"


### PR DESCRIPTION
When some communication vuarts are configured in hypervisor
scenario files, serial.conf will be generated and should be
installed in the etc folder of service VM.

In this patch, update deb configuration file to install
serial.conf into etc folder of service VM.

Tracked-On: #6652

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>