### PR TITLE
doc: fix git clone and misspelling

### DIFF
--- a/doc/developer-guides/hld/hld-power-management.rst
+++ b/doc/developer-guides/hld/hld-power-management.rst
@@ -75,7 +75,7 @@ The build flow is:
 1) Use an offline tool (e.g. **iasl**) to parse the Px/Cx data and hard-code to
    a CPU state table in the Hypervisor. The Hypervisor loads the data after
    the system boots.
-2) Before User VM launching, the Device mode queries the Px/Cx data from the Service
+2) Before User VM launching, the Device model queries the Px/Cx data from the Service
    VM HSM via ioctl interface.
 3) HSM transmits the query request to the Hypervisor by hypercall.
 4) The Hypervisor returns the Px/Cx data.

--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -161,12 +161,12 @@ To set up the ACRN build environment on the development computer:
    .. code-block:: bash
 
       cd ~/acrn-work
-      git clone https://github.com/projectacrn/acrn-hypervisor
+      git clone https://github.com/projectacrn/acrn-hypervisor.git
       cd acrn-hypervisor
       git checkout v2.6
 
       cd ..
-      git clone --depth 1 --branch release_2.6 https://github.com/projectacrn/acrn-kernel
+      git clone --depth 1 --branch release_2.6 https://github.com/projectacrn/acrn-kernel.git
 
 .. _gsg-board-setup:
 


### PR DESCRIPTION
It's recommended we always use the .git extension when referring to the
git repo when cloning.  Fix that in the GSG.

Also, fix a misspelling in the hld-power-management doc.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>