### PR TITLE
config_tools: fix the duplicate PT_SLOT value issue in UI

### DIFF
--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -111,6 +111,7 @@ def ui_entry_api(board_info, scenario_info, launch_info, out=''):
         return err_dic
 
     err_dic = main(arg_list)
+    launch_cfg_lib.reset_pt_slot()
     return err_dic
 
 
@@ -149,7 +150,6 @@ def generate_script_file(names, pt_sel, virt_io, dm, sriov, vmid, config):
 
     print("{}".format(header_info), file=config)
     com.gen(names, pt_sel, virt_io, dm, sriov, vmid, config)
-    launch_cfg_lib.reset_pt_slot()
     if launch_cfg_lib.ERR_LIST:
         return launch_cfg_lib.ERR_LIST
 


### PR DESCRIPTION
when we add two or more virtio block devices and rename them for a VM
in launch XML files, then generate launch scripts through the UI.
After ensuring the devices names are different, we repeat these operations
continuously. Finally, we will get the duplicate PT_SLOT value for
different virtio block devices in a launch script. This is wrong.

After the user click the "Generate Launch Script" button to generate the
launch scripts every time, we will reset PT_SLOT variate to fix the issue.

Tracked-On: #6767

Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>