### PR TITLE
config_tool: add cpu affinity check (release_2.7)

### DIFF
--- a/misc/config_tools/launch_config/launch_item.py
+++ b/misc/config_tools/launch_config/launch_item.py
@@ -26,6 +26,14 @@ class AcrnDmArgs:
         self.args["cpu_sharing"] = common.get_hv_item_tag(self.scenario_info, "FEATURES", "SCHEDULER")
         self.args["pm_channel"] = common.get_leaf_tag_map(self.launch_info, "poweroff_channel")
         self.args["cpu_affinity"] = common.get_leaf_tag_map(self.launch_info, "cpu_affinity", "pcpu_id")
+        # get default cpu_affinity from scenario file
+        scenario_cpu_aff = common.get_leaf_tag_map(self.scenario_info, "cpu_affinity", "pcpu_id")
+        for vm_id, cpu_ids in self.args["cpu_affinity"].items():
+            cpu_ids = [x for x in cpu_ids if x is not None]
+            if cpu_ids:
+                continue
+            self.args["cpu_affinity"][vm_id] = scenario_cpu_aff[vm_id]
+
         self.args["shm_enabled"] = common.get_hv_item_tag(self.scenario_info, "FEATURES", "IVSHMEM", "IVSHMEM_ENABLED")
         self.args["shm_regions"] = common.get_leaf_tag_map(self.launch_info, "shm_regions", "shm_region")
         for vmid, shm_regions in self.args["shm_regions"].items():
@@ -49,10 +57,10 @@ class AcrnDmArgs:
         launch_cfg_lib.args_aval_check(self.args["enable_ptm"], "enable_ptm", launch_cfg_lib.y_n)
         launch_cfg_lib.args_aval_check(self.args["allow_trigger_s5"], "allow_trigger_s5", launch_cfg_lib.y_n)
         cpu_affinity = launch_cfg_lib.user_vm_cpu_affinity(self.args["cpu_affinity"])
-        err_dic = scenario_cfg_lib.vm_cpu_affinity_check(self.launch_info, cpu_affinity, "pcpu_id")
+        err_dic = scenario_cfg_lib.vm_cpu_affinity_check(self.scenario_info, cpu_affinity)
         launch_cfg_lib.ERR_LIST.update(err_dic)
         launch_cfg_lib.check_shm_regions(self.args["shm_regions"], self.scenario_info)
-        launch_cfg_lib.check_console_vuart(self.args["console_vuart"],self.args["vuart0"], self.scenario_info)
+        launch_cfg_lib.check_console_vuart(self.args["console_vuart"], self.args["vuart0"], self.scenario_info)
         launch_cfg_lib.check_communication_vuart(self.args["communication_vuarts"], self.scenario_info)
         launch_cfg_lib.check_enable_ptm(self.args["enable_ptm"], self.scenario_info)
 

--- a/misc/config_tools/scenario_config/scenario_item.py
+++ b/misc/config_tools/scenario_config/scenario_item.py
@@ -399,7 +399,7 @@ class VmInfo:
         scenario_cfg_lib.vm_name_check(self.name, "name")
         scenario_cfg_lib.load_vm_check(self.load_vm, "load_vm")
         scenario_cfg_lib.guest_flag_check(self.guest_flags, "guest_flags", "guest_flag")
-        err_dic = scenario_cfg_lib.vm_cpu_affinity_check(self.scenario_info, self.cpus_per_vm, "pcpu_id")
+        err_dic = scenario_cfg_lib.vm_cpu_affinity_check(self.scenario_info, self.cpus_per_vm)
         scenario_cfg_lib.vcpu_clos_check(self.cpus_per_vm, self.clos_per_vm, self.guest_flags, "clos", "vcpu_clos")
 
         self.mem_info.check_item()


### PR DESCRIPTION
1. ensure cpu affinity in launch xml is subset of its scenario settings.
2. cpu_affinity is a must have parameter for acrn_dm, if the user did not provide cpu affinity in launch xml, load it from scenario settings.

Tracked-On: #6724
Signed-off-by: Weiyi Feng <weiyix.feng@intel.com>