### PR TITLE
hv: initialize and save/restore IA32_TSC_AUX MSR for guest

### DIFF
--- a/hypervisor/arch/x86/guest/trusty.c
+++ b/hypervisor/arch/x86/guest/trusty.c
@@ -149,6 +149,7 @@ static void save_world_ctx(struct acrn_vcpu *vcpu, struct ext_context *ext_ctx)
 	ext_ctx->ia32_lstar = msr_read(MSR_IA32_LSTAR);
 	ext_ctx->ia32_fmask = msr_read(MSR_IA32_FMASK);
 	ext_ctx->ia32_kernel_gs_base = msr_read(MSR_IA32_KERNEL_GS_BASE);
+	ext_ctx->tsc_aux = msr_read(MSR_IA32_TSC_AUX);
 
 	/* XSAVE area */
 	save_xsave_area(vcpu, ext_ctx);
@@ -201,6 +202,7 @@ static void load_world_ctx(struct acrn_vcpu *vcpu, const struct ext_context *ext
 	msr_write(MSR_IA32_LSTAR, ext_ctx->ia32_lstar);
 	msr_write(MSR_IA32_FMASK, ext_ctx->ia32_fmask);
 	msr_write(MSR_IA32_KERNEL_GS_BASE, ext_ctx->ia32_kernel_gs_base);
+	msr_write(MSR_IA32_TSC_AUX, ext_ctx->tsc_aux);
 
 	/* XSAVE area */
 	rstore_xsave_area(vcpu, ext_ctx);

--- a/hypervisor/include/arch/x86/asm/cpu.h
+++ b/hypervisor/include/arch/x86/asm/cpu.h
@@ -411,6 +411,7 @@ struct ext_context {
 
 	uint64_t dr7;
 	uint64_t tsc_offset;
+	uint64_t tsc_aux;
 
 	struct xsave_area xs_area;
 	uint64_t xcr0;

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -581,10 +581,11 @@ void set_vcpu_regs(struct acrn_vcpu *vcpu, struct acrn_regs *vcpu_regs);
  * Reset target vCPU's all registers in run_context to initial values.
  *
  * @param[inout] vcpu pointer to vcpu data structure
+ * @param[in] mode the reset mode
  *
  * @return None
  */
-void reset_vcpu_regs(struct acrn_vcpu *vcpu);
+void reset_vcpu_regs(struct acrn_vcpu *vcpu, enum reset_mode mode);
 
 bool sanitize_cr0_cr4_pattern(void);
 


### PR DESCRIPTION
Commit cbf3825 "hv: Pass-through IA32_TSC_AUX MSR to L1 guest"
lets guest own the physical MSR IA32_TSC_AUX and does not handle this MSR
in the hypervisor.
If multiple vCPUs share the same pCPU, when one vCPU reads MSR IA32_TSC_AUX,
it may get the value set by other vCPUs.

To fix this issue, this patch does:
 - initialize the MSR content to 0 for the given vCPU, which is consistent with
   the value specified in SDM Vol3 "Table 9-1. IA-32 and Intel 64 Processor
   States Following Power-up, Reset, or INIT"
 - save/restore the MSR content for the given vCPU during context switch

v1 -> v2:
 * According to Table 9-1, the content of IA32_TSC_AUX MSR is unchanged
   following INIT, v2 updates the initialization logic so that the content for
   vCPU is consistent with SDM.

Tracked-On: #6799
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>