### PR TITLE
[for v2.7]misc: life_mngr: fix some typo issues

### DIFF
--- a/misc/services/life_mngr/Makefile
+++ b/misc/services/life_mngr/Makefile
@@ -85,5 +85,5 @@ install:
 	[ -d $(CONF_DIR) ] || mkdir -p $(CONF_DIR)
 	install -d $(DESTDIR)$(bindir)
 	install -t $(DESTDIR)$(bindir) $(OUT_DIR)/life_mngr
-	install -t $(DESTDIR)/etc/life_mngr $(OUT_DIR)/life_mngr.conf
+	install -t $(DESTDIR)$(CONF_DIR) $(OUT_DIR)/life_mngr.conf
 	install -p -D -m 0644 $(OUT_DIR)/life_mngr.service $(DESTDIR)$(systemd_unitdir)/system/

--- a/misc/services/life_mngr/command_handler.c
+++ b/misc/services/life_mngr/command_handler.c
@@ -98,7 +98,7 @@ int socket_req_shutdown_service_vm_handler(void *arg, int fd)
 {
 	int ret;
 
-	usleep(LISTEN_INTERVAL + SCECOND_TO_US);
+	usleep(LISTEN_INTERVAL + SECOND_TO_US);
 	ret = send_socket_ack(arg, fd, ACK_REQ_SYS_SHUTDOWN);
 	if (ret < 0)
 		return 0;
@@ -114,7 +114,7 @@ int socket_req_user_vm_shutdown_handler(void *arg, int fd)
 	struct socket_dev *sock = (struct socket_dev *)arg;
 	struct socket_client *client = NULL;
 
-	usleep(LISTEN_INTERVAL + SCECOND_TO_US);
+	usleep(LISTEN_INTERVAL + SECOND_TO_US);
 	client = find_socket_client(sock, fd);
 	if (client == NULL)
 		return -1;
@@ -143,7 +143,7 @@ int socket_req_system_shutdown_user_vm_handler(void *arg, int fd)
 	int ret;
 	struct channel_dev *c_dev = NULL;
 
-	usleep(LISTEN_INTERVAL + SCECOND_TO_US);
+	usleep(LISTEN_INTERVAL + SECOND_TO_US);
 	c_dev = (struct channel_dev *)LIST_FIRST(&channel->tty_conn_head);
 	if (c_dev == NULL) {
 		(void) send_socket_ack(arg, fd, USER_VM_DISCONNECT);
@@ -219,7 +219,7 @@ int req_shutdown_handler(void *arg, int fd)
 								strlen(ACK_REQ_SYS_SHUTDOWN));
 	if (ret < 0)
 		LOG_WRITE("Send acked message to user VM fail\n");
-	usleep(SCECOND_TO_US);
+	usleep(SECOND_TO_US);
 	LOG_PRINTF("Send acked shutdown request message to user VM (%s)\n", c_dev->name);
 	enable_all_uart_channel_dev_resend(c, POWEROFF_CMD, VM_SHUTDOWN_RETRY_TIMES);
 	notify_all_connected_uart_channel_dev(c, POWEROFF_CMD);

--- a/misc/services/life_mngr/uart.h
+++ b/misc/services/life_mngr/uart.h
@@ -13,8 +13,8 @@
 
 #define TTY_PATH_MAX 32U
 
-#define SCECOND_TO_US 1000000
-#define WAIT_RECV (SCECOND_TO_US>>2)
+#define SECOND_TO_US 1000000
+#define WAIT_RECV (SECOND_TO_US>>2)
 #define RETRY_RECV_TIMES 20U
 
 struct uart_dev {

--- a/misc/services/life_mngr/uart_channel.c
+++ b/misc/services/life_mngr/uart_channel.c
@@ -142,7 +142,7 @@ void *poll_and_dispatch_uart_channel_events(void *arg)
 		 */
 		if (num == 0) {
 			if (c_dev->resend_time > 1) {
-				usleep(LISTEN_INTERVAL + SCECOND_TO_US);
+				usleep(LISTEN_INTERVAL + SECOND_TO_US);
 				LOG_PRINTF("Resend (%s) to (%s)\n", c_dev->resend_buf, c_dev->name);
 				ret = send_message_by_uart(c_dev->uart_device, (void *)c_dev->resend_buf,
 								strlen(c_dev->resend_buf));

--- a/misc/services/life_mngr/uart_channel.h
+++ b/misc/services/life_mngr/uart_channel.h
@@ -10,13 +10,13 @@
 #include <sys/un.h>
 #include "uart.h"
 
-#define WAIT_USER_VM_POWEROFF (10*SCECOND_TO_US)
+#define WAIT_USER_VM_POWEROFF (10*SECOND_TO_US)
 
 #define CHANNEL_DEV_NAME_MAX 128U
 #define CHANNEL_DEV_BUF_LEN 256U
 
 #define MIN_RESEND_TIME 3U
-#define LISTEN_INTERVAL (5 * SCECOND_TO_US)
+#define LISTEN_INTERVAL (5 * SECOND_TO_US)
 
 typedef void data_handler_f(const char *cmd_name, int fd);
 


### PR DESCRIPTION
Change macro name:
SCECOND_TO_US --> SECOND_TO_US

Use macro CONF_DIR in Makefile

Tracked-On: #6652
Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>