### PR TITLE
[release_2.7]hv: reset CAT Capacity Bitmask(CBM) MSRs

### DIFF
--- a/hypervisor/include/arch/x86/asm/cpuid.h
+++ b/hypervisor/include/arch/x86/asm/cpuid.h
@@ -142,6 +142,7 @@
 #define CPUID_FEATURES          1U
 #define CPUID_TLB               2U
 #define CPUID_SERIALNUM         3U
+#define CPUID_LEAF_CACHE_TOPOLOGY 4U
 #define CPUID_EXTEND_FEATURE    7U
 #define CPUID_XSAVE_FEATURES   0xDU
 #define CPUID_RDT_ALLOCATION   0x10U


### PR DESCRIPTION
  ACRN get messy default values for some CAT CBM MSRs,
  these unexpected default value will result in TCC
  Software SRAM initializes crash.

  This patch resets above error default values before calling
  CRL(cache reserve library) ABI initializaion function.

Tracked-On: #6780
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>