### PR TITLE
doc: terminology cleanup in RTC virt

### DIFF
--- a/doc/developer-guides/hld/rtc-virt-hld.rst
+++ b/doc/developer-guides/hld/rtc-virt-hld.rst
@@ -3,7 +3,10 @@
 RTC Virtualization
 ##################
 
-This document describes the RTC virtualization implementation in
-ACRN device model.
+This document describes the real-time clock (RTC) virtualization implementation
+in the ACRN Device Model.
 
-vRTC is a read-only RTC for the pre-launched VM, Service OS, and post-launched RT VM. It supports RW for the CMOS address port 0x70 and RO for the CMOS data port 0x71. Reads to the CMOS RAM offsets are fetched by reading the CMOS h/w directly and writes to CMOS offsets are discarded.
+vRTC is a read-only RTC for the pre-launched VM, Service VM, and post-launched
+RTVM. It supports read/write (RW) for the CMOS address port 0x70 and read only
+(RO) for the CMOS data port 0x71. Reads to the CMOS RAM offsets are fetched from
+the CMOS hardware directly. Writes to the CMOS offsets are discarded.


### PR DESCRIPTION
- Replace SOS or Service OS with Service VM
- Clean up some of the grammar

Signed-off-by: Amy Reyes <amy.reyes@intel.com>