### PR TITLE
doc: terminology cleanup in Zephyr tutorial

### DIFF
--- a/doc/tutorials/using_zephyr_as_uos.rst
+++ b/doc/tutorials/using_zephyr_as_uos.rst
@@ -3,12 +3,13 @@
 Run Zephyr as the User VM
 #########################
 
-This tutorial describes how to run Zephyr as the User VM on the ACRN hypervisor. We are using
+This tutorial describes how to run Zephyr as the User VM on the ACRN
+hypervisor. We are using
 Kaby Lake-based Intel NUC (model NUC7i5DNHE) in this tutorial.
 Other :ref:`ACRN supported platforms <hardware>` should work as well.
 
 .. note::
-   This tutorial uses the (default) SDC scenario. If you use a different
+   This tutorial uses the default SDC scenario. If you use a different
    scenario, you will need a serial port connection to your platform to see
    Zephyr console output.
 
@@ -26,15 +27,17 @@ Steps for Using Zephyr as User VM
    Follow the `Zephyr Getting Started Guide <https://docs.zephyrproject.org/latest/getting_started/>`_ to
    set up the Zephyr development environment.
 
-   The build process for ACRN User VM target is similar to other boards. We will build the `Hello World
-   <https://docs.zephyrproject.org/latest/samples/hello_world/README.html>`_ sample for ACRN:
+   The build process for ACRN User VM target is similar to that of other
+   boards. We will build the `Hello World
+   <https://docs.zephyrproject.org/latest/samples/hello_world/README.html>`_
+   sample for ACRN:
 
    .. code-block:: none
 
-      $ cd samples/hello_world
-      $ mkdir build && cd build
-      $ cmake -DBOARD=acrn ..
-      $ make
+      cd samples/hello_world
+      mkdir build && cd build
+      cmake -DBOARD=acrn ..
+      make
 
    This will build the application ELF binary in ``samples/hello_world/build/zephyr/zephyr.elf``.
 
@@ -45,7 +48,7 @@ Steps for Using Zephyr as User VM
 
    .. code-block:: none
 
-      $ ./boards/x86/common/scripts/build_grub.sh x86_64
+      ./boards/x86/common/scripts/build_grub.sh x86_64
 
    The EFI executable binary will be found at ``boards/x86/common/scripts/grub/bin/grub_x86_64.efi``.
 
@@ -53,23 +56,23 @@ Steps for Using Zephyr as User VM
 
    .. code-block:: none
 
-      $ dd if=/dev/zero of=zephyr.img bs=1M count=35
-      $ mkfs.vfat -F 32 zephyr.img
-      $ sudo mount `sudo losetup -f -P --show zephyr.img` /mnt
+      dd if=/dev/zero of=zephyr.img bs=1M count=35
+      mkfs.vfat -F 32 zephyr.img
+      sudo mount `sudo losetup -f -P --show zephyr.img` /mnt
 
    Create the following directories.
 
    .. code-block:: none
 
-      $ sudo mkdir -p /mnt/efi/boot
-      $ sudo mkdir -p /mnt/kernel
+      sudo mkdir -p /mnt/efi/boot
+      sudo mkdir -p /mnt/kernel
 
    Copy ``zephyr.elf`` and ``grub_x86_64.efi``
 
    .. code-block:: none
 
-      $ sudo cp boards/x86/common/scripts/grub/bin/grub_x86_64.efi /mnt/efi/boot/bootx64.efi
-      $ sudo cp samples/hello_world/build/zephyr/zephyr.elf /mnt/kernel
+      sudo cp boards/x86/common/scripts/grub/bin/grub_x86_64.efi /mnt/efi/boot/bootx64.efi
+      sudo cp samples/hello_world/build/zephyr/zephyr.elf /mnt/kernel
 
    Create ``/mnt/efi/boot/grub.cfg`` containing the following:
 
@@ -86,15 +89,14 @@ Steps for Using Zephyr as User VM
 
    .. code-block:: none
 
-      $ sudo umount /mnt
+      sudo umount /mnt
 
-   You now have a virtual disk image with a bootable Zephyr in ``zephyr.img``. If the Zephyr build system is not
+   You now have a virtual disk image with a bootable Zephyr in ``zephyr.img``.
+   If the Zephyr build system is not
    the ACRN Service VM, then you will need to transfer this image to the
-   ACRN Service VM (via, e.g, a USB drive or network)
+   ACRN Service VM (via, e.g., a USB drive or network).
 
-#. Follow :ref:`gsg`
-   to boot "The ACRN Service OS" based on Ubnuntu OS (ACRN tag: v2.2)
-
+#. Follow :ref:`gsg` to boot the Service VM based on Ubuntu OS (ACRN tag: v2.2)
 
 #. Boot Zephyr as User VM
 
@@ -102,16 +104,17 @@ Steps for Using Zephyr as User VM
 
    .. code-block:: none
 
-      $ mkdir zephyr && cd zephyr
-      $ cp /usr/share/acrn/samples/nuc/launch_zephyr.sh .
+      mkdir zephyr && cd zephyr
+      cp /usr/share/acrn/samples/nuc/launch_zephyr.sh .
 
-   You will also need to copy the ``zephyr.img`` created in the above section into directory ``zephyr``.
+   Copy the ``zephyr.img`` created in the above section into directory
+   ``zephyr``.
 
    Run the ``launch_zephyr.sh`` script to launch Zephyr as User VM.
 
    .. code-block:: none
 
-      $ sudo ./launch_zephyr.sh
+      sudo ./launch_zephyr.sh
 
    Then Zephyr will boot automatically. You will see a console message from the hello_world sample application:
 


### PR DESCRIPTION
- Replace SOS or Service OS with Service VM
- Clean up some of the grammar

Signed-off-by: Amy Reyes <amy.reyes@intel.com>