### PR TITLE
HV: fix build issue on RELEASE version

### DIFF
--- a/hypervisor/common/efi_mmap.c
+++ b/hypervisor/common/efi_mmap.c
@@ -38,9 +38,8 @@ void init_efi_mmap_entries(struct efi_info *uefi_info)
 	void *efi_memmap = (void *)((uint64_t)uefi_info->memmap | ((uint64_t)uefi_info->memmap_hi << 32U));
 	struct efi_memory_desc *efi_memdesc = (struct efi_memory_desc *)efi_memmap;
 	uint32_t entry = 0U;
-	uint32_t efi_memdesc_nr = uefi_info->memmap_size / uefi_info->memdesc_size;
 
-	ASSERT(efi_memdesc_nr <= MAX_EFI_MMAP_ENTRIES);
+	ASSERT((uefi_info->memmap_size / uefi_info->memdesc_size) <= MAX_EFI_MMAP_ENTRIES);
 
 	while ((void *)efi_memdesc < (efi_memmap + uefi_info->memmap_size)) {
 		hv_memdesc[entry] = *efi_memdesc;


### PR DESCRIPTION
The HV will be built failed with below compiler message:

  common/efi_mmap.c: In function ‘init_efi_mmap_entries’:
  common/efi_mmap.c:41:11: error: unused variable ‘efi_memdesc_nr’
			[-Werror=unused-variable]
  uint32_t efi_memdesc_nr = uefi_info->memmap_size / uefi_info->memdesc_size;
  ^~~~~~~~~~~~~~
  cc1: all warnings being treated as errors

The root cause is ASSERT() api is for DEBUG only so efi_memdesc_nr is not used
in RELEASE code.

The patch fix this issue by removing efi_memdesc_nr declaration;

Tracked-On: #6834

Signed-off-by: Victor Sun <victor.sun@intel.com>