### PR TITLE
config_tools: remove GUEST_FLAG_SECURITY_VM in DM_OWNED_GUEST_FLAG_MASK

### DIFF
--- a/misc/config_tools/xforms/vm_configurations.h.xsl
+++ b/misc/config_tools/xforms/vm_configurations.h.xsl
@@ -50,7 +50,7 @@
       <xsl:when test="count(vm[vm_type='SERVICE_VM'])">
         <xsl:value-of select="acrn:comment('Bitmask of guest flags that can be programmed by device model. Other bits are set by hypervisor only.')" />
         <xsl:value-of select="$newline" />
-        <xsl:value-of select="acrn:define('DM_OWNED_GUEST_FLAG_MASK', '(GUEST_FLAG_SECURE_WORLD_ENABLED | GUEST_FLAG_LAPIC_PASSTHROUGH | GUEST_FLAG_RT | GUEST_FLAG_IO_COMPLETION_POLLING | GUEST_FLAG_SECURITY_VM)', '')" />
+        <xsl:value-of select="acrn:define('DM_OWNED_GUEST_FLAG_MASK', '(GUEST_FLAG_SECURE_WORLD_ENABLED | GUEST_FLAG_LAPIC_PASSTHROUGH | GUEST_FLAG_RT | GUEST_FLAG_IO_COMPLETION_POLLING)', '')" />
       </xsl:when>
       <xsl:otherwise>
       <xsl:value-of select="acrn:define('DM_OWNED_GUEST_FLAG_MASK', '0', 'UL')" />


### PR DESCRIPTION
GUEST_FLAG_SECURITY_VM only for pre-launch vm, should not be
programmed by device model, so we remove it in DM_OWNED_GUEST_FLAG_MASK.

Tracked-On: #6366
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>