### PR TITLE
hv: Add x86 TEE support

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -22,6 +22,7 @@ HW_MOD = $(HV_MODDIR)/hw_mod.a
 VP_BASE_MOD = $(HV_MODDIR)/vp_base_mod.a
 VP_DM_MOD = $(HV_MODDIR)/vp_dm_mod.a
 VP_TRUSTY_MOD = $(HV_MODDIR)/vp_trusty_mod.a
+VP_X86_TEE_MOD = $(HV_MODDIR)/vp_x86_tee_mod.a
 VP_HCALL_MOD = $(HV_MODDIR)/vp_hcall_mod.a
 LIB_DEBUG = $(HV_MODDIR)/libdebug.a
 LIB_RELEASE = $(HV_MODDIR)/librelease.a
@@ -342,6 +343,9 @@ VP_TRUSTY_C_SRCS += arch/x86/seed/seed.c
 VP_TRUSTY_C_SRCS += arch/x86/seed/seed_abl.c
 VP_TRUSTY_C_SRCS += arch/x86/seed/seed_sbl.c
 
+# x86 tee support
+VP_X86_TEE_C_SRCS += arch/x86/guest/optee.c
+
 # virtual platform hypercall
 VP_HCALL_C_SRCS += arch/x86/guest/vmcall.c
 VP_HCALL_C_SRCS += common/hypercall.c
@@ -360,6 +364,7 @@ VP_BASE_C_OBJS := $(patsubst %.c,$(HV_OBJDIR)/%.o,$(VP_BASE_C_SRCS))
 VP_BASE_S_OBJS := $(patsubst %.S,$(HV_OBJDIR)/%.o,$(VP_BASE_S_SRCS))
 VP_DM_C_OBJS := $(patsubst %.c,$(HV_OBJDIR)/%.o,$(VP_DM_C_SRCS))
 VP_TRUSTY_C_OBJS := $(patsubst %.c,$(HV_OBJDIR)/%.o,$(VP_TRUSTY_C_SRCS))
+VP_X86_TEE_C_OBJS := $(patsubst %.c,$(HV_OBJDIR)/%.o,$(VP_X86_TEE_C_SRCS))
 VP_HCALL_C_OBJS := $(patsubst %.c,$(HV_OBJDIR)/%.o,$(VP_HCALL_C_SRCS))
 SYS_INIT_C_OBJS := $(patsubst %.c,$(HV_OBJDIR)/%.o,$(SYS_INIT_C_SRCS))
 
@@ -373,6 +378,7 @@ MODULES += $(HW_MOD)
 MODULES += $(VP_BASE_MOD)
 MODULES += $(VP_DM_MOD)
 MODULES += $(VP_TRUSTY_MOD)
+MODULES += $(VP_X86_TEE_MOD)
 MODULES += $(VP_HCALL_MOD)
 ifeq ($(CONFIG_RELEASE),y)
 MODULES += $(LIB_RELEASE)
@@ -420,7 +426,7 @@ pre_build: $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)
 .PHONY: header
 header: $(VERSION) $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)
 
-.PHONY: lib-mod boot-mod hw-mod vp-base-mod vp-dm-mod vp-trusty-mod vp-hcall-mod sys-init-mod
+.PHONY: lib-mod boot-mod hw-mod vp-base-mod vp-dm-mod vp-trusty-mod vp-x86tee-mod vp-hcall-mod sys-init-mod
 $(LIB_MOD): $(LIB_C_OBJS) $(LIB_S_OBJS)
 	$(AR) $(ARFLAGS) $(LIB_MOD) $(LIB_C_OBJS) $(LIB_S_OBJS)
 
@@ -450,6 +456,11 @@ $(VP_TRUSTY_MOD): $(VP_TRUSTY_C_OBJS)
 	$(AR) $(ARFLAGS) $(VP_TRUSTY_MOD) $(VP_TRUSTY_C_OBJS)
 
 vp-trusty-mod: $(VP_TRUSTY_MOD)
+
+$(VP_X86_TEE_MOD): $(VP_X86_TEE_C_OBJS)
+	$(AR) $(ARFLAGS) $(VP_X86_TEE_MOD) $(VP_X86_TEE_C_OBJS)
+
+vp-x86tee-mod: $(VP_X86_TEE_MOD)
 
 $(VP_HCALL_MOD): $(VP_HCALL_C_OBJS)
 	$(AR) $(ARFLAGS) $(VP_HCALL_MOD) $(VP_HCALL_C_OBJS)

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -14,6 +14,7 @@
 #include <asm/ioapic.h>
 #include <asm/pgtable.h>
 #include <asm/irq.h>
+#include <asm/guest/optee.h>
 
 /*
  * Check if the IRQ is single-destination and return the destination vCPU if so.
@@ -534,6 +535,8 @@ void ptirq_softirq(uint16_t pcpu_id)
 					vmsi->addr.full, vmsi->data.full);
 			}
 		}
+
+		handle_x86_tee_int(entry, pcpu_id);
 	}
 }
 

--- a/hypervisor/arch/x86/guest/optee.c
+++ b/hypervisor/arch/x86/guest/optee.c
@@ -12,6 +12,7 @@
 #include <asm/trampoline.h>
 #include <reloc.h>
 #include <hypercall.h>
+#include <logmsg.h>
 
 void prepare_tee_vm_memmap(struct acrn_vm *vm, const struct acrn_vm_config *vm_config)
 {
@@ -35,14 +36,112 @@ void prepare_tee_vm_memmap(struct acrn_vm *vm, const struct acrn_vm_config *vm_c
 	}
 }
 
+static struct acrn_vm *get_companion_vm(struct acrn_vm *vm)
+{
+	return get_vm_from_vmid(get_vm_config(vm->vm_id)->companion_vm_id);
+}
+
+static int32_t tee_switch_to_ree(struct acrn_vcpu *vcpu)
+{
+	uint64_t rdi, rsi, rdx, rbx;
+	struct acrn_vm *ree_vm;
+	struct acrn_vcpu *ree_vcpu;
+	int32_t ret = -EINVAL;
+
+	rdi = vcpu_get_gpreg(vcpu, CPU_REG_RDI);
+	rsi = vcpu_get_gpreg(vcpu, CPU_REG_RSI);
+	rdx = vcpu_get_gpreg(vcpu, CPU_REG_RDX);
+	rbx = vcpu_get_gpreg(vcpu, CPU_REG_RBX);
+
+	ree_vm = get_companion_vm(vcpu->vm);
+	ree_vcpu = vcpu_from_pid(ree_vm, get_pcpu_id());
+
+	if (ree_vcpu != NULL) {
+		/*
+		 * We should avoid copy any values to REE registers,
+		 * If this is a FIQ return.
+		 */
+		if (rdi != OPTEE_RETURN_FIQ_DONE) {
+			vcpu_set_gpreg(ree_vcpu, CPU_REG_RDI, rdi);
+			vcpu_set_gpreg(ree_vcpu, CPU_REG_RSI, rsi);
+			vcpu_set_gpreg(ree_vcpu, CPU_REG_RDX, rdx);
+			vcpu_set_gpreg(ree_vcpu, CPU_REG_RBX, rbx);
+		}
+
+		sleep_thread(&vcpu->thread_obj);
+		ret = 0;
+	} else {
+		pr_fatal("No REE vCPU running on this pCPU%u, \n", get_pcpu_id());
+	}
+
+	return ret;
+}
+
+static int32_t ree_switch_to_tee(struct acrn_vcpu *vcpu)
+{
+	uint64_t rax, rdi, rsi, rdx, rbx, rcx;
+	struct acrn_vm *tee_vm;
+	struct acrn_vcpu *tee_vcpu;
+	int32_t ret = -EINVAL;
+
+	rax = vcpu_get_gpreg(vcpu, CPU_REG_RAX);
+	rdi = vcpu_get_gpreg(vcpu, CPU_REG_RDI);
+	rsi = vcpu_get_gpreg(vcpu, CPU_REG_RSI);
+	rdx = vcpu_get_gpreg(vcpu, CPU_REG_RDX);
+	rbx = vcpu_get_gpreg(vcpu, CPU_REG_RBX);
+	rcx = vcpu_get_gpreg(vcpu, CPU_REG_RCX);
+
+	tee_vm = get_companion_vm(vcpu->vm);
+	tee_vcpu = vcpu_from_pid(tee_vm, get_pcpu_id());
+	if (tee_vcpu != NULL) {
+		vcpu_set_gpreg(tee_vcpu, CPU_REG_RAX, rax);
+		vcpu_set_gpreg(tee_vcpu, CPU_REG_RDI, rdi);
+		vcpu_set_gpreg(tee_vcpu, CPU_REG_RSI, rsi);
+		vcpu_set_gpreg(tee_vcpu, CPU_REG_RDX, rdx);
+		vcpu_set_gpreg(tee_vcpu, CPU_REG_RBX, rbx);
+		vcpu_set_gpreg(tee_vcpu, CPU_REG_RCX, rcx);
+
+		wake_thread(&tee_vcpu->thread_obj);
+
+		ret = 0;
+	} else {
+		pr_fatal("No TEE vCPU running on this pCPU%u, \n", get_pcpu_id());
+	}
+
+	return ret;
+}
+
 int32_t hcall_handle_tee_vcpu_boot_done(struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
 		__unused uint64_t param1, __unused uint64_t param2)
 {
+	struct acrn_vm *ree_vm;
+	uint64_t rdi;
+
+	/*
+	 * The (RDI == 1) indicates to start REE VM, otherwise only need
+	 * to sleep the corresponding TEE vCPU.
+	 */
+	rdi = vcpu_get_gpreg(vcpu, CPU_REG_RDI);
+	if (rdi == 1UL) {
+		ree_vm = get_companion_vm(vcpu->vm);
+		start_vm(ree_vm);
+	}
+
+	sleep_thread(&vcpu->thread_obj);
+
 	return 0;
 }
 
 int32_t hcall_switch_ee(struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
 		__unused uint64_t param1, __unused uint64_t param2)
 {
-	return 0;
+	int32_t ret = 0;
+
+	if ((get_vm_config(vcpu->vm->vm_id)->guest_flags & GUEST_FLAG_TEE) != 0U) {
+		ret = tee_switch_to_ree(vcpu);
+	} else if ((get_vm_config(vcpu->vm->vm_id)->guest_flags & GUEST_FLAG_REE) != 0U) {
+		ret = ree_switch_to_tee(vcpu);
+	}
+
+	return ret;
 }

--- a/hypervisor/arch/x86/guest/optee.c
+++ b/hypervisor/arch/x86/guest/optee.c
@@ -11,6 +11,7 @@
 #include <asm/guest/optee.h>
 #include <asm/trampoline.h>
 #include <reloc.h>
+#include <hypercall.h>
 
 void prepare_tee_vm_memmap(struct acrn_vm *vm, const struct acrn_vm_config *vm_config)
 {
@@ -32,4 +33,16 @@ void prepare_tee_vm_memmap(struct acrn_vm *vm, const struct acrn_vm_config *vm_c
 		hv_hpa = hva2hpa((void *)(get_hv_image_base()));
 		ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, hv_hpa, get_hv_ram_size());
 	}
+}
+
+int32_t hcall_handle_tee_vcpu_boot_done(struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
+		__unused uint64_t param1, __unused uint64_t param2)
+{
+	return 0;
+}
+
+int32_t hcall_switch_ee(struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
+		__unused uint64_t param1, __unused uint64_t param2)
+{
+	return 0;
 }

--- a/hypervisor/arch/x86/guest/optee.c
+++ b/hypervisor/arch/x86/guest/optee.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <asm/guest/vm.h>
+#include <asm/guest/ept.h>
+#include <asm/vm_config.h>
+#include <asm/mmu.h>
+#include <asm/guest/optee.h>
+#include <asm/trampoline.h>
+#include <reloc.h>
+
+void prepare_tee_vm_memmap(struct acrn_vm *vm, const struct acrn_vm_config *vm_config)
+{
+	uint64_t hv_hpa;
+
+	/*
+	 * Only need to map following things, let init_vpci to map the secure devices
+	 * if any.
+	 *
+	 * 1. go through physical e820 table, to ept add all system memory entries.
+	 * 2. remove hv owned memory.
+	 */
+	if ((vm_config->guest_flags & GUEST_FLAG_TEE) != 0U) {
+		vm->e820_entry_num = get_e820_entries_count();
+		vm->e820_entries = (struct e820_entry *)get_e820_entry();
+
+		prepare_vm_identical_memmap(vm, E820_TYPE_RAM, EPT_WB | EPT_RWX);
+
+		hv_hpa = hva2hpa((void *)(get_hv_image_base()));
+		ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, hv_hpa, get_hv_ram_size());
+	}
+}

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -551,6 +551,24 @@ static uint64_t lapic_pt_enabled_pcpu_bitmap(struct acrn_vm *vm)
 	return bitmap;
 }
 
+void prepare_vm_identical_memmap(struct acrn_vm *vm, uint16_t e820_entry_type, uint64_t prot_orig)
+{
+	const struct e820_entry *entry;
+	const struct e820_entry *p_e820 = vm->e820_entries;
+	uint32_t entries_count = vm->e820_entry_num;
+	uint64_t *pml4_page = (uint64_t *)vm->arch_vm.nworld_eptp;
+	uint32_t i;
+
+	for (i = 0U; i < entries_count; i++) {
+		entry = p_e820 + i;
+		if (entry->type == e820_entry_type) {
+			ept_add_mr(vm, pml4_page, entry->baseaddr,
+				entry->baseaddr, entry->length,
+				prot_orig);
+		}
+	}
+}
+
 /**
  * @pre vm_id < CONFIG_MAX_VM_NUM && vm_config != NULL && rtn_vm != NULL
  * @pre vm->state == VM_POWERED_OFF

--- a/hypervisor/include/arch/x86/asm/guest/optee.h
+++ b/hypervisor/include/arch/x86/asm/guest/optee.h
@@ -10,6 +10,9 @@
 #include <asm/guest/vm.h>
 #include <asm/vm_config.h>
 
+/* If the RDI equals to this value, then this is a RETURN after FIQ DONE */
+#define OPTEE_RETURN_FIQ_DONE	0xBE000006UL
+
 void prepare_tee_vm_memmap(struct acrn_vm *vm, const struct acrn_vm_config *vm_config);
 
 #endif /* TEE_H_ */

--- a/hypervisor/include/arch/x86/asm/guest/optee.h
+++ b/hypervisor/include/arch/x86/asm/guest/optee.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TEE_H_
+#define TEE_H_
+
+#include <asm/guest/vm.h>
+#include <asm/vm_config.h>
+
+void prepare_tee_vm_memmap(struct acrn_vm *vm, const struct acrn_vm_config *vm_config);
+
+#endif /* TEE_H_ */

--- a/hypervisor/include/arch/x86/asm/guest/optee.h
+++ b/hypervisor/include/arch/x86/asm/guest/optee.h
@@ -9,10 +9,17 @@
 
 #include <asm/guest/vm.h>
 #include <asm/vm_config.h>
+#include <ptdev.h>
+
+#define TEE_NOTIFICATION_VECTOR 0x29U
 
 /* If the RDI equals to this value, then this is a RETURN after FIQ DONE */
 #define OPTEE_RETURN_FIQ_DONE	0xBE000006UL
 
+/* This value tells OPTEE that this switch to TEE is due to secure interrupt */
+#define OPTEE_FIQ_ENTRY	0xB20000FFUL
+
 void prepare_tee_vm_memmap(struct acrn_vm *vm, const struct acrn_vm_config *vm_config);
+void handle_x86_tee_int(struct ptirq_remapping_info *entry, uint16_t pcpu_id);
 
 #endif /* TEE_H_ */

--- a/hypervisor/include/arch/x86/asm/guest/vm.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm.h
@@ -233,7 +233,7 @@ void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec);
 void start_vm(struct acrn_vm *vm);
 int32_t reset_vm(struct acrn_vm *vm);
 int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *vm_config, struct acrn_vm **rtn_vm);
-void prepare_vm(uint16_t vm_id, struct acrn_vm_config *vm_config);
+int32_t prepare_vm(uint16_t vm_id, struct acrn_vm_config *vm_config);
 void launch_vms(uint16_t pcpu_id);
 bool is_poweroff_vm(const struct acrn_vm *vm);
 bool is_created_vm(const struct acrn_vm *vm);

--- a/hypervisor/include/arch/x86/asm/guest/vm.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm.h
@@ -247,6 +247,7 @@ struct acrn_vm *get_service_vm(void);
 
 void create_service_vm_e820(struct acrn_vm *vm);
 void create_prelaunched_vm_e820(struct acrn_vm *vm);
+void prepare_vm_identical_memmap(struct acrn_vm *vm, uint16_t e820_entry_type, uint64_t prot_orig);
 uint64_t find_space_from_ve820(struct acrn_vm *vm, uint32_t size, uint64_t min_addr, uint64_t max_addr);
 
 int32_t prepare_os_image(struct acrn_vm *vm);

--- a/hypervisor/include/arch/x86/asm/vm_config.h
+++ b/hypervisor/include/arch/x86/asm/vm_config.h
@@ -156,6 +156,7 @@ struct acrn_vm_config {
 							 * We could add more guest flags in future;
 							 */
 	uint32_t vm_prio;				/* The priority for VM vCPU scheduling */
+	uint16_t companion_vm_id;			/* The companion VM id for this VM */
 	struct acrn_vm_mem_config memory;		/* memory configuration of VM */
 	struct epc_section epc;				/* EPC memory configuration of VM */
 	uint16_t pci_dev_num;				/* indicate how many PCI devices in VM */

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -478,6 +478,32 @@ int32_t hcall_save_restore_sworld_ctx(struct acrn_vcpu *vcpu, struct acrn_vm *ta
 		uint64_t param1, uint64_t param2);
 
 /**
+ * @brief Handle the TEE boot done signal.
+ *
+ * @param vcpu Pointer to VCPU data structure
+ * @param target_vm not used
+ * @param param1 not used
+ * @param param2 not used
+ *
+ * @return 0 on success, non-zero on error.
+ */
+int32_t hcall_handle_tee_vcpu_boot_done(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm,
+		uint64_t param1, uint64_t param2);
+
+/**
+ * @brief Switch the execution environment.
+ *
+ * @param vcpu Pointer to VCPU data structure
+ * @param target_vm not used
+ * @param param1 not used
+ * @param param2 not used
+ *
+ * @return 0 on success, non-zero on error.
+ */
+int32_t hcall_switch_ee(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm,
+		uint64_t param1, uint64_t param2);
+
+/**
  * @}
  */
 /* End of trusty_hypercall */

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -59,6 +59,8 @@
 #define GUEST_FLAG_SECURITY_VM			(1UL << 6U)	/* Whether this VM needs to do security-vm related fixup (TPM2 and SMBIOS pt) */
 #define GUEST_FLAG_VCAT_ENABLED			(1UL << 7U)	/* Whether this VM supports vCAT */
 #define GUEST_FLAG_STATIC_VM       (1UL << 8U)  /* Whether this VM uses static VM configuration */
+#define GUEST_FLAG_TEE				(1UL << 9U)	/* Whether the VM is TEE VM */
+#define GUEST_FLAG_REE				(1UL << 10U)	/* Whether the VM is REE VM */
 
 /* TODO: We may need to get this addr from guest ACPI instead of hardcode here */
 #define VIRTUAL_SLEEP_CTL_ADDR		0x400U /* Pre-launched VM uses ACPI reduced HW mode and sleep control register */

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -89,6 +89,11 @@
 #define HC_ID_PM_BASE               0x80UL
 #define HC_PM_GET_CPU_STATE         BASE_HC_ID(HC_ID, HC_ID_PM_BASE + 0x00UL)
 
+/* X86 TEE */
+#define HC_ID_TEE_BASE              0x90UL
+#define HC_TEE_VCPU_BOOT_DONE	    BASE_HC_ID(HC_ID, HC_ID_TEE_BASE + 0x00UL)
+#define HC_SWITCH_EE		    BASE_HC_ID(HC_ID, HC_ID_TEE_BASE + 0x01UL)
+
 #define ACRN_INVALID_VMID (0xffffU)
 #define ACRN_INVALID_HPA (~0UL)
 

--- a/misc/config_tools/library/common.py
+++ b/misc/config_tools/library/common.py
@@ -23,7 +23,8 @@ DATACHECK_SCHEMA_FILE = SOURCE_ROOT_DIR + 'misc/config_tools/schema/datachecks.x
 PY_CACHES = ["__pycache__", "../board_config/__pycache__", "../scenario_config/__pycache__"]
 GUEST_FLAG = ["0", "0UL", "GUEST_FLAG_SECURE_WORLD_ENABLED", "GUEST_FLAG_LAPIC_PASSTHROUGH",
               "GUEST_FLAG_IO_COMPLETION_POLLING", "GUEST_FLAG_NVMX_ENABLED", "GUEST_FLAG_HIDE_MTRR",
-              "GUEST_FLAG_RT", "GUEST_FLAG_SECURITY_VM", "GUEST_FLAG_VCAT_ENABLED"]
+              "GUEST_FLAG_RT", "GUEST_FLAG_SECURITY_VM", "GUEST_FLAG_VCAT_ENABLED",
+              "GUEST_FLAG_TEE", "GUEST_FLAG_REE"]
 
 MULTI_ITEM = ["guest_flag", "pcpu_id", "vcpu_clos", "input", "block", "network", "pci_dev", "shm_region", "communication_vuart"]
 

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -52,6 +52,8 @@
     <xs:enumeration value="GUEST_FLAG_NVMX_ENABLED" />
     <xs:enumeration value="GUEST_FLAG_SECURITY_VM" />
     <xs:enumeration value="GUEST_FLAG_VCAT_ENABLED" />
+    <xs:enumeration value="GUEST_FLAG_TEE" />
+    <xs:enumeration value="GUEST_FLAG_REE" />
   </xs:restriction>
 </xs:simpleType>
 

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -396,6 +396,11 @@ Refer SDM 17.19.2 for details, and use with caution.</xs:documentation>
         <xs:documentation>Specify the VM vCPU priority for scheduling.</xs:documentation>
       </xs:annotation>
     </xs:element>
+    <xs:element name="companion_vmid" type="xs:integer" default="65535">
+      <xs:annotation>
+        <xs:documentation>Specify the companion VM id of this VM.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
     <xs:element name="os_config" type="OSConfigurations" minOccurs="0">
       <xs:annotation>
         <xs:documentation>General information for host kernel, boot

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -88,6 +88,7 @@
       <xsl:value-of select="$newline" />
     </xsl:if>
     <xsl:value-of select="acrn:initializer('vm_prio', priority)" />
+    <xsl:value-of select="acrn:initializer('companion_vm_id', concat(companion_vmid, 'U'))" />
     <xsl:apply-templates select="guest_flags" />
 
     <xsl:if test="acrn:is-rdt-enabled()">


### PR DESCRIPTION
This PR contains patches that fixes the v4 of Deng Jie's x86_tee patch series.

One minor change from his original version: 

In hv: tee: Support the concept of companion VM, a default value of 65535 is added as companion_vmid for successful compilation.