### PR TITLE
Port UUID changes to release v2.7 branch

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -1007,8 +1007,8 @@ main(int argc, char *argv[])
 
 	vmname = argv[0];
 
-	if (strnlen(vmname, MAX_VMNAME_LEN) >= MAX_VMNAME_LEN) {
-		pr_err("The name of the VM exceeds the maximum length: %u\n", MAX_VMNAME_LEN - 1);
+	if (strnlen(vmname, MAX_VM_NAME_LEN) >= MAX_VM_NAME_LEN) {
+		pr_err("The name of the VM exceeds the maximum length: %u\n", MAX_VM_NAME_LEN - 1);
 		exit(1);
 	}
 

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -210,7 +210,7 @@ vm_create(const char *name, uint64_t req_buf, int *vcpu_num)
 
 	/* command line arguments specified CPU affinity could overwrite HV's static configuration */
 	create_vm.cpu_affinity = cpu_affinity_bitmap;
-	strncpy((char *)create_vm.name, name, strnlen(name, MAX_VMNAME_LEN));
+	strncpy((char *)create_vm.name, name, strnlen(name, MAX_VM_NAME_LEN));
 
 	if (is_rtvm) {
 		create_vm.vm_flag |= GUEST_FLAG_RT;

--- a/devicemodel/hw/platform/ioc.c
+++ b/devicemodel/hw/platform/ioc.c
@@ -91,7 +91,7 @@ typedef void* (*ioc_work)(void *arg);
  * IOC mediator and virtual UART communication channel path,
  * comes from DM command line parameters.
  */
-static char virtual_uart_path[32 + MAX_VMNAME_LEN];
+static char virtual_uart_path[32 + MAX_VM_NAME_LEN];
 
 /*
  * To activate CBC signal channel(/dev/cbc-signals).

--- a/devicemodel/include/dm.h
+++ b/devicemodel/include/dm.h
@@ -32,8 +32,7 @@
 #include <stdbool.h>
 #include "types.h"
 #include "dm_string.h"
-
-#define MAX_VMNAME_LEN	16U
+#include "acrn_common.h"
 
 struct vmctx;
 extern uint8_t trusty_enabled;

--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -36,17 +36,3 @@ bool vm_has_matched_name(uint16_t vmid, const char *name)
 
 	return (strncmp(vm_config->name, name, MAX_VM_NAME_LEN) == 0);
 }
-
-uint16_t get_unused_vmid(void)
-{
-	uint16_t vm_id;
-	struct acrn_vm_config *vm_config;
-
-	for (vm_id = 0; vm_id < CONFIG_MAX_VM_NUM; vm_id++) {
-		vm_config = get_vm_config(vm_id);
-		if (vm_config->name[0] == '\0') {
-			break;
-		}
-	}
-	return (vm_id < CONFIG_MAX_VM_NUM) ? (vm_id) : (ACRN_INVALID_VMID);
-}

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -116,9 +116,7 @@ uint16_t allocate_dynamical_vmid(struct acrn_vm_creation *cv)
 	if (vm_id != ACRN_INVALID_VMID) {
 		vm_config = get_vm_config(vm_id);
 		memcpy_s(vm_config->name, MAX_VM_NAME_LEN, cv->name, MAX_VM_NAME_LEN);
-		vm_config->guest_flags = (cv->vm_flag | GUEST_FLAG_DYN_VM_CFG);
 		vm_config->cpu_affinity = cv->cpu_affinity;
-		vm_config->load_order = POST_LAUNCHED_VM;
 	}
 	spinlock_release(&vm_id_lock);
 	return vm_id;
@@ -143,12 +141,12 @@ struct acrn_vm *parse_target_vm(struct acrn_vm *service_vm, uint64_t hcall_id, u
 			 */
 			if (vm_id == ACRN_INVALID_VMID) {
 				vm_id = allocate_dynamical_vmid(&cv);
-			}
-			/* it doesn't find the available vm_slot for the given vm_name.
-			 * Maybe the CONFIG_MAX_VM_NUM is too small to start the VM.
-			 */
-			if (vm_id == ACRN_INVALID_VMID) {
-				pr_err("The VM name provided (%s) is invalid, cannot create VM", cv.name);
+				/* it doesn't find the available vm_slot for the given vm_name.
+				 * Maybe the CONFIG_MAX_VM_NUM is too small to start the VM.
+				 */
+				if (vm_id == ACRN_INVALID_VMID) {
+					pr_err("The VM name provided (%s) is invalid, cannot create VM", cv.name);
+				}
 			}
 		}
 		break;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -259,6 +259,7 @@ int32_t hcall_create_vm(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint6
 		if (is_poweroff_vm(get_vm_from_vmid(vmid))) {
 
 			/* Filter out the bits should not set by DM and then assign it to guest_flags */
+			vm_config->guest_flags &= ~DM_OWNED_GUEST_FLAG_MASK;
 			vm_config->guest_flags |= (cv.vm_flag & DM_OWNED_GUEST_FLAG_MASK);
 
 			/* post-launched VM is allowed to choose pCPUs from vm_config->cpu_affinity only */
@@ -298,9 +299,8 @@ int32_t hcall_create_vm(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint6
 
 	}
 
-	if (((ret != 0) || (cv.vmid == ACRN_INVALID_VMID))
-			&& (vm_config->guest_flags & GUEST_FLAG_DYN_VM_CFG) != 0UL) {
-		memset(vm_config, 0U, sizeof(struct acrn_vm_config));
+	if (((ret != 0) || (cv.vmid == ACRN_INVALID_VMID)) && (!is_static_configured_vm(target_vm))) {
+		memset(vm_config->name, 0U, MAX_VM_NAME_LEN);
 	}
 
 	return ret;

--- a/hypervisor/include/arch/x86/asm/guest/vm.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm.h
@@ -257,6 +257,8 @@ bool is_lapic_pt_configured(const struct acrn_vm *vm);
 bool is_rt_vm(const struct acrn_vm *vm);
 bool is_nvmx_configured(const struct acrn_vm *vm);
 bool is_vcat_configured(const struct acrn_vm *vm);
+bool is_static_configured_vm(const struct acrn_vm *vm);
+uint16_t get_unused_vmid(void);
 bool is_pi_capable(const struct acrn_vm *vm);
 bool has_rt_vm(void);
 struct acrn_vm *get_highest_severity_vm(bool runtime);

--- a/hypervisor/include/arch/x86/asm/vm_config.h
+++ b/hypervisor/include/arch/x86/asm/vm_config.h
@@ -37,19 +37,19 @@
 #define CONFIG_SERVICE_VM	.load_order = SERVICE_VM,	\
 				.severity = SEVERITY_SERVICE_VM
 
-#define CONFIG_SAFETY_VM(idx)	.load_order = PRE_LAUNCHED_VM,	\
+#define CONFIG_SAFETY_VM	.load_order = PRE_LAUNCHED_VM,	\
 				.severity = SEVERITY_SAFETY_VM
 
-#define CONFIG_PRE_STD_VM(idx)	.load_order = PRE_LAUNCHED_VM,	\
+#define CONFIG_PRE_STD_VM	.load_order = PRE_LAUNCHED_VM,	\
 				.severity = SEVERITY_STANDARD_VM
 
-#define CONFIG_PRE_RT_VM(idx)	.load_order = PRE_LAUNCHED_VM,	\
+#define CONFIG_PRE_RT_VM	.load_order = PRE_LAUNCHED_VM,	\
 				.severity = SEVERITY_RTVM
 
-#define CONFIG_POST_STD_VM(idx)	.load_order = POST_LAUNCHED_VM,	\
+#define CONFIG_POST_STD_VM	.load_order = POST_LAUNCHED_VM,	\
 				.severity = SEVERITY_STANDARD_VM
 
-#define CONFIG_POST_RT_VM(idx)	.load_order = POST_LAUNCHED_VM,	\
+#define CONFIG_POST_RT_VM	.load_order = POST_LAUNCHED_VM,	\
 				.severity = SEVERITY_RTVM
 
 /* ACRN guest severity */
@@ -201,7 +201,6 @@ struct acrn_vm_config {
 struct acrn_vm_config *get_vm_config(uint16_t vm_id);
 uint8_t get_vm_severity(uint16_t vm_id);
 bool vm_has_matched_name(uint16_t vmid, const char *name);
-uint16_t get_unused_vmid(void);
 
 extern struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM];
 

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -58,7 +58,7 @@
 #define GUEST_FLAG_NVMX_ENABLED			(1UL << 5U)	/* Whether this VM supports nested virtualization */
 #define GUEST_FLAG_SECURITY_VM			(1UL << 6U)	/* Whether this VM needs to do security-vm related fixup (TPM2 and SMBIOS pt) */
 #define GUEST_FLAG_VCAT_ENABLED			(1UL << 7U)	/* Whether this VM supports vCAT */
-#define GUEST_FLAG_DYN_VM_CFG       (1UL << 8U)  /* Whether this VM uses dynamic VM configuration */
+#define GUEST_FLAG_STATIC_VM       (1UL << 8U)  /* Whether this VM uses static VM configuration */
 
 /* TODO: We may need to get this addr from guest ACPI instead of hardcode here */
 #define VIRTUAL_SLEEP_CTL_ADDR		0x400U /* Pre-launched VM uses ACPI reduced HW mode and sleep control register */

--- a/misc/config_tools/xforms/lib.xsl
+++ b/misc/config_tools/xforms/lib.xsl
@@ -104,6 +104,28 @@
     </func:result>
   </func:function>
 
+    <func:function name="acrn:vm_fill">
+
+        <xsl:param name="cur"/>
+        <xsl:param name="end"/>
+
+        <func:result>
+            <xsl:text>,</xsl:text>
+            <xsl:value-of select="$newline"/>
+            <xsl:text>{</xsl:text>
+            <xsl:value-of select="acrn:comment(concat('Dynamic configured  VM', $cur))"/>
+            <xsl:value-of select="$newline"/>
+            <xsl:text>CONFIG_POST_STD_VM,</xsl:text>
+            <xsl:value-of select="$newline"/>
+            <xsl:text>}</xsl:text>
+            <xsl:value-of select="$newline"/>
+
+            <xsl:if test="not($cur + 1 = $end)">
+                <xsl:value-of select="acrn:vm_fill($cur + 1, $end)"/>
+            </xsl:if>
+        </func:result>
+    </func:function>
+
   <func:function name="acrn:min">
     <xsl:param name="a" />
     <xsl:param name="b" />

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -19,6 +19,8 @@
     <xsl:value-of select="acrn:include('asm/pci_dev.h')" />
     <xsl:value-of select="acrn:include('asm/pgtable.h')" />
     <xsl:value-of select="acrn:include('schedule.h')" />
+    <xsl:value-of select="$newline" />
+    <xsl:value-of select="$newline" />
 
     <xsl:apply-templates select="config-data/acrn-config" />
   </xsl:template>
@@ -139,10 +141,10 @@
     <xsl:if test="guest_flag">
       <xsl:choose>
         <xsl:when test="guest_flag = '' or guest_flag = '0' or guest_flag = '0UL'">
-          <xsl:value-of select="acrn:initializer('guest_flags', '0UL')" />
+          <xsl:value-of select="acrn:initializer('guest_flags', 'GUEST_FLAG_STATIC_VM')" />
         </xsl:when>
         <xsl:otherwise>
-          <xsl:value-of select="acrn:initializer('guest_flags', concat('(', acrn:string-join(guest_flag, '|', '', ''),')'))" />
+          <xsl:value-of select="acrn:initializer('guest_flags', concat('(GUEST_FLAG_STATIC_VM|', acrn:string-join(guest_flag, '|', '', ''),')'))" />
         </xsl:otherwise>
       </xsl:choose>
     </xsl:if>

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -70,13 +70,15 @@
     <!-- Definition of vm_configs -->
     <xsl:value-of select="acrn:array-initializer('struct acrn_vm_config', 'vm_configs', 'CONFIG_MAX_VM_NUM')" />
     <xsl:apply-templates select="vm"/>
+    <xsl:value-of select="acrn:vm_fill(count(vm), hv/CAPACITIES/MAX_VM_NUM)"/>
+    <xsl:value-of select="$newline"/>
     <xsl:value-of select="$end_of_array_initializer" />
   </xsl:template>
 
   <xsl:template match="vm">
     <!-- Initializer of a acrn_vm_configs instance -->
     <xsl:text>{</xsl:text>
-    <xsl:value-of select="acrn:comment(concat('VM', @id))" />
+    <xsl:value-of select="acrn:comment(concat('Static configured VM', @id))" />
     <xsl:value-of select="$newline" />
 
     <xsl:apply-templates select="vm_type" />
@@ -105,17 +107,15 @@
     </xsl:if>
 
     <!-- End of the initializer -->
-    <xsl:text>},</xsl:text>
-    <xsl:value-of select="$newline" />
+    <xsl:text>}</xsl:text>
+    <xsl:if test="not(position() = last())">
+      <xsl:text>,</xsl:text>
+      <xsl:value-of select="$newline" />
+    </xsl:if>
   </xsl:template>
 
   <xsl:template match="vm_type">
     <xsl:value-of select="concat('CONFIG_', current())" />
-    <xsl:if test="not(acrn:is-sos-vm(current()))">
-      <xsl:text>(</xsl:text>
-      <xsl:value-of select="count(../preceding-sibling::vm[vm_type = current()]) + 1" />
-      <xsl:text>)</xsl:text>
-    </xsl:if>
     <xsl:text>,</xsl:text>
     <xsl:value-of select="$newline" />
   </xsl:template>

--- a/misc/services/acrn_manager/acrn_mngr.h
+++ b/misc/services/acrn_manager/acrn_mngr.h
@@ -51,7 +51,7 @@ struct mngr_msg {
 
 		/* req of ACRND_TIMER */
 		struct req_acrnd_timer {
-			char name[MAX_VMNAME_LEN];
+			char name[MAX_VM_NAME_LEN];
 			time_t t;
 		} acrnd_timer;
 
@@ -75,7 +75,7 @@ struct mngr_msg {
 
 		/* req of RTC_TIMER */
 		struct req_rtc_timer {
-			char vmname[MAX_VMNAME_LEN];
+			char vmname[MAX_VM_NAME_LEN];
 			time_t t;
 		} rtc_timer;
 

--- a/misc/services/acrn_manager/acrn_vm_ops.c
+++ b/misc/services/acrn_manager/acrn_vm_ops.c
@@ -357,7 +357,7 @@ int list_vm()
 
 int start_vm(const char *vmname)
 {
-	char cmd[PATH_LEN + sizeof(ACRN_CONF_PATH_ADD) * 2 + MAX_VMNAME_LEN * 2];
+	char cmd[PATH_LEN + sizeof(ACRN_CONF_PATH_ADD) * 2 + MAX_VM_NAME_LEN * 2];
 
 	if (snprintf(cmd, sizeof(cmd), "bash %s/%s.sh $(cat %s/%s.args)",
 			ACRN_CONF_PATH_ADD, vmname, ACRN_CONF_PATH_ADD, vmname) >= sizeof(cmd)) {

--- a/misc/services/acrn_manager/acrnctl.c
+++ b/misc/services/acrn_manager/acrnctl.c
@@ -87,8 +87,8 @@ static int check_name(const char *name)
 	if (!strcmp(name, "nothing"))
 		return -1;
 
-	if (strnlen(name, MAX_VMNAME_LEN) >= MAX_VMNAME_LEN) {
-		printf("(%s) size exceed MAX_VMNAME_LEN:%u\n", name, MAX_VMNAME_LEN);
+	if (strnlen(name, MAX_VM_NAME_LEN) >= MAX_VM_NAME_LEN) {
+		printf("(%s) size exceed MAX_VM_NAME_LEN:%u\n", name, MAX_VM_NAME_LEN);
 		return -1;
 	}
 

--- a/misc/services/acrn_manager/acrnctl.h
+++ b/misc/services/acrn_manager/acrnctl.h
@@ -29,7 +29,7 @@ struct vmmngr_struct *vmmngr_find(const char *vmname);
 
 /* Per-vm vm managerment struct */
 struct vmmngr_struct {
-	char name[MAX_VMNAME_LEN];
+	char name[MAX_VM_NAME_LEN];
 	unsigned long state;
 	unsigned long state_tmp;
 	unsigned long update;   /* update count, remove a vm if no update for it */

--- a/misc/services/acrn_manager/acrnd.c
+++ b/misc/services/acrn_manager/acrnd.c
@@ -30,7 +30,7 @@
 /* acrnd worker timer */
 
 struct work_arg {
-	char name[MAX_VMNAME_LEN];
+	char name[MAX_VM_NAME_LEN];
 };
 
 struct acrnd_work {
@@ -360,7 +360,7 @@ static void handle_timer_req(struct mngr_msg *msg, int client_fd, void *param)
 	}
 
 	strncpy(arg.name, msg->data.acrnd_timer.name, sizeof(arg.name) - 1);
-	if (sizeof(arg.name) - 1 < strnlen(msg->data.acrnd_timer.name, MAX_VMNAME_LEN)) {
+	if (sizeof(arg.name) - 1 < strnlen(msg->data.acrnd_timer.name, MAX_VM_NAME_LEN)) {
 		perror("timer name was truncated\n");
 		goto reply_ack;
 	}


### PR DESCRIPTION
port UUID changes from mainline to release_v2.7
HV:
   use GUEST_FLAG_STATIC_VM to identify static or dynamic VM
   only clear name field for dynamic configured VM
DM:
   use MAX_VM_NAME_LEN instead of MAX_VMNAME_LEN
MISC:
   use MAX_VM_NAME_LEN instead of MAX_VMNAME_LEN
CONFIG_TOOL:
   add GUEST_FLAG_STATIC_VM in guest_flags for all static configured VMs
   
   