### PR TITLE
Fix kernel ACPI error msg while launching rtvm

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1094,9 +1094,7 @@ int32_t hcall_get_cpu_pm_state(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm
 	if (is_created_vm(target_vm)) {
 		switch (cmd & PMCMD_TYPE_MASK) {
 		case ACRN_PMCMD_GET_PX_CNT: {
-			if (target_vm->pm.px_cnt != 0U) {
-				ret = copy_to_gpa(vm, &(target_vm->pm.px_cnt), param2, sizeof(target_vm->pm.px_cnt));
-			}
+			ret = copy_to_gpa(vm, &(target_vm->pm.px_cnt), param2, sizeof(target_vm->pm.px_cnt));
 			break;
 		}
 		case ACRN_PMCMD_GET_PX_DATA: {
@@ -1121,9 +1119,7 @@ int32_t hcall_get_cpu_pm_state(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm
 			break;
 		}
 		case ACRN_PMCMD_GET_CX_CNT: {
-			if (target_vm->pm.cx_cnt != 0U) {
-				ret = copy_to_gpa(vm, &(target_vm->pm.cx_cnt), param2, sizeof(target_vm->pm.cx_cnt));
-			}
+			ret = copy_to_gpa(vm, &(target_vm->pm.cx_cnt), param2, sizeof(target_vm->pm.cx_cnt));
 			break;
 		}
 		case ACRN_PMCMD_GET_CX_DATA: {


### PR DESCRIPTION
This patch is to eliminate kernel error msgs:
'ACPI Error: AE_NOT_FOUND, Evaluating _PSS'

This is caused by missing of _PSS table in guest ACPI. It would
happen when pstate is not injected to the guest.

Kernel ACPI pstate driver first probes
_PPC(performance capabilites) and _PCT(performance control)
in ACPI. If they exist, then it loads the _PSS(performance state).
If _PPC/_PCT are presented while _PSS is missing, it prints
the error msg.

In acrn-dm, _PPC/_PCT are hard-coded to all vCPUs, while _PSS
are constructed with the pCPUs' pstate data. This is base on
assumption that all VMs can have pstate.

Now the pstate is given to VM only when the VM is not sharing
any CPU(and no RTVM is setup in the scenario).
When the VM doesn't have pstate, the hypercall will return px_cnt=0,
and the _PSS is not constructed. In this case, _PPC/PCT should not
be injected, too.

Tracked-On: #6848

Signed-off-by: Zhou, Wu <wu.zhou@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>
Acked-by: Eddie Dong <eddie.dong@Intel.com>

