### PR TITLE
config-tools: get GPU_SBDF automatically

### DIFF
--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -134,7 +134,7 @@ static int32_t handle_one_drhd(struct acpi_dmar_hardware_unit *acpi_drhd, struct
 		if (is_apl_platform()) {
 			if ((((uint32_t)drhd->segment << 16U) |
 		     	     ((uint32_t)dev_scope->bus << 8U) |
-		     	     dev_scope->devfun) == CONFIG_GPU_SBDF) {
+		     	     dev_scope->devfun) == CONFIG_IGD_SBDF) {
 				drhd->ignore = true;
 			}
 		}

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -540,7 +540,7 @@ void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev)
 	if (vdev->phyfun == NULL) {
 		init_bars(vdev, is_pf_vdev);
 		init_vmsix_on_msi(vdev);
-		if (is_service_vm(vpci2vm(vdev->vpci)) && (vdev->pdev->bdf.value == CONFIG_GPU_SBDF)) {
+		if (is_service_vm(vpci2vm(vdev->vpci)) && (vdev->pdev->bdf.value == CONFIG_IGD_SBDF)) {
 			pci_vdev_write_vcfg(vdev, PCIR_ASLS_CTL, 4U, pci_pdev_read_cfg(vdev->pdev->bdf, PCIR_ASLS_CTL, 4U));
 		}
 		if (is_prelaunched_vm(vpci2vm(vdev->vpci)) && (!is_pf_vdev)) {
@@ -550,7 +550,7 @@ void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev)
 			pci_command |= 0x400U;
 			pci_pdev_write_cfg(vdev->pdev->bdf, PCIR_COMMAND, 2U, pci_command);
 
-			if (vdev->pdev->bdf.value == CONFIG_GPU_SBDF) {
+			if (vdev->pdev->bdf.value == CONFIG_IGD_SBDF) {
 				passthru_gpu_opregion(vdev);
 			}
 		}

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -520,7 +520,7 @@ static int32_t write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 	} else {
 		if (offset != vdev->pdev->sriov.pre_pos) {
 			if (!is_quirk_ptdev(vdev)) {
-				if ((vdev->pdev->bdf.value != CONFIG_GPU_SBDF) || (offset != PCIR_ASLS_CTL)) {
+				if ((vdev->pdev->bdf.value != CONFIG_IGD_SBDF) || (offset != PCIR_ASLS_CTL)) {
 					/* passthru to physical device */
 					pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
 				}
@@ -550,7 +550,7 @@ static int32_t read_pt_dev_cfg(const struct pci_vdev *vdev, uint32_t offset,
 		} else if (!is_quirk_ptdev(vdev)) {
 			/* passthru to physical device */
 			*val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, bytes);
-			if ((vdev->pdev->bdf.value == CONFIG_GPU_SBDF) && (offset == PCIR_ASLS_CTL)) {
+			if ((vdev->pdev->bdf.value == CONFIG_IGD_SBDF) && (offset == PCIR_ASLS_CTL)) {
 				*val = pci_vdev_read_vcfg(vdev, offset, bytes);
 			}
 		} else {

--- a/misc/config_tools/board_inspector/legacy/dmar.py
+++ b/misc/config_tools/board_inspector/legacy/dmar.py
@@ -167,7 +167,7 @@ class DmarTbl:
 
 # TODO: Get board information is independent part of acrn-config tools, it does not get the GPU_SBDF default
 # config from the other part of tools, so hard code the GPU_SBDF to gernerate DRHDx_IGNORE macro
-CONFIG_GPU_SBDF = 0x10
+CONFIG_IGD_SBDF = 0x10
 
 PCI_BRIDGE_HEADER = 1
 
@@ -257,7 +257,7 @@ def walk_pci_bus(tmp_pdf, dmar_tbl, dmar_hw_list, drhd_cnt):
         get_secondary_bus(dmar_tbl, tmp_pdf.device, tmp_pdf.function)
 
         if ((dmar_tbl.dmar_drhd.segment << 16) | (
-                dmar_tbl.dmar_dev_scope.bus << 8) | tmp_pdf.path) == CONFIG_GPU_SBDF:
+                dmar_tbl.dmar_dev_scope.bus << 8) | tmp_pdf.path) == CONFIG_IGD_SBDF:
             dmar_hw_list.hw_ignore[drhd_cnt] = 'true'
 
         dmar_tbl.path_offset += ctypes.sizeof(DevScopePath)

--- a/misc/config_tools/hv_config/board_defconfig.py
+++ b/misc/config_tools/hv_config/board_defconfig.py
@@ -133,12 +133,6 @@ def get_serial_console(config):
         if serial_value:
             print('CONFIG_SERIAL_MMIO_BASE={}'.format(serial_value), file=config)
 
-
-def get_miscfg(hv_info, config):
-
-    print("CONFIG_GPU_SBDF={}".format(hv_info.mis.gpu_sbdf), file=config)
-
-
 def get_features(hv_info, config):
 
     print("CONFIG_{}=y".format(hv_info.features.scheduler), file=config)
@@ -201,7 +195,6 @@ def generate_file(hv_info, config):
     print('CONFIG_BOARD="{}"'.format(board_name), file=config)
 
     get_memory(hv_info, config)
-    get_miscfg(hv_info, config)
     get_features(hv_info, config)
     get_capacities(hv_info, config)
     get_serial_console(config)

--- a/misc/config_tools/hv_config/hv_item.py
+++ b/misc/config_tools/hv_config/hv_item.py
@@ -80,20 +80,6 @@ class CapHv:
         hv_cfg_lib.hv_range_check(self.max_pci_dev_num, "CAPACITIES", "MAX_PCI_DEV_NUM", hv_cfg_lib.RANGE_DB['PCI_DEV_NUM'])
         hv_cfg_lib.max_msix_table_num_check(self.max_msix_table_num, "CAPACITIES", "MAX_MSIX_TABLE_NUM")
 
-
-class MisCfg:
-
-    def __init__(self, hv_file):
-        self.hv_file = hv_file
-        self.gpu_sbdf = 0
-
-    def get_info(self):
-        self.gpu_sbdf =  common.get_hv_item_tag(self.hv_file, "MISC_CFG", "GPU_SBDF")
-
-    def check_item(self):
-        hv_cfg_lib.hv_size_check(self.gpu_sbdf, "MISC_CFG", "GPU_SBDF")
-
-
 class Features:
     def __init__(self, hv_file):
         self.hv_file = hv_file
@@ -179,19 +165,16 @@ class HvInfo:
         self.mem = Memory(self.hv_file)
         self.cap = CapHv(self.hv_file)
         self.log = LogOpt(self.hv_file)
-        self.mis = MisCfg(self.hv_file)
         self.features = Features(self.hv_file)
 
     def get_info(self):
         self.mem.get_info()
         self.log.get_info()
         self.cap.get_info()
-        self.mis.get_info()
         self.features.get_info()
 
     def check_item(self):
         self.mem.check_item()
         self.log.check_item()
         self.cap.check_item()
-        self.mis.check_item()
         self.features.check_item()

--- a/misc/config_tools/static_allocators/bdf.py
+++ b/misc/config_tools/static_allocators/bdf.py
@@ -119,7 +119,7 @@ def create_device_node(allocation_etree, vm_id, devdict):
         if common.get_node(f"./func", dev_node) is None:
             common.append_node(f"./func", f"{bdf.func:#04x}", dev_node)
 
-def create_gpu_sbdf(board_etree, allocation_etree):
+def create_igd_sbdf(board_etree, allocation_etree):
     """
     Extract the integrated GPU bdf from board.xml. If the device is not present, set bdf to "0xFFFF" which indicates the device
     doesn't exist.
@@ -127,15 +127,15 @@ def create_gpu_sbdf(board_etree, allocation_etree):
     bus = "0x0"
     device_node = common.get_node(f"//bus[@type='pci' and @address='{bus}']/device[vendor='0x8086' and class='0x030000']", board_etree)
     if device_node is None:
-        common.append_node("/acrn-config/hv/MISC_CFG/GPU_SBDF", '0xFFFF', allocation_etree)
+        common.append_node("/acrn-config/hv/MISC_CFG/IGD_SBDF", '0xFFFF', allocation_etree)
     else:
         address = device_node.get('address')
         dev = int(address, 16) >> 16
         func = int(address, 16) & 0xffff
-        common.append_node("/acrn-config/hv/MISC_CFG/GPU_SBDF", f"{(int(bus, 16) << 8) | (dev << 3) | func:#06x}", allocation_etree)
+        common.append_node("/acrn-config/hv/MISC_CFG/IGD_SBDF", f"{(int(bus, 16) << 8) | (dev << 3) | func:#06x}", allocation_etree)
 
 def fn(board_etree, scenario_etree, allocation_etree):
-    create_gpu_sbdf(board_etree, allocation_etree)
+    create_igd_sbdf(board_etree, allocation_etree)
     vm_nodes = scenario_etree.xpath("//vm")
     for vm_node in vm_nodes:
         vm_id = vm_node.get('id')

--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -255,8 +255,9 @@
   </xsl:template>
 
   <xsl:template match="MISC_CFG">
-    <xsl:call-template name="integer-by-key">
+    <xsl:call-template name="integer-by-key-value">
       <xsl:with-param name="key" select="'GPU_SBDF'" />
+      <xsl:with-param name="value" select="//allocation-data/acrn-config/hv/MISC_CFG/GPU_SBDF" />
     </xsl:call-template>
   </xsl:template>
 

--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -256,8 +256,8 @@
 
   <xsl:template match="MISC_CFG">
     <xsl:call-template name="integer-by-key-value">
-      <xsl:with-param name="key" select="'GPU_SBDF'" />
-      <xsl:with-param name="value" select="//allocation-data/acrn-config/hv/MISC_CFG/GPU_SBDF" />
+      <xsl:with-param name="key" select="'IGD_SBDF'" />
+      <xsl:with-param name="value" select="//allocation-data/acrn-config/hv/MISC_CFG/IGD_SBDF" />
     </xsl:call-template>
   </xsl:template>
 


### PR DESCRIPTION
Get the GPU_SBDF by looking for device from board.xml and extract the
BDF from device address.

Tracked-On: #6855
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>