### PR TITLE
dm: validate input of virtio_console_control_tx()

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -283,6 +283,9 @@ virtio_console_control_tx(struct virtio_console_port *port, void *arg,
 	console = port->console;
 	ctrl = (struct virtio_console_control *)iov->iov_base;
 
+	if ((console == NULL) || (ctrl == NULL))
+		return;
+
 	switch (ctrl->event) {
 	case VIRTIO_CONSOLE_DEVICE_READY:
 		console->ready = true;


### PR DESCRIPTION
 this patch validates input of virtio_console_control_tx()
 function to avoid potential progream crash with malicious
 input from guest.

Tracked-On: #6851
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>