### PR TITLE
doc: fix 2.3 release notes broken link

### DIFF
--- a/doc/release_notes/release_notes_2.3.rst
+++ b/doc/release_notes/release_notes_2.3.rst
@@ -74,7 +74,7 @@ New and updated reference documents are available, including:
 
 * :ref:`asa`
 * GVT-g-porting (obsolete with v2.6))
-* :ref:`vbsk-overhead`
+* VBS-K Framework Virtualization Overhead Analysis
 * :ref:`asm_coding_guidelines`
 * :ref:`c_coding_guidelines`
 * :ref:`contribute_guidelines`


### PR DESCRIPTION
Removed the VBS-K Framework Virtualization Overhead Analysis document on
master.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>