### PR TITLE
Fix lifecycle manager bug

### DIFF
--- a/misc/services/life_mngr/command_handler.c
+++ b/misc/services/life_mngr/command_handler.c
@@ -68,11 +68,12 @@ static void start_system_shutdown(void)
 		LOG_WRITE("UART connection list is empty, will trigger shutdown system\n");
 		close_socket(sock_server);
 		stop_listen_uart_channel_dev(channel);
-		if (wait_post_vms_shutdown())
-			LOG_WRITE("Service VM start to power off here\n");
-		else
-			LOG_WRITE("Timeout waiting for VMs poweroff, will force poweroff VMs\n");
-		system_shutdown_flag = true;
+		if (wait_post_vms_shutdown()) {
+			LOG_WRITE("Service VM starts to power off.\n");
+			system_shutdown_flag = true;
+		} else {
+			LOG_WRITE("Some User VMs failed to power off, cancelled the platform shut down process.\n");
+		}
 	}
 }
 

--- a/misc/services/life_mngr/life_mngr_win.c
+++ b/misc/services/life_mngr/life_mngr_win.c
@@ -179,6 +179,12 @@ int main()
 	snprintf(buf, sizeof(buf), SYNC_FMT, WIN_VM_NAME);
 	enable_uart_resend(buf, MIN_RESEND_TIME);
 	send_message_by_uart(hCom2, buf, strlen(buf));
+	/**
+	 * The lifecycle manager in Service VM checks sync message every 5 seconds
+	 * during listening phase, delay 5 seconds to wait Service VM to receive the
+	 * sync message, then start to read ack message from Service VM.
+	 */
+	Sleep(5U * MS_TO_SECOND);
 	do {
 		do {
 			retry_times = RETRY_RECV_TIMES;


### PR DESCRIPTION
1. Refine platform shutdown when User VM fails to shutdown.
2. Add sync delay for WaaG lifecycle manager to avoid unnecessary sync resending.