### PR TITLE
Dm: fix mevent timing issue to v2.7

### DIFF
--- a/devicemodel/core/mevent.c
+++ b/devicemodel/core/mevent.c
@@ -341,7 +341,7 @@ mevent_delete_event(struct mevent *evp, int closefd)
 	evp->closefd = closefd;
 
 	epoll_ctl(epoll_fd, EPOLL_CTL_DEL, evp->me_fd, NULL);
-	if (!is_dispatch_thread() && evp->teardown != NULL) {
+	if (!is_dispatch_thread()) {
 		mevent_add_to_del_list(evp, closefd);
 	} else {
 		if (evp->closefd) {


### PR DESCRIPTION
If a file descriptor being monitored by epoll_wait is closed
in another thread, the result is unspecified. So add all mevents
removed in other threads to delete list. And drain the list in
the dispatch mevent thread.

Tracked-On: #6877
Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>