### PR TITLE
[release 2.7]HV: correct hv_ram_size when hv is relocated

### DIFF
--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -76,7 +76,7 @@ address_tag_start:
     .short  0
     .long   address_tag_end - address_tag_start
     .long   mb2_header_start  /* address corresponding to the beginning of the Multiboot2 header */
-    .long   _ld_ram_start     /* load_addr: load from the binary's beginning */
+    .long   ld_ram_start     /* load_addr: load from the binary's beginning */
     /*
      * load_end_addr: this includes .bss so that boot loader could reserve the
      * memory that .bss occupies to avoid placing boot modules or other data in that area.
@@ -84,7 +84,7 @@ address_tag_start:
      * However, the boot loader is supposed not to actually load the .bss section because
      * it's beyond the scope of acrn.bin
      */
-    .long   _ld_ram_end
+    .long   ld_ram_end
     .long   0   /* bss_end_addr, don't ask boot loader to clear .bss */
 address_tag_end:
 

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -255,7 +255,7 @@ void init_paging(void)
 	const struct abi_mmap *p_mmap = abi->mmap_entry;
 
 	pr_dbg("HV MMU Initialization");
-	hv_ram_size = (uint64_t)&ld_ram_size;
+	hv_ram_size = (uint64_t)(&_ld_ram_end - &_ld_ram_start);
 
 	init_sanitized_page((uint64_t *)sanitized_page, hva2hpa_early(sanitized_page));
 

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -255,7 +255,7 @@ void init_paging(void)
 	const struct abi_mmap *p_mmap = abi->mmap_entry;
 
 	pr_dbg("HV MMU Initialization");
-	hv_ram_size = (uint64_t)(&_ld_ram_end - &_ld_ram_start);
+	hv_ram_size = (uint64_t)(&ld_ram_end - &ld_ram_start);
 
 	init_sanitized_page((uint64_t *)sanitized_page, hva2hpa_early(sanitized_page));
 

--- a/hypervisor/bsp/ld/link_ram.ld.in
+++ b/hypervisor/bsp/ld/link_ram.ld.in
@@ -100,5 +100,4 @@ SECTIONS
 
    . = ALIGN(0x200000) ;
     _ld_ram_end = . ;
-    ld_ram_size = _ld_ram_end - _ld_ram_start ;
 }

--- a/hypervisor/bsp/ld/link_ram.ld.in
+++ b/hypervisor/bsp/ld/link_ram.ld.in
@@ -13,7 +13,7 @@ SECTIONS
 {
     .boot :
     {
-        _ld_ram_start = . ;
+        ld_ram_start = . ;
         KEEP(*(multiboot_header)) ;
     } > ram
 
@@ -99,5 +99,5 @@ SECTIONS
     } > ram
 
    . = ALIGN(0x200000) ;
-    _ld_ram_end = . ;
+    ld_ram_end = . ;
 }

--- a/hypervisor/include/arch/x86/asm/boot/ld_sym.h
+++ b/hypervisor/include/arch/x86/asm/boot/ld_sym.h
@@ -14,6 +14,7 @@ extern uint8_t		ld_entry_end;
 extern const uint8_t	ld_trampoline_load;
 extern uint8_t		ld_trampoline_start;
 extern uint8_t		ld_trampoline_end;
-extern uint8_t		ld_ram_size;
+extern uint8_t		_ld_ram_start;
+extern uint8_t		_ld_ram_end;
 
 #endif /* LD_SYM_H */

--- a/hypervisor/include/arch/x86/asm/boot/ld_sym.h
+++ b/hypervisor/include/arch/x86/asm/boot/ld_sym.h
@@ -14,7 +14,7 @@ extern uint8_t		ld_entry_end;
 extern const uint8_t	ld_trampoline_load;
 extern uint8_t		ld_trampoline_start;
 extern uint8_t		ld_trampoline_end;
-extern uint8_t		_ld_ram_start;
-extern uint8_t		_ld_ram_end;
+extern uint8_t		ld_ram_start;
+extern uint8_t		ld_ram_end;
 
 #endif /* LD_SYM_H */


### PR DESCRIPTION
In previous commit df7ffab
the CONFIG_HV_RAM_SIZE was removed and the hv_ram_size was calculated in
link script by following formula:
ld_ram_size = _ld_ram_end - _ld_ram_start ;
but _ld_ram_start is a relative address in boot section whereas _ld_ram_end
is a absolute address in global, the mix operation cause hv_ram_size is
incorrect when HV binary is relocated.

The patch fix this issue by getting _ld_ram_start and _ld_ram_end respectively
and calculated at runtime.

Tracked-On: #6885

Signed-off-by: Victor Sun victor.sun@intel.com
Acked-by: Anthony Xu anthony.xu@intel.com