### PR TITLE
doc: replace UUID with vm name to identify a vm

### DIFF
--- a/doc/developer-guides/hld/hld-devicemodel.rst
+++ b/doc/developer-guides/hld/hld-devicemodel.rst
@@ -54,7 +54,7 @@ options:
   acrn-dm [-hAWYv] [-B bootargs] [-E elf_image_path]
                [-G GVT_args] [-i ioc_mediator_parameters] [-k kernel_image_path]
                [-l lpc] [-m mem] [-r ramdisk_image_path]
-               [-s pci] [-U uuid] [--vsbl vsbl_file_name] [--ovmf ovmf_file_path]
+               [-s pci] [--vsbl vsbl_file_name] [--ovmf ovmf_file_path]
                [--part_info part_info_name] [--enable_trusty] [--intr_monitor param_setting]
                [--acpidev_pt HID] [--mmiodev_pt MMIO_regions]
                [--vtpm2 sock_path] [--virtio_poll interval] [--mac_seed seed_string]
@@ -72,7 +72,6 @@ options:
        -m: memory size in MB
        -r: ramdisk image path
        -s: <slot,driver,configinfo> PCI slot config
-       -U: uuid
        -v: version
        -W: force virtio to use single-vector MSI
        -Y: disable MPtable generation

--- a/doc/developer-guides/hld/hld-security.rst
+++ b/doc/developer-guides/hld/hld-security.rst
@@ -793,7 +793,7 @@ Extract-and-Expand Key Derivation Function), `RFC5869
 
 The parameters of HKDF derivation in the hypervisor are:
 
-#. VMInfo= vm-uuid (from the hypervisor configuration file)
+#. VMInfo= vm name (from the hypervisor configuration file)
 #. theHash=SHA-256
 #. OutSeedLen = 64 in bytes
 #. Guest Dev and User SEED (dvSEED/uvSEED)

--- a/doc/tutorials/rdt_configuration.rst
+++ b/doc/tutorials/rdt_configuration.rst
@@ -208,7 +208,6 @@ Configure RDT for VM Using VM Configuration
       <vm id="0">
          <vm_type readonly="true">PRE_STD_VM</vm_type>
          <name>ACRN PRE-LAUNCHED VM0</name>
-         <uuid configurable="0">26c5e0d8-8f8a-47d8-8109-f201ebd61a5e</uuid>
          <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>1</vcpu_clos>

--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -207,19 +207,6 @@ Here are descriptions for each of these ``acrn-dm`` command line parameters:
 
 ----
 
-``-U``, ``--uuid <uuid>``
-   Set UUID for a VM.  Every VM is identified by a UUID.  You can define that
-   UUID with this option.  If you don't use this option, a default one
-   ("d2795438-25d6-11e8-864e-cb7a18b34643") will be used.
-
-   usage::
-
-      -u "42795636-1d31-6512-7432-087d33b34756"
-
-   set the newly created VM's UUID to ``42795636-1d31-6512-7432-087d33b34756``
-
-----
-
 ``-v``, ``--version``
    Show Device Model version.
 


### PR DESCRIPTION
Since PR #6787 has landed, we need to remove the UUID parameter
"-U" of "acrn-dm" and replace UUID with VM name to identify a VM
in document.

Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>