### PR TITLE
doc: add initial list of TSC members

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -6,8 +6,7 @@ patches directly to the project.  In our collaborative open-source environment,
 standards and methods for submitting changes help reduce the chaos that can result
 from an active development community.
 
-This document briefly summarizes the full `Contribution
-Guidelines <http://projectacrn.github.io/latest/developer-guides/contribute_guidelines.html>`_
+This document briefly summarizes the full :ref:`contribute_acrn`
 documentation.
 
 * ACRN uses the permissive open source `BSD 3-Clause license`_
@@ -35,5 +34,21 @@ documentation.
 * The `ACRN user mailing list`_ is a great place to engage with the
   community, ask questions, discuss issues, and help each other.
 
+
+.. _tsc_members:
+
+Technical Steering Committee (TSC)
+**********************************
+
+As set by the Project's `technical-charter`_, the Technical Steering Committee
+has a chair and a number of members. This is the list of the current members:
+
+- Anthony Xu (chair): anthony.xu@intel.com
+
+- Helmut Buchsbaum: helmut.buchsbaum@tttech-industrial.com
+
+- Thomas Gleixner: tglx@linutronix.de
+
 .. _ACRN user mailing list: https://lists.projectacrn.org/g/acrn-user
 .. _BSD 3-Clause license: https://github.com/projectacrn/acrn-hypervisor/blob/master/LICENSE
+.. _technical-charter: https://projectacrn.org/technical-charter/

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -51,6 +51,7 @@ doxy:
 content:
 	$(Q)mkdir -p $(SOURCEDIR)
 	$(Q)rsync -rt --exclude=$(BUILDDIR) . $(SOURCEDIR)
+	$(Q)cp ../CONTRIBUTING $(SOURCEDIR)
 	$(Q)scripts/extract_content.py $(SOURCEDIR) misc
 	$(Q)mkdir -p $(SOURCEDIR)/misc/config_tools/schema
 	$(Q)rsync -rt ../misc/config_tools/schema/*.xsd $(SOURCEDIR)/misc/config_tools/schema

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -37,6 +37,12 @@ project. Here's where you'll find how the development team works and the
 guidelines they (and you) use to contribute code (and documentation) to
 the project.
 
+The project has a Technical Steering Committee (TSC) that is responsible
+for all technical oversight of the open source Project. The role and rules
+governing the operations of the TSC are described in the project's
+`technical-charter`_. Members of the TSC are listed with their contact
+details in the :ref:`tsc_members` paragraph.
+
 .. rst-class:: rst-columns2
 
 .. toctree::
@@ -56,4 +62,4 @@ API Documentation
 
    api/index
 
-
+.. _technical-charter: https://projectacrn.org/technical-charter/

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -63,6 +63,8 @@ an open source platform.
    </ul>
 
 
+.. include:: CONTRIBUTING
+
 Source code for Project ACRN is maintained in the
 `Project ACRN GitHub repo`_, and is provided under the BSD 3-clause
 license.


### PR DESCRIPTION
Add the initial list of TSC members to the project's CONTRIBUTING
file (top-level folder).

The 'CONTRIBUTING' file is also now included in the main documentation
and is cross-referenced in the doc/contribute.rst guide.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>