### PR TITLE
[v2.7]HV: update destination shorthand field in x2apic ICR emulation

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2058,6 +2058,11 @@ vlapic_x2apic_pt_icr_access(struct acrn_vcpu *vcpu, uint64_t val)
 	} else {
 		dmask = vlapic_calc_dest(vcpu, shorthand, (dest == 0xffffffffU), dest, phys, false);
 
+		/**
+		 * The hypervisor sets the "Destination Shorthand" field to 00B (No Shorthand)
+		 * since the emulation is done through sending IPI to each VCPU in dmask one by one.
+		 */
+		icr_low = icr_low & (~APIC_DEST_MASK);
 		for (vcpu_id = 0U; vcpu_id < vcpu->vm->hw.created_vcpus; vcpu_id++) {
 			if (((dmask & (1UL << vcpu_id)) != 0UL) &&
 					(vcpu->vm->hw.vcpu_array[vcpu_id].state != VCPU_OFFLINE)) {


### PR DESCRIPTION
    Currently, in RTVM with multi vCPUs, lapic pass through is
    configured, each vCPU works in x2apic mode. When one vCPU sends
    IPI to all other vCPUs, writes ICR register with the value
    0x00000000000c00f8, this ICR writting will trigger VM exit,
    the hypervisor passes destination shorthand field 11B (All Excluding
    Self) in the virtual ICR value into physical ICR value,
    this IPI will be sent to each physical CPU core
    in the platform according to 10.6.1 Interrupt Command Register (ICR),
    Vol 3, SDM. This will cause one User VM with lapic pass through
    configuration can send IPI with any vector (such as NMI or reboot
    vector) to other VM, this interference may cause other VM hang.

    In this patch, set "Destination Shorthand" field of the
    ICR value as 00B (No Shorthand) since the emulation is done
    through sending IPI to each VCPU in dmask one by one.

    Tracked-On: #6908

    Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>
