### PR TITLE
hv: Add stateful VM check before system shutdown

### DIFF
--- a/hypervisor/include/arch/x86/asm/guest/vm.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm.h
@@ -256,6 +256,7 @@ void vrtc_init(struct acrn_vm *vm);
 
 bool is_lapic_pt_configured(const struct acrn_vm *vm);
 bool is_rt_vm(const struct acrn_vm *vm);
+bool is_stateful_vm(const struct acrn_vm *vm);
 bool is_nvmx_configured(const struct acrn_vm *vm);
 bool is_vcat_configured(const struct acrn_vm *vm);
 bool is_static_configured_vm(const struct acrn_vm *vm);


### PR DESCRIPTION
This patch introduces stateful VM which represents a VM that has its own
internal state such as a file cache, and adds a check before system
shutdown to make sure that stateless VM does not block system shutdown.

Tracked-On: #6571
Signed-off-by: Wang Yu <yu1.wang@intel.com>
Signed-off-by: Yifan Liu <yifan1.liu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>