### PR TITLE
hv: remove CONFIG_LOG_DESTINATION

### DIFF
--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -38,7 +38,7 @@ static void init_debug_pre(void)
 	console_init();
 
 	/* Enable logging */
-	init_logmsg(CONFIG_LOG_DESTINATION);
+	init_logmsg();
 }
 
 /*TODO: move into debug module */

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -17,10 +17,6 @@
 #define LOG_INFO		5U
 #define LOG_DEBUG		6U
 
-/* Logging flags */
-#define LOG_FLAG_STDOUT		0x00000001U
-#define LOG_FLAG_MEMORY		0x00000002U
-#define LOG_FLAG_NPK		0x00000004U
 #define LOG_ENTRY_SIZE	80U
 /* Size of buffer used to store a message being logged,
  * should align to LOG_ENTRY_SIZE.
@@ -49,7 +45,11 @@ void asm_assert(int32_t line, const char *file, const char *txt);
 
 #endif /* HV_DEBUG */
 
-void init_logmsg(uint32_t flags);
+void init_logmsg();
+
+/*
+ * @pre the severity > 0
+ */
 void do_logmsg(uint32_t severity, const char *fmt, ...);
 
 /** The well known printf() function.
@@ -112,7 +112,9 @@ void vprintf(const char *fmt, va_list args);
 
 #define dev_dbg(lvl, ...)					\
 	do {							\
-		do_logmsg((lvl), pr_prefix __VA_ARGS__);	\
+		if ((lvl) > 0) {                                \
+			do_logmsg((lvl), pr_prefix __VA_ARGS__);\
+		}                                               \
 	} while (0)
 
 #define panic(...) 							\

--- a/hypervisor/release/logmsg.c
+++ b/hypervisor/release/logmsg.c
@@ -6,7 +6,7 @@
 
 #include <types.h>
 
-void init_logmsg(__unused uint32_t flags) {}
+void init_logmsg() {}
 void do_logmsg(__unused uint32_t severity, __unused const char *fmt, ...) {}
 void printf(__unused const char *fmt, ...) {}
 void vprintf(__unused const char *fmt, __unused va_list args) {}


### PR DESCRIPTION
The CONFIG_LOG_DESTINATION parameter selects where the logging messages
send to，serial console or memory or npk device MMIO region.

Now we want to remove it and check the loglevel of each channel,close the
output when the loglevel is ZERO.

Tracked-On: #6934
Signed-off-by: Chenli Wei <chenli.wei@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>