### PR TITLE
config_tools:doc: sync with release_2.7 for XSD files

### DIFF
--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -382,7 +382,7 @@ to the pre-launched VM.</xs:documentation>
     </xs:element>
     <xs:element name="bootargs" type="xs:string">
       <xs:annotation>
-        <xs:documentation>Specify kernel boot arguments for Service OS.</xs:documentation>
+        <xs:documentation>Specify kernel boot arguments for Service VM OS.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:sequence>


### PR DESCRIPTION
update "bootargs" documentation to keep with release_2.7 branch
in VMtype.xsd.

Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>