### PR TITLE
config_tools: rename sdc.xml to shared.xml on qemu platform

### DIFF
--- a/misc/config_tools/data/qemu/shared.xml
+++ b/misc/config_tools/data/qemu/shared.xml
@@ -1,4 +1,4 @@
-<acrn-config board="qemu" scenario="sdc">
+<acrn-config board="qemu" scenario="shared">
   <hv>
     <DEBUG_OPTIONS>
       <RELEASE>n</RELEASE>


### PR DESCRIPTION
rename sdc.xml to shared.xml on qemu platform

Tracked-On: #6315
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>