### PR TITLE
hv:remove 2 bits vmx capability check

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -891,7 +891,7 @@ void rstore_xsave_area(const struct acrn_vcpu *vcpu, const struct ext_context *e
 		 * 2. "vcpu->arch.xsave_enabled" is true (state restoring for guest)
 		 *
 		 * Before vCPU is launched, condition 1 is satisfied.
-		 * After vCPU is launched, condition 2 is satisfied because is_valid_xsave_combination() guarantees
+		 * After vCPU is launched, condition 2 is satisfied because
 		 * that "vcpu->arch.xsave_enabled" is consistent with pcpu_has_cap(X86_FEATURE_XSAVES).
 		 *
 		 * Therefore, the check against "vcpu->launched" and "vcpu->arch.xsave_enabled" can be eliminated here.


### PR DESCRIPTION
remove is_valid_xsave_combination api,
assume the hardware or QEMU can guarantee that support
XSAVE on CPU side and XSAVE_XRSTR on VMX side or not.
will add offline-tool in QEMU platform to avoid the user
use wrong XSAVE configurations.
remov check VMX_PROCBASED_CTLS2_XSVE_XRSTR based on the above reason.
for VMX_PROCBASED_CTLS2_PAUSE_LOOP, now it will panic
if run ACRN over QEMU, here remove it from essential check,
and it will print error information when set this bit
if there is no the hardware capability.

v1-v2:
  remove is_valid_xsave_combination

Tracked-On: #6584
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>