### PR TITLE
Remove acrnctl suspend and resume command

### DIFF
--- a/misc/services/acrn_manager/README.rst
+++ b/misc/services/acrn_manager/README.rst
@@ -27,8 +27,6 @@ You can see the available ``acrnctl`` commands by running:
      stop [--force/-f]
      del
      add
-     suspend
-     resume
      reset
      blkrescan
    Use acrnctl [cmd] help for details

--- a/misc/services/acrn_manager/acrn_vm_ops.c
+++ b/misc/services/acrn_manager/acrn_vm_ops.c
@@ -387,24 +387,6 @@ int stop_vm(const char *vmname, int force)
 	return ack.data.err;
 }
 
-int suspend_vm(const char *vmname)
-{
-	struct mngr_msg req;
-	struct mngr_msg ack;
-
-	req.magic = MNGR_MSG_MAGIC;
-	req.msgid = DM_SUSPEND;
-	req.timestamp = time(NULL);
-
-	send_msg(vmname, &req, &ack);
-
-	if (ack.data.err) {
-		printf("Unable to suspend vm. errno(%d)\n", ack.data.err);
-	}
-
-	return ack.data.err;
-}
-
 int resume_vm(const char *vmname, unsigned reason)
 {
 	struct mngr_msg req;

--- a/misc/services/acrn_manager/acrnctl.h
+++ b/misc/services/acrn_manager/acrnctl.h
@@ -56,7 +56,6 @@ int stop_vm(const char *vmname, int force);
 int start_vm(const char *vmname);
 int pause_vm(const char *vmname);
 int continue_vm(const char *vmname);
-int suspend_vm(const char *vmname);
 int resume_vm(const char *vmname, unsigned reason);
 int blkrescan_vm(const char *vmname, char *devargs);
 


### PR DESCRIPTION
This patch set is to remove acrnctl suspend and resume command since
these two commands is not used by user any more.

Tracked-On: #5921
