### PR TITLE
hv_prebuild: Support LAPIC-PT only VM

### DIFF
--- a/misc/hv_prebuild/vm_cfg_checks.c
+++ b/misc/hv_prebuild/vm_cfg_checks.c
@@ -67,9 +67,9 @@ bool sanitize_vm_config(void)
 
 		switch (vm_config->load_order) {
 		case PRE_LAUNCHED_VM:
-			/* GUEST_FLAG_RT must be set if we have GUEST_FLAG_LAPIC_PASSTHROUGH set in guest_flags */
-			if (((vm_config->guest_flags & GUEST_FLAG_LAPIC_PASSTHROUGH) != 0U)
-					&& ((vm_config->guest_flags & GUEST_FLAG_RT) == 0U)) {
+			/* GUEST_FLAG_LAPIC_PASSTHROUGH must be set if we have GUEST_FLAG_RT set in guest_flags */
+			if (((vm_config->guest_flags & GUEST_FLAG_RT) != 0U)
+				&& ((vm_config->guest_flags & GUEST_FLAG_LAPIC_PASSTHROUGH)== 0U)) {
 				ret = false;
 			} else if (vm_config->epc.size != 0UL) {
 				ret = false;


### PR DESCRIPTION
Currently in sanitize_vm_config, all LAPIC-PT VM are treated as RTVM,
which can be relaxed: LAPIC PT VM does not have to be RTVM.

Change the logic in sanitize_vm_config to support this relaxation.

Tracked-On: #6968
Signed-off-by: Yifan Liu <yifan1.liu@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>