### PR TITLE
Config-tools: Generate ioapic number and line maximum automatically

### DIFF
--- a/misc/config_tools/board_inspector/board_inspector.py
+++ b/misc/config_tools/board_inspector/board_inspector.py
@@ -74,6 +74,7 @@ def main(board_name, board_xml, args):
         root_node.append(lxml.etree.Element("processors"))
         root_node.append(lxml.etree.Element("caches"))
         root_node.append(lxml.etree.Element("memory"))
+        root_node.append(lxml.etree.Element("ioapics"))
         root_node.append(lxml.etree.Element("devices"))
 
         extractors_path = os.path.join(script_dir, "extractors")

--- a/misc/config_tools/board_inspector/extractors/40-acpi-tables.py
+++ b/misc/config_tools/board_inspector/extractors/40-acpi-tables.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2021 Intel Corporation.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+
+import logging
+import re, os, fcntl, errno
+import lxml.etree
+from extractors.helpers import add_child, get_node
+
+from acpiparser import parse_apic, apic
+
+DEFAULT_MAX_IOAPIC_LINES = 240
+
+def extract_gsi_number(ioapic_node, apic_id):
+    f = open("/dev/kmsg", 'r')
+    fd = os.dup(f.fileno())
+    f.close()
+
+    ret = fcntl.fcntl(fd, fcntl.F_SETFL, os.O_NONBLOCK)
+    if ret != 0:
+        os.close(fd)
+        add_child(ioapic_node, "gsi_number", DEFAULT_MAX_IOAPIC_LINES)
+        return
+
+    while True:
+        try:
+            line =  os.read(fd, 512).decode("utf-8")
+            m = re.match(r"\s*\d+,\d+,\d+,-;IOAPIC\[[\d+]\]:\s+apic_id\s+{},\s+version\s+\d+,\s+address\s+0x[0-9a-f]+,\s+GSI\s+(\d+)-(\d+)".format(apic_id), line)
+            if m:
+                previous_max = int(m.group(1))
+                current_max = int(m.group(2)) + 1
+                add_child(ioapic_node, "gsi_number", str(current_max - previous_max))
+                break
+        except:
+            add_child(ioapic_node, "gsi_number", DEFAULT_MAX_IOAPIC_LINES)
+            break
+    os.close(fd)
+
+def extract_topology(ioapics_node, tables):
+    for subtable in tables.interrupt_controller_structures:
+        if subtable.subtype == apic.MADT_TYPE_IO_APIC:
+            apic_id = subtable.io_apic_id
+            ioapic_node = add_child(ioapics_node, "ioapic", None, id=hex(apic_id))
+            add_child(ioapic_node, "address", hex(subtable.io_apic_addr))
+            add_child(ioapic_node, "gsi_base", hex(subtable.global_sys_int_base))
+            extract_gsi_number(ioapic_node, apic_id)
+
+def extract(args, board_etree):
+    try:
+        tables = parse_apic()
+    except Exception as e:
+        logging.warning(f"Parse ACPI tables failed: {str(e)}")
+        logging.warning(f"Will not extract information from ACPI tables")
+        return
+
+    ioapics_node = get_node(board_etree, "//ioapics")
+    extract_topology(ioapics_node, tables)

--- a/misc/config_tools/board_inspector/extractors/50-acpi-namespace.py
+++ b/misc/config_tools/board_inspector/extractors/50-acpi-namespace.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/xforms/config.h.xsl
+++ b/misc/config_tools/xforms/config.h.xsl
@@ -7,6 +7,8 @@
     version="1.0"
     xmlns:xi="http://www.w3.org/2003/XInclude"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:math="http://exslt.org/math"
+    xmlns:exslt="http://exslt.org/common"
     xmlns:acrn="http://projectacrn.org">
   <xsl:include href="lib.xsl" />
   <xsl:output method="text" />

--- a/misc/config_tools/xforms/config.mk.xsl
+++ b/misc/config_tools/xforms/config.mk.xsl
@@ -7,6 +7,8 @@
     version="1.0"
     xmlns:xi="http://www.w3.org/2003/XInclude"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:math="http://exslt.org/math"
+    xmlns:exslt="http://exslt.org/common"
     xmlns:acrn="http://projectacrn.org">
   <xsl:include href="lib.xsl" />
   <xsl:output method="text" />

--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -15,6 +15,14 @@
       <xsl:with-param name="key" select="'BOARD'" />
       <xsl:with-param name="value" select="@board" />
     </xsl:call-template>
+    <xsl:call-template name="integer-by-key-value">
+      <xsl:with-param name="key" select="'MAX_IOAPIC_NUM'" />
+      <xsl:with-param name="value" select="count(//ioapic)" />
+    </xsl:call-template>
+    <xsl:call-template name="integer-by-key-value">
+      <xsl:with-param name="key" select="'MAX_IOAPIC_LINES'" />
+      <xsl:with-param name="value" select="math:max(//gsi_number/text() | exslt:node-set(0))" />
+    </xsl:call-template>
     <xsl:call-template name="msi-msix-max" />
   </xsl:template>
 
@@ -158,15 +166,7 @@
     </xsl:call-template>
 
     <xsl:call-template name="integer-by-key">
-      <xsl:with-param name="key" select="'MAX_IOAPIC_NUM'" />
-    </xsl:call-template>
-
-    <xsl:call-template name="integer-by-key">
       <xsl:with-param name="key" select="'MAX_PCI_DEV_NUM'" />
-    </xsl:call-template>
-
-    <xsl:call-template name="integer-by-key">
-      <xsl:with-param name="key" select="'MAX_IOAPIC_LINES'" />
     </xsl:call-template>
 
     <xsl:call-template name="integer-by-key">


### PR DESCRIPTION
1. Extract common ioapic information such as ioapic id, address, gsi base and gsi num to board.xml
2. Generate MAX_IOAPIC_NUM and MAX_IOAPIC_LINE based on board.xml based on the information from part 1.