### PR TITLE
dm: remove some dynamic parameters from acrn-dm usage

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -142,22 +142,19 @@ usage(int code)
 {
 	fprintf(stderr,
 		"Usage: %s [-hAWYv] [-B bootargs] [-E elf_image_path]\n"
-		"       %*s [-G GVT_args] [-i ioc_mediator_parameters] [-k kernel_image_path]\n"
+		"       %*s [-k kernel_image_path]\n"
 		"       %*s [-l lpc] [-m mem] [-r ramdisk_image_path]\n"
-		"       %*s [-s pci] [--vsbl vsbl_file_name] [--ovmf ovmf_file_path]\n"
-		"       %*s [--part_info part_info_name] [--enable_trusty] [--intr_monitor param_setting]\n"
+		"       %*s [-s pci] [--ovmf ovmf_file_path]\n"
+		"       %*s [--enable_trusty] [--intr_monitor param_setting]\n"
 		"       %*s [--acpidev_pt HID] [--mmiodev_pt MMIO_Regions]\n"
 		"       %*s [--vtpm2 sock_path] [--virtio_poll interval] [--mac_seed seed_string]\n"
 		"       %*s [--cpu_affinity pCPUs] [--lapic_pt] [--rtvm] [--windows]\n"
 		"       %*s [--debugexit] [--logger_setting param_setting]\n"
-		"       %*s [--pm_notify_channel channel] [--pm_by_vuart vuart_node]\n"
 		"       %*s [--ssram] <vm>\n"
 		"       -A: create ACPI tables\n"
 		"       -B: bootargs for kernel\n"
 		"       -E: elf image path\n"
-		"       -G: GVT args: low_gm_size, high_gm_size, fence_sz\n"
 		"       -h: help\n"
-		"       -i: ioc boot parameters\n"
 		"       -k: kernel image path\n"
 		"       -l: LPC device configuration\n"
 		"       -m: memory size in MB\n"
@@ -165,13 +162,10 @@ usage(int code)
 		"       -s: <slot,driver,configinfo> PCI slot config\n"
 		"       -v: version\n"
 		"       -W: force virtio to use single-vector MSI\n"
-		"       -Y: disable MPtable generation\n"
 		"       --mac_seed: set a platform unique string as a seed for generate mac address\n"
-		"       --vsbl: vsbl file path\n"
 		"       --ovmf: ovmf file path\n"
 		"       --ssram: Enable Software SRAM passthrough\n"
 		"       --cpu_affinity: list of pCPUs assigned to this VM\n"
-		"       --part_info: guest partition info file path\n"
 		"       --enable_trusty: enable trusty for guest\n"
 		"       --debugexit: enable debug exit function\n"
 		"       --intr_monitor: enable interrupt storm monitor\n"
@@ -183,15 +177,13 @@ usage(int code)
 		"       --lapic_pt: enable local apic passthrough\n"
 		"       --rtvm: indicate that the guest is rtvm\n"
 		"       --logger_setting: params like console,level=4;kmsg,level=3\n"
-		"       --pm_notify_channel: define the channel used to notify guest about power event\n"
-		"       --pm_by_vuart:pty,/run/acrn/vuart_vmname or tty,/dev/ttySn\n"
 		"       --windows: support Oracle virtio-blk, virtio-net and virtio-input devices\n"
 		"            for windows guest with secure boot\n",
 		progname, (int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
-		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "");
+		(int)strnlen(progname, PATH_MAX), "");
 
 	exit(code);
 }
@@ -849,7 +841,7 @@ main(int argc, char *argv[])
 			else
 				break;
 			break;
-		case 'i':
+		case 'i': /* obsolete parameter */
 			ioc_parse(optarg);
 			break;
 
@@ -872,7 +864,7 @@ main(int argc, char *argv[])
 		case 'W':
 			virtio_msix = 0;
 			break;
-		case 'Y':
+		case 'Y': /* obsolete parameter */
 			mptgen = 0;
 			break;
 		case 'k':
@@ -891,14 +883,14 @@ main(int argc, char *argv[])
 			else
 				break;
 			break;
-		case 'G':
+		case 'G': /* obsolete parameter */
 			if (acrn_parse_gvtargs(optarg) != 0)
 				errx(EX_USAGE, "invalid GVT param %s", optarg);
 			break;
 		case 'v':
 			print_version();
 			break;
-		case CMD_OPT_VSBL:
+		case CMD_OPT_VSBL: /* obsolete parameter */
 			if (high_bios_size() == 0 && acrn_parse_vsbl(optarg) != 0)
 				errx(EX_USAGE, "invalid vsbl param %s", optarg);
 			break;
@@ -911,7 +903,7 @@ main(int argc, char *argv[])
 			if (acrn_parse_cpu_affinity(optarg) != 0)
 				errx(EX_USAGE, "invalid pcpu param %s", optarg);
 			break;
-		case CMD_OPT_PART_INFO:
+		case CMD_OPT_PART_INFO: /* obsolete parameter */
 			if (acrn_parse_guest_part_info(optarg) != 0) {
 				errx(EX_USAGE,
 					"invalid guest partition info param %s",
@@ -968,7 +960,7 @@ main(int argc, char *argv[])
 			if (init_logger_setting(optarg) != 0)
 				errx(EX_USAGE, "invalid logger setting params %s", optarg);
 			break;
-		case CMD_OPT_PM_NOTIFY_CHANNEL:
+		case CMD_OPT_PM_NOTIFY_CHANNEL: /* obsolete parameter */
 			if (strncmp("ioc", optarg, sizeof("ioc")) == 0)
 				pm_notify_channel = PWR_EVENT_NOTIFY_IOC;
 			else if (strncmp("power_button", optarg, sizeof("power_button")) == 0)
@@ -984,7 +976,7 @@ main(int argc, char *argv[])
 			} else
 				errx(EX_USAGE, "invalid pm_notify_channel: %s", optarg);
 			break;
-		case CMD_OPT_PM_BY_VUART:
+		case CMD_OPT_PM_BY_VUART: /* obsolete parameter */
 			if (parse_pm_by_vuart(optarg) != 0)
 				errx(EX_USAGE, "invalid pm-by-vuart params %s", optarg);
 			break;

--- a/devicemodel/hw/pci/gvt.c
+++ b/devicemodel/hw/pci/gvt.c
@@ -5,6 +5,11 @@
  *
  */
 
+/*
+ * The interface of gvt is obsoleted.
+ * We reserve these code for future.
+ */
+
 #include <sys/stat.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/devicemodel/hw/pci/npk.c
+++ b/devicemodel/hw/pci/npk.c
@@ -4,6 +4,11 @@
  */
 
 /*
+ * The interface of npk is obsoleted.
+ * We reserve these code for future.
+ */
+
+/*
  * The Intel Trace Hub (aka. North Peak, NPK) is a trace aggregator for
  * Software, Firmware, and Hardware. On the virtualization platform, it
  * can be used to output the traces from Service VM/User VM/Hypervisor/FW together

--- a/devicemodel/hw/pci/virtio/virtio_coreu.c
+++ b/devicemodel/hw/pci/virtio/virtio_coreu.c
@@ -6,6 +6,11 @@
  */
 
 /*
+ * The interface of virtio_coreu is obsoleted.
+ * We reserve these code for future.
+ */
+
+/*
  * CoreU Virtualization
  *
  * CoreU is for PAVP session management. CoreU contains two parts, the daemon

--- a/devicemodel/hw/pci/virtio/virtio_hdcp.c
+++ b/devicemodel/hw/pci/virtio/virtio_hdcp.c
@@ -5,6 +5,11 @@
  *
  */
 
+ /*
+ * The interface of virtio_hdcp is obsoleted.
+ * We reserve these code for future.
+ */
+
 /*
  * HDCP Virtualization
  *

--- a/devicemodel/include/ioc.h
+++ b/devicemodel/include/ioc.h
@@ -822,7 +822,10 @@ struct ioc_state_info {
 	int32_t (*handler)(struct ioc_dev *ioc);
 };
 
-/* Parse IOC parameters */
+/*
+ * obsolete interface
+ * Parse IOC parameters
+ */
 int ioc_parse(const char *opts);
 
 struct vmctx;

--- a/devicemodel/include/pm_vuart.h
+++ b/devicemodel/include/pm_vuart.h
@@ -11,7 +11,7 @@
 #ifndef	__PM_VUART__
 #define	__PM_VUART__
 
-int parse_pm_by_vuart(const char *opts);
+int parse_pm_by_vuart(const char *opts); /* obsolete interface */
 int pm_by_vuart_init(struct vmctx *ctx, bool trigger_s5);
 void pm_by_vuart_deinit(struct vmctx *ctx);
 

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -63,11 +63,11 @@ size_t ovmf_image_size(void);
 int acrn_parse_kernel(char *arg);
 int acrn_parse_ramdisk(char *arg);
 int acrn_parse_bootargs(char *arg);
-int acrn_parse_gvtargs(char *arg);
-int acrn_parse_vsbl(char *arg);
+int acrn_parse_gvtargs(char *arg);         /* obsolete interface */
+int acrn_parse_vsbl(char *arg);            /* obsolete interface */
 int acrn_parse_ovmf(char *arg);
 int acrn_parse_elf(char *arg);
-int acrn_parse_guest_part_info(char *arg);
+int acrn_parse_guest_part_info(char *arg); /* obsolete interface */
 char *get_bootargs(void);
 void vsbl_set_bdf(int bnum, int snum, int fnum);
 


### PR DESCRIPTION
The following parameters have not used by new design:

1.  --vsbl <vsbl_file_path>
2.  --part_info <part_info_name>
3.  -G, --gvtargs <GVT_args>
4.  -s <slot>,pci-gvt
5.  -Y, --mptgen
6.  -s <slot>,virtio-hdcp
7.  -s <slot>,npk
8.  -s <slot>,virtio-coreu
9.  -i, --ioc_node <ioc_mediator_parameters>
10. --pm_by_vuart [pty|tty],<node_path>
11. --pm_notify_channel <channel>

This patch remove these parameters from usage and comment in code to
explain they are all obsoleted now.

Tracked-On: #6690 
Acked-by: Wang, Yu1 <yu1.wang@intel.com>
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>