### PR TITLE
Misc: acrnd: fix acrnd start failure

### DIFF
--- a/misc/services/acrn_manager/acrnd.service
+++ b/misc/services/acrn_manager/acrnd.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=ACRN manager deamon
-After=weston.service
 After=systemd-resolved.service
-ConditionPathExists=/sys/kernel/gvt
 ConditionPathExists=/dev/acrn_hsm
 
 [Service]


### PR DESCRIPTION
Currently, if user starts acrnd service, acrnd service will fail to
find the folder "/sys/kernel/gvt" in Service VM, fail to start.

Root cause is GVT-g is not supported in current ACRN, the folder
"/sys/kernel/gvt" will not be created in Service VM.

This patch updates acrnd service to remove this condition check.

v1-->v2:
	Weston service is optional for ACRN, acrnd should not depend
	on it, so remove weston service dependency in acrnd service.

Tracked-On: #6994
Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>