### PR TITLE
board_inspector/pcieparser: check config space size of PCIe devices

### DIFF
--- a/misc/config_tools/board_inspector/pcieparser/__init__.py
+++ b/misc/config_tools/board_inspector/pcieparser/__init__.py
@@ -36,7 +36,10 @@ def parse_config_space(path):
     hdr = header(data)
     caps = capabilities(data, hdr.capability_pointer)
     config_space = PCIConfigSpace(hdr, caps, [])
-    if config_space.has_cap("PCI Express"):
+    # While PCI Express specification requires that a PCIe endpoint must have an extended capability header at offset
+    # 100h of its configuration space, we do see real PCIe endpoints not meeting this requirement occasionally. Thus,
+    # check the length of the configuration space as well before trying to parse its extended capability list.
+    if config_space.has_cap("PCI Express") and len(data) >= 260:
         extcaps = extended_capabilities(data)
         config_space = PCIConfigSpace(hdr, caps, extcaps)
     return config_space


### PR DESCRIPTION
According to PCIe specification (since 2.0), absence of any extended
capabilities is required to be indicated by an extended capability header
with a capability ID of FFFFh and a next capability offset of 000h. Thus,
the board inspector today accesses the first extended capability header at
100h in the configuration space of a PCIe function unconditionally.

However, in practice we have seen real PCI functions which has a PCIe
capability but no extended capability header. This will cause the board
inspector to crash due to invalid configuration space accesses.

To fix that, this patch adds a check to the size of the configuration space
before walking the extended capabilities of a PCIe function.

Tracked-On: #6411
Signed-off-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>