### PR TITLE
deb-pkg: Delete the folder name of acrn-hypervisor in the configurati…

### DIFF
--- a/.deb.conf
+++ b/.deb.conf
@@ -1,138 +1,138 @@
 {
 "acrn.bin":{
-			"source":"acrn-hypervisor/build/hypervisor/acrn.bin",
+			"source":"build/hypervisor/acrn.bin",
 			"target":"boot/"
 			},
 "acrnctl":{
-			"source":"acrn-hypervisor/build/misc/services/acrnctl",
+			"source":"build/misc/services/acrnctl",
 			"target":"usr/bin/"
 			},
 "acrnd":{
-			"source":"acrn-hypervisor/build/misc/services/acrnd",
+			"source":"build/misc/services/acrnd",
 			"target":"usr/bin/"
 			},
 "acrn-dm":{
-			"source":"acrn-hypervisor/build/devicemodel/acrn-dm",
+			"source":"build/devicemodel/acrn-dm",
 			"target":"usr/bin/"
 			},
 "acrnlog":{
-			"source":"acrn-hypervisor/build/misc/debug_tools/acrnlog",
+			"source":"build/misc/debug_tools/acrnlog",
 			"target":"usr/bin/"
 			},
 "acrnprobe":{
-			"source":"acrn-hypervisor/build/misc/debug_tools/acrn-crashlog/acrnprobe/bin/acrnprobe",
+			"source":"build/misc/debug_tools/acrn-crashlog/acrnprobe/bin/acrnprobe",
 			"target":"usr/bin/"
 			},
 "acrntrace":{
-			"source":"acrn-hypervisor/build/misc/debug_tools/acrntrace",
+			"source":"build/misc/debug_tools/acrntrace",
 			"target":"usr/bin/"
 			},
 "crashlogctl":{
-			"source":"acrn-hypervisor/misc/debug_tools/acrn_crashlog/data/crashlogctl",
+			"source":"misc/debug_tools/acrn_crashlog/data/crashlogctl",
 			"target":"usr/bin/"
 			},
 "debugger":{
-			"source":"acrn-hypervisor/build/misc/debug_tools/acrn-crashlog/usercrash/bin/debugger",
+			"source":"build/misc/debug_tools/acrn-crashlog/usercrash/bin/debugger",
 			"target":"usr/bin/"
 			},
 "usercrash-wrapper":{
-			"source":"acrn-hypervisor/misc/debug_tools/acrn_crashlog/data/usercrash-wrapper",
+			"source":"misc/debug_tools/acrn_crashlog/data/usercrash-wrapper",
 			"target":"usr/bin/"
 			},
 "acrn.32.out":{
-			"source":"acrn-hypervisor/build/hypervisor/acrn.32.out",
+			"source":"build/hypervisor/acrn.32.out",
 			"target":"boot/"
 			},
 "ACPI_VM0.bin":{
-			"source":"acrn-hypervisor/build/hypervisor/acpi/ACPI_VM0.bin",
+			"source":"build/hypervisor/acpi/ACPI_VM0.bin",
 			"target":"boot"
 			},
 "ACPI_VM1.bin":{
-			"source":"acrn-hypervisor/build/hypervisor/acpi/ACPI_VM1.bin",
+			"source":"build/hypervisor/acpi/ACPI_VM1.bin",
 			"target":"boot"
 			},
 "100-acrn-grub":{
-			"source":"acrn-hypervisor/misc/packaging/100_ACRN",
+			"source":"misc/packaging/100_ACRN",
 			"target":"etc/grub.d/"
 			},
 "serial.conf":{
-			"source":"acrn-hypervisor/build/hypervisor/serial.conf",
+			"source":"build/hypervisor/serial.conf",
 			"target":"etc/"
 			},
 "50-acrn.netdev":{
-			"source":"acrn-hypervisor/misc/packaging/50-acrn.netdev",
+			"source":"misc/packaging/50-acrn.netdev",
 			"target":"usr/lib/systemd/network"
 			},
 "50-acrn.network":{
-			"source":"acrn-hypervisor/misc/packaging/50-acrn.network",
+			"source":"misc/packaging/50-acrn.network",
 			"target":"usr/lib/systemd/network"
 			},
 "50-eth.network":{
-			"source":"acrn-hypervisor/misc/packaging/50-eth.network",
+			"source":"misc/packaging/50-eth.network",
 			"target":"usr/lib/systemd/network"
 			},
 "50-tap0.netdev":{
-			"source":"acrn-hypervisor/misc/packaging/50-tap0.netdev",
+			"source":"misc/packaging/50-tap0.netdev",
 			"target":"usr/lib/systemd/network"
 			},
 "acrnd.service":{
-			"source":"acrn-hypervisor/build/misc/services/acrnd.service",
+			"source":"build/misc/services/acrnd.service",
 			"target":"usr/lib/systemd/system"
 			},
 "acrnlog.service":{
-			"source":"acrn-hypervisor/build/misc/debug_tools/acrnlog.service",
+			"source":"build/misc/debug_tools/acrnlog.service",
 			"target":"usr/lib/systemd/system"
 			},
 "acrnprobe.service":{
-			"source":"acrn-hypervisor/misc/debug_tools/acrn_crashlog/data/acrnprobe.service",
+			"source":"misc/debug_tools/acrn_crashlog/data/acrnprobe.service",
 			"target":"usr/lib/systemd/system"
 			},
 "usercrash.service":{
-			"source":"acrn-hypervisor/misc/debug_tools/acrn_crashlog/data/usercrash.service",
+			"source":"misc/debug_tools/acrn_crashlog/data/usercrash.service",
 			"target":"usr/lib/systemd/system"
 			},
 "libacrn-mngr.a":{
-			"source":"acrn-hypervisor/build/misc/services/libacrn-mngr.a",
+			"source":"build/misc/services/libacrn-mngr.a",
 			"target":"usr/lib64"
 			},
 "acrnprobe.xml":{
-			"source":"acrn-hypervisor/misc/debug_tools/acrn_crashlog/data/acrnprobe.xml",
+			"source":"misc/debug_tools/acrn_crashlog/data/acrnprobe.xml",
 			"target":"usr/share/defaults/telemetrics"
 			},
 "OVMF.fd":{
-			"source":"acrn-hypervisor/devicemodel/bios/OVMF.fd",
+			"source":"devicemodel/bios/OVMF.fd",
 			"target":"usr/share/acrn/bios"
 			},
 "40-watchdog.conf":{
-			"source":"acrn-hypervisor/misc/debug_tools/acrn_crashlog/data/40-watchdog.conf",
+			"source":"misc/debug_tools/acrn_crashlog/data/40-watchdog.conf",
 			"target":"usr/share/acrn/crashlog"
 			},
 "80-coredump.conf":{
-			"source":"acrn-hypervisor/misc/debug_tools/acrn_crashlog/data/80-coredump.conf",
+			"source":"misc/debug_tools/acrn_crashlog/data/80-coredump.conf",
 			"target":"usr/share/acrn/crashlog"
 			},
 "launch_hard_rt_vm.sh":{
-			"source":"acrn-hypervisor/misc/config_tools/data/sample_launch_scripts/nuc/launch_hard_rt_vm.sh",
+			"source":"misc/config_tools/data/sample_launch_scripts/nuc/launch_hard_rt_vm.sh",
 			"target":"usr/share/acrn/samples/nuc"
 			},
 "launch_uos.sh":{
-			"source":"acrn-hypervisor/misc/config_tools/data/sample_launch_scripts/nuc/launch_uos.sh",
+			"source":"misc/config_tools/data/sample_launch_scripts/nuc/launch_uos.sh",
 			"target":"usr/share/acrn/samples/nuc"
 			},
 "launch_vxworks.sh":{
-			"source":"acrn-hypervisor/misc/config_tools/data/sample_launch_scripts/nuc/launch_vxworks.sh",
+			"source":"misc/config_tools/data/sample_launch_scripts/nuc/launch_vxworks.sh",
 			"target":"usr/share/acrn/samples/nuc"
 			},
 "launch_win.sh":{
-			"source":"acrn-hypervisor/misc/config_tools/data/sample_launch_scripts/nuc/launch_win.sh",
+			"source":"misc/config_tools/data/sample_launch_scripts/nuc/launch_win.sh",
 			"target":"usr/share/acrn/samples/nuc"
 			},
 "launch_xenomai.sh":{
-			"source":"acrn-hypervisor/misc/config_tools/data/sample_launch_scripts/nuc/launch_xenomai.sh",
+			"source":"misc/config_tools/data/sample_launch_scripts/nuc/launch_xenomai.sh",
 			"target":"usr/share/acrn/samples/nuc"
 			},
 "launch_zephyr.sh":{
-			"source":"acrn-hypervisor/misc/config_tools/data/sample_launch_scripts/nuc/launch_zephyr.sh",
+			"source":"misc/config_tools/data/sample_launch_scripts/nuc/launch_zephyr.sh",
 			"target":"usr/share/acrn/samples/nuc"
 			}
 }

--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -92,7 +92,7 @@ def create_acrn_deb(board, scenario, version, build_dir):
         target = deb_info[i]['target']
         if target == 'boot/':
             continue
-        source = cur_dir + '/../' + source
+        source = cur_dir + source
         target = deb_dir + target
         if os.path.exists(target):
             run_command('cp %s %s' % (source, target), cur_dir)


### PR DESCRIPTION
…on file

When cloning the ACRN source code to a folder, which is not named "acrn-hypervisor",
the debian package created by the "make" call does not contain all needed files.
Because the file ".deb.conf" contains hardcoded folder names which contain the
folder name "acrn-hypervisor".

Tracked-On: #7022

Signed-off-by: Hu Fenglin <fenglin.hu@intel.com>