### PR TITLE
config_tools: remove some dynamic parameters of acrn-dm

### DIFF
--- a/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
@@ -6,8 +6,6 @@
     <mem_size desc="User VM memory size in MByte">4096</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -53,8 +51,6 @@
     <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
@@ -6,8 +6,6 @@
     <mem_size desc="UOS memory size in MByte">4096</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -53,9 +51,7 @@
     <mem_size desc="UOS memory size in MByte">1024</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
       <pcpu_id/>
@@ -100,8 +96,6 @@
     <mem_size desc="UOS memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -147,8 +141,6 @@
     <mem_size desc="UOS memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -194,8 +186,6 @@
     <mem_size desc="UOS memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -241,8 +231,6 @@
     <mem_size desc="UOS memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
@@ -1,9 +1,9 @@
 <acrn-config board="generic_board" scenario="shared" user_vm_launcher="6">
   <user_vm id="1">
-    <user_vm_type desc="UOS type">WINDOWS</user_vm_type>
+    <user_vm_type desc="User VM type">WINDOWS</user_vm_type>
     <vm_name>POST_STD_VM1</vm_name>
-    <rtos_type desc="UOS Realtime capability">no</rtos_type>
-    <mem_size desc="UOS memory size in MByte">4096</mem_size>
+    <rtos_type desc="User VM Realtime capability">no</rtos_type>
+    <mem_size desc="User VM memory size in MByte">4096</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
@@ -45,10 +45,10 @@
     </sriov>
   </user_vm>
   <user_vm id="2">
-    <user_vm_type desc="UOS type">PREEMPT-RT LINUX</user_vm_type>
+    <user_vm_type desc="User VM type">PREEMPT-RT LINUX</user_vm_type>
     <vm_name>POST_RT_VM1</vm_name>
-    <rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
-    <mem_size desc="UOS memory size in MByte">1024</mem_size>
+    <rtos_type desc="User VM Realtime capability">Hard RT</rtos_type>
+    <mem_size desc="User VM memory size in MByte">1024</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
@@ -90,10 +90,10 @@
     </sriov>
   </user_vm>
   <user_vm id="3">
-    <user_vm_type desc="UOS type">YOCTO</user_vm_type>
+    <user_vm_type desc="User VM type">YOCTO</user_vm_type>
     <vm_name>POST_STD_VM2</vm_name>
-    <rtos_type desc="UOS Realtime capability">no</rtos_type>
-    <mem_size desc="UOS memory size in MByte">512</mem_size>
+    <rtos_type desc="User VM Realtime capability">no</rtos_type>
+    <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
@@ -135,10 +135,10 @@
     </sriov>
   </user_vm>
   <user_vm id="4">
-    <user_vm_type desc="UOS type">YOCTO</user_vm_type>
+    <user_vm_type desc="User VM type">YOCTO</user_vm_type>
     <vm_name>POST_STD_VM3</vm_name>
-    <rtos_type desc="UOS Realtime capability">no</rtos_type>
-    <mem_size desc="UOS memory size in MByte">512</mem_size>
+    <rtos_type desc="User VM Realtime capability">no</rtos_type>
+    <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
@@ -180,10 +180,10 @@
     </sriov>
   </user_vm>
   <user_vm id="5">
-    <user_vm_type desc="UOS type">YOCTO</user_vm_type>
+    <user_vm_type desc="User VM type">YOCTO</user_vm_type>
     <vm_name>POST_STD_VM4</vm_name>
-    <rtos_type desc="UOS Realtime capability">no</rtos_type>
-    <mem_size desc="UOS memory size in MByte">512</mem_size>
+    <rtos_type desc="User VM Realtime capability">no</rtos_type>
+    <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
@@ -225,10 +225,10 @@
     </sriov>
   </user_vm>
   <user_vm id="6">
-    <user_vm_type desc="UOS type">YOCTO</user_vm_type>
+    <user_vm_type desc="User VM type">YOCTO</user_vm_type>
     <vm_name>POST_STD_VM5</vm_name>
-    <rtos_type desc="UOS Realtime capability">no</rtos_type>
-    <mem_size desc="UOS memory size in MByte">512</mem_size>
+    <rtos_type desc="User VM Realtime capability">no</rtos_type>
+    <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
@@ -6,8 +6,6 @@
     <mem_size desc="User VM memory size in MByte">4096</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -53,8 +51,6 @@
     <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
@@ -6,8 +6,6 @@
     <mem_size desc="User VM memory size in MByte">4096</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -53,9 +51,7 @@
     <mem_size desc="User VM memory size in MByte">1024</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
       <pcpu_id/>
@@ -100,8 +96,6 @@
     <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -147,8 +141,6 @@
     <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -194,8 +186,6 @@
     <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -241,8 +231,6 @@
     <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
@@ -6,8 +6,6 @@
     <mem_size desc="User VM memory size in MByte">4096</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/sdc_launch_1user_vm_laag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc_launch_1user_vm_laag.xml
@@ -6,8 +6,6 @@
     <mem_size desc="User VM memory size in MByte">2048</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/sdc_launch_1user_vm_zephyr.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc_launch_1user_vm_zephyr.xml
@@ -6,8 +6,6 @@
     <mem_size desc="User VM memory size in MByte">128</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
@@ -6,8 +6,6 @@
     <mem_size desc="User VM memory size in MByte">1024</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_vxworks.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_vxworks.xml
@@ -6,8 +6,6 @@
     <mem_size desc="User VM memory size in MByte">2048</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
@@ -6,8 +6,6 @@
     <mem_size desc="User VM memory size in MByte">4096</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
@@ -6,8 +6,6 @@
     <mem_size desc="User VM memory size in MByte">4096</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -53,8 +51,6 @@
     <mem_size desc="User VM memory size in MByte">1024</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
@@ -6,8 +6,6 @@
     <mem_size desc="User VM memory size in MByte">4096</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -53,8 +51,6 @@
     <mem_size desc="User VM memory size in MByte">1024</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -100,8 +96,6 @@
     <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -147,8 +141,6 @@
     <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -194,8 +186,6 @@
     <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -241,8 +231,6 @@
     <mem_size desc="User VM memory size in MByte">512</mem_size>
     <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-    <poweroff_channel desc="the method of power off User VM"/>
-    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <enable_ptm desc="enable ptm of User VM">n</enable_ptm>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"/>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -563,27 +563,6 @@ def dm_arg_set(names, sel, virt_io, dm, sriov, vmid, config):
     if user_vm_type == "WINDOWS":
         print("   --windows \\", file=config)
 
-    # pm_channel set
-    if dm['pm_channel'][vmid] and dm['pm_channel'][vmid] != None:
-        pm_key = dm['pm_channel'][vmid]
-        pm_vuart = "--pm_notify_channel uart"
-        if vmid in dm["allow_trigger_s5"] and dm["allow_trigger_s5"][vmid] == 'y':
-            pm_vuart = pm_vuart + ",allow_trigger_s5 "
-        else:
-            pm_vuart = pm_vuart + " "
-        if pm_key == "vuart1(tty)":
-            vuart_base = launch_cfg_lib.get_vuart1_from_scenario(sos_vmid + vmid)
-            if vuart_base == "INVALID_COM_BASE":
-                err_key = "user_vm:id={}:poweroff_channel".format(vmid)
-                launch_cfg_lib.ERR_LIST[err_key] = "vuart1 of VM{} in scenario file should select 'SERVICE_VM_COM2_BASE'".format(sos_vmid + vmid)
-                return
-            scenario_cfg_lib.get_sos_vuart_settings()
-            print("   {} \\".format(pm_vuart + launch_cfg_lib.PM_CHANNEL_DIC[pm_key] + scenario_cfg_lib.SERVICE_VM_UART1_VALID_NUM), file=config)
-        elif pm_key == "vuart1(pty)":
-            print("   {} \\".format(pm_vuart + launch_cfg_lib.PM_CHANNEL_DIC[pm_key]), file=config)
-        else:
-            print("   {} \\".format(launch_cfg_lib.PM_CHANNEL_DIC[pm_key]), file=config)
-
     # set logger_setting for all VMs
     print("   $logger_setting \\", file=config)
 

--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -196,19 +196,6 @@ def run_container(board_name, user_vm_type, config):
     print('}', file=config)
     print('', file=config)
 
-def boot_image_type(args, vmid, config):
-
-    if not args['vbootloader'][vmid] or (args['vbootloader'][vmid] and args['vbootloader'][vmid] != "vsbl"):
-        return
-
-    print('boot_dev_flag=",b"', file=config)
-    print("if [ $4 == 1 ];then", file=config)
-    print('  boot_image_option="--vsbl /usr/share/acrn/bios/VSBL_debug.bin"', file=config)
-    print("else", file=config)
-    print('  boot_image_option="--vsbl /usr/share/acrn/bios/VSBL.bin"', file=config)
-    print("fi", file=config)
-    print("", file=config)
-
 
 def interrupt_storm(pt_sel, config):
     if not pt_sel:
@@ -458,8 +445,6 @@ def vboot_arg_set(dm, vmid, config):
     # TODO: Support to generate '-k' xml config from webUI and to parse it
     if dm['vbootloader'][vmid] == "ovmf":
         print("   --ovmf /usr/share/acrn/bios/OVMF.fd \\", file=config)
-    elif dm['vbootloader'][vmid] == "vsbl":
-        print("   $boot_image_option \\",file=config)
 
 
 def xhci_args_set(dm, vmid, config):
@@ -553,15 +538,12 @@ def dm_arg_set(names, sel, virt_io, dm, sriov, vmid, config):
     user_vm_type = names['user_vm_types'][vmid]
     board_name = names['board_name']
 
-    boot_image_type(dm, vmid, config)
-
     sos_vmid = launch_cfg_lib.get_sos_vmid()
 
     # clearlinux/android/alios
-    print('acrn-dm -A -m $mem_size -s 0:0,hostbridge \\', file=config)
+    print('acrn-dm -m $mem_size -s 0:0,hostbridge \\', file=config)
     if launch_cfg_lib.is_linux_like(user_vm_type) or user_vm_type in ("ANDROID", "ALIOS"):
         if user_vm_type in ("ANDROID", "ALIOS"):
-            print('   $npk_virt \\', file=config)
             print("   -s {},virtio-rpmb \\".format(launch_cfg_lib.virtual_dev_slot("virtio-rpmb")), file=config)
             print("   --enable_trusty \\", file=config)
         # mac_seed
@@ -651,7 +633,6 @@ def dm_arg_set(names, sel, virt_io, dm, sriov, vmid, config):
 
     if launch_cfg_lib.is_linux_like(user_vm_type) or user_vm_type in ("ANDROID", "ALIOS"):
         if board_name == "apl-mrb":
-            print("   -i /run/acrn/ioc_$vm_name,0x20 \\", file=config)
             print("   -l com2,/run/acrn/ioc_$vm_name \\", file=config)
 
         if not is_nuc_whl_linux(names, vmid):

--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -52,10 +52,8 @@ def get_launch_item_values(board_info, scenario_info=None):
 
     launch_item_values["user_vm,vbootloader"] = launch_cfg_lib.BOOT_TYPE
     launch_item_values['user_vm,vuart0'] = launch_cfg_lib.DM_VUART0
-    launch_item_values['user_vm,poweroff_channel'] = launch_cfg_lib.PM_CHANNEL
     launch_item_values["user_vm,cpu_affinity"] = board_cfg_lib.get_processor_info()
     launch_item_values['user_vm,enable_ptm'] = launch_cfg_lib.y_n
-    launch_item_values['user_vm,allow_trigger_s5'] = launch_cfg_lib.y_n
     launch_cfg_lib.set_shm_regions(launch_item_values, scenario_info)
     launch_cfg_lib.set_pci_vuarts(launch_item_values, scenario_info)
 

--- a/misc/config_tools/launch_config/launch_item.py
+++ b/misc/config_tools/launch_config/launch_item.py
@@ -25,7 +25,6 @@ class AcrnDmArgs:
         self.args["vbootloader"] = common.get_leaf_tag_map(self.launch_info, "vbootloader")
         self.args["vuart0"] = common.get_leaf_tag_map(self.launch_info, "vuart0")
         self.args["cpu_sharing"] = common.get_hv_item_tag(self.scenario_info, "FEATURES", "SCHEDULER")
-        self.args["pm_channel"] = common.get_leaf_tag_map(self.launch_info, "poweroff_channel")
         self.args["cpu_affinity"] = common.get_leaf_tag_map(self.launch_info, "cpu_affinity", "pcpu_id")
         # get default cpu_affinity from scenario file
         scenario_names = {v: k for k, v in common.get_leaf_tag_map(self.scenario_info, "name").items()}
@@ -53,7 +52,6 @@ class AcrnDmArgs:
         self.args["communication_vuarts"] = common.get_leaf_tag_map(self.launch_info, "communication_vuarts", "communication_vuart")
         self.args["console_vuart"] = common.get_leaf_tag_map(self.launch_info, "console_vuart")
         self.args["enable_ptm"] = common.get_leaf_tag_map(self.launch_info, "enable_ptm")
-        self.args["allow_trigger_s5"] = common.get_leaf_tag_map(self.launch_info, "allow_trigger_s5")
 
     def check_item(self):
         (rootfs, num) = board_cfg_lib.get_rootfs(self.board_info)
@@ -63,7 +61,6 @@ class AcrnDmArgs:
         launch_cfg_lib.args_aval_check(self.args["vbootloader"], "vbootloader", launch_cfg_lib.BOOT_TYPE)
         launch_cfg_lib.args_aval_check(self.args["vuart0"], "vuart0", launch_cfg_lib.DM_VUART0)
         launch_cfg_lib.args_aval_check(self.args["enable_ptm"], "enable_ptm", launch_cfg_lib.y_n)
-        launch_cfg_lib.args_aval_check(self.args["allow_trigger_s5"], "allow_trigger_s5", launch_cfg_lib.y_n)
         cpu_affinity = launch_cfg_lib.user_vm_cpu_affinity(self.args["cpu_affinity"])
         err_dic = scenario_cfg_lib.vm_cpu_affinity_check(self.scenario_info, self.launch_info, cpu_affinity)
         launch_cfg_lib.ERR_LIST.update(err_dic)

--- a/misc/config_tools/launch_config/pt.py
+++ b/misc/config_tools/launch_config/pt.py
@@ -74,8 +74,6 @@ def ipu_pt(sel, vmid, config):
         print("    fi", file=config)
 
     if bdf_ipu or bdf_ipu_i2c:
-        print("else", file=config)
-        print('    boot_ipu_option="$boot_ipu_option"" -s {},virtio-ipu "'.format(launch_cfg_lib.virtual_dev_slot("virtio-ipu")), file=config)
         print("fi", file=config)
         print("", file=config)
 
@@ -189,8 +187,6 @@ def audio_pt(user_vm_type, sel, vmid, config):
                 print('    boot_audio_option="-s {},passthru,{}/{}/{}"'.format(
                     slot_audio, bus, dev, fun), file=config)
 
-        print("else", file=config)
-        print('    boot_audio_option="-s {},virtio-audio"'.format(slot_audio), file=config)
         print("fi", file=config)
 
 

--- a/misc/config_tools/library/launch_cfg_lib.py
+++ b/misc/config_tools/library/launch_cfg_lib.py
@@ -50,15 +50,6 @@ PT_SLOT = {
     }
 
 
-PM_CHANNEL = ['', 'IOC', 'PowerButton', 'vuart1(pty)', 'vuart1(tty)']
-PM_CHANNEL_DIC = {
-    None:'',
-    'IOC':'--pm_notify_channel ioc',
-    'PowerButton':'--pm_notify_channel power_button',
-    'vuart1(pty)':'--pm_by_vuart pty,/run/acrn/life_mngr_$vm_name \\\n   -l com2,/run/acrn/life_mngr_$vm_name',
-    'vuart1(tty)':'--pm_by_vuart tty,/dev/',
-}
-
 MOUNT_FLAG_DIC = {}
 
 

--- a/misc/config_tools/library/launch_cfg_lib.py
+++ b/misc/config_tools/library/launch_cfg_lib.py
@@ -14,7 +14,7 @@ import lxml
 import lxml.etree
 
 ERR_LIST = {}
-BOOT_TYPE = ['no', 'vsbl', 'ovmf']
+BOOT_TYPE = ['no', 'ovmf']
 RTOS_TYPE = ['no', 'Soft RT', 'Hard RT']
 DM_VUART0 = ['Disable', 'Enable']
 y_n = ['y', 'n']


### PR DESCRIPTION
Since PR #7002 has removed some dynamic parameters from acrn-dm usage, this patch also removes the following parameters in launch script generation logic.

1. --vsbl <vsbl_file_path>
2. -s <slot>,npk
3. -i, --ioc_node <ioc_mediator_parameters>
4. -A, --acpi
5. virtio-ipu
6. virtio-audio
7. --pm_notify_channel
8. --pm_by_vuart
