### PR TITLE
config_tools: add __init__.py under static_allocators/lib directory

### DIFF
--- a/misc/config_tools/static_allocators/lib/__init__.py
+++ b/misc/config_tools/static_allocators/lib/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2021 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#


### PR DESCRIPTION
If the user installed the lib python package in the host machine,
it will fail to build acrn hypervisor since the same package named lib is
also used in acrn config tool(static_allocators/lib).
So we add the __init__.py file under the static_allocators/lib directory
to fix the error.

Tracked-On: #7001
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>