### PR TITLE
config_tools: merge board_private.rootfs/bootargs to os_config.bootargs

### DIFF
--- a/misc/config_tools/data/cfl-k700-i7/hybrid.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid.xml
@@ -138,7 +138,9 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>SERVICE_VM_OS_BOOTARGS</bootargs>
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check
+        quiet loglevel=3 i915.nuclear_pageflip=1 swiotlb=131072
+        </bootargs>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>
@@ -163,12 +165,6 @@
     <pci_devs>
       <pci_dev/>
     </pci_devs>
-    <board_private>
-      <rootfs>/dev/nvme0n1p3</rootfs>
-      <bootargs>        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 swiotlb=131072
-        </bootargs>
-    </board_private>
   </vm>
   <vm id="2">
     <vm_type>POST_STD_VM</vm_type>

--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -134,7 +134,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>SERVICE_VM_OS_BOOTARGS</bootargs>
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=ttyS0,115200n8 ignore_loglevel no_timer_check</bootargs>
     </os_config>
     <cpu_affinity>
       <pcpu_id>0</pcpu_id>
@@ -167,12 +167,6 @@
     <pci_devs>
       <pci_dev/>
     </pci_devs>
-    <board_private>
-      <rootfs>/dev/nvme0n1p3</rootfs>
-      <bootargs>
-        rw rootwait console=ttyS0,115200n8 ignore_loglevel no_timer_check
-        </bootargs>
-    </board_private>
   </vm>
   <vm id="2">
     <vm_type>POST_STD_VM</vm_type>

--- a/misc/config_tools/data/cfl-k700-i7/shared.xml
+++ b/misc/config_tools/data/cfl-k700-i7/shared.xml
@@ -67,7 +67,8 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>SERVICE_VM_OS_BOOTARGS</bootargs>
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1</bootargs>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>
@@ -92,13 +93,6 @@
     <pci_devs>
       <pci_dev/>
     </pci_devs>
-    <board_private>
-      <rootfs>/dev/nvme0n1p3</rootfs>
-      <bootargs>
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1
-        </bootargs>
-    </board_private>
   </vm>
   <vm id="1">
     <vm_type>POST_STD_VM</vm_type>

--- a/misc/config_tools/data/generic_board/hybrid.xml
+++ b/misc/config_tools/data/generic_board/hybrid.xml
@@ -138,7 +138,8 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>SERVICE_VM_OS_BOOTARGS</bootargs>
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 swiotlb=131072</bootargs>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>
@@ -163,12 +164,6 @@
     <pci_devs>
       <pci_dev/>
     </pci_devs>
-    <board_private>
-      <rootfs>/dev/nvme0n1p3</rootfs>
-      <bootargs>        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 swiotlb=131072
-        </bootargs>
-    </board_private>
   </vm>
   <vm id="2">
     <vm_type>POST_STD_VM</vm_type>

--- a/misc/config_tools/data/generic_board/hybrid_rt.xml
+++ b/misc/config_tools/data/generic_board/hybrid_rt.xml
@@ -144,7 +144,8 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>SERVICE_VM_OS_BOOTARGS</bootargs>
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+            i915.nuclear_pageflip=1 swiotlb=131072</bootargs>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>
@@ -169,13 +170,6 @@
     <pci_devs>
       <pci_dev/>
     </pci_devs>
-    <board_private>
-      <rootfs>/dev/nvme0n1p3</rootfs>
-      <bootargs>
-            rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-            i915.nuclear_pageflip=1 swiotlb=131072
-            </bootargs>
-    </board_private>
   </vm>
   <vm id="2">
     <vm_type>POST_STD_VM</vm_type>

--- a/misc/config_tools/data/generic_board/shared.xml
+++ b/misc/config_tools/data/generic_board/shared.xml
@@ -74,7 +74,8 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>SERVICE_VM_OS_BOOTARGS</bootargs>
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 swiotlb=131072</bootargs>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>
@@ -99,12 +100,6 @@
     <pci_devs>
       <pci_dev/>
     </pci_devs>
-    <board_private>
-      <rootfs>/dev/nvme0n1p3</rootfs>
-      <bootargs>        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 swiotlb=131072
-        </bootargs>
-    </board_private>
   </vm>
   <vm id="1">
     <vm_type>POST_STD_VM</vm_type>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid.xml
@@ -138,7 +138,8 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>SERVICE_VM_OS_BOOTARGS</bootargs>
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 swiotlb=131072</bootargs>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>
@@ -163,12 +164,6 @@
     <pci_devs>
       <pci_dev/>
     </pci_devs>
-    <board_private>
-      <rootfs>/dev/nvme0n1p3</rootfs>
-      <bootargs>        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 swiotlb=131072
-        </bootargs>
-    </board_private>
   </vm>
   <vm id="2">
     <vm_type>POST_STD_VM</vm_type>

--- a/misc/config_tools/data/nuc11tnbi5/shared.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared.xml
@@ -74,7 +74,8 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>SERVICE_VM_OS_BOOTARGS</bootargs>
+      <bootargs>rw rootwait root=/dev/nvme0n1p3 console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 swiotlb=131072</bootargs>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>
@@ -99,12 +100,6 @@
     <pci_devs>
       <pci_dev/>
     </pci_devs>
-    <board_private>
-      <rootfs>/dev/nvme0n1p3</rootfs>
-      <bootargs>        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 swiotlb=131072
-        </bootargs>
-    </board_private>
   </vm>
   <vm id="1">
     <vm_type>POST_STD_VM</vm_type>

--- a/misc/config_tools/data/qemu/shared.xml
+++ b/misc/config_tools/data/qemu/shared.xml
@@ -66,7 +66,8 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>SERVICE_VM_OS_BOOTARGS</bootargs>
+      <bootargs>root=/dev/vda1 earlyprintk=serial,ttyS0,115200n8 rw rootwait console=tty0 consoleblank=0 no_timer_check ignore_loglevel
+        ignore_loglevel no_timer_check intel_iommu=off tsc=reliable</bootargs>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>
@@ -91,13 +92,6 @@
     <pci_devs>
       <pci_dev/>
     </pci_devs>
-    <board_private>
-      <rootfs>/dev/vda1</rootfs>
-      <bootargs>
-        earlyprintk=serial,ttyS0,115200n8 rw rootwait console=tty0 consoleblank=0 no_timer_check ignore_loglevel
-        ignore_loglevel no_timer_check intel_iommu=off tsc=reliable
-        </bootargs>
-    </board_private>
   </vm>
   <vm id="1">
     <vm_type>POST_STD_VM</vm_type>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -128,7 +128,8 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>SERVICE_VM_OS_BOOTARGS</bootargs>
+      <bootargs>root=/dev/sda3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1</bootargs>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>
@@ -153,13 +154,6 @@
     <pci_devs>
       <pci_dev/>
     </pci_devs>
-    <board_private>
-      <rootfs>/dev/sda3</rootfs>
-      <bootargs>
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1
-        </bootargs>
-    </board_private>
   </vm>
   <vm id="2">
     <vm_type>POST_STD_VM</vm_type>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
@@ -133,7 +133,8 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>SERVICE_VM_OS_BOOTARGS</bootargs>
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1</bootargs>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>
@@ -158,13 +159,6 @@
     <pci_devs>
       <pci_dev/>
     </pci_devs>
-    <board_private>
-      <rootfs>/dev/nvme0n1p3</rootfs>
-      <bootargs>
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1
-        </bootargs>
-    </board_private>
   </vm>
   <vm id="2">
     <vm_type>POST_STD_VM</vm_type>

--- a/misc/config_tools/data/whl-ipc-i5/sdc.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc.xml
@@ -65,7 +65,8 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>SERVICE_VM_OS_BOOTARGS</bootargs>
+      <bootargs>root=/dev/sda3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1</bootargs>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>
@@ -90,13 +91,6 @@
     <pci_devs>
       <pci_dev/>
     </pci_devs>
-    <board_private>
-      <rootfs>/dev/sda3</rootfs>
-      <bootargs>
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1
-        </bootargs>
-    </board_private>
   </vm>
   <vm id="1">
     <vm_type>POST_STD_VM</vm_type>

--- a/misc/config_tools/data/whl-ipc-i5/shared.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared.xml
@@ -66,7 +66,8 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>SERVICE_VM_OS_BOOTARGS</bootargs>
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1</bootargs>
     </os_config>
     <legacy_vuart id="0">
       <type>VUART_LEGACY_PIO</type>
@@ -91,13 +92,6 @@
     <pci_devs>
       <pci_dev/>
     </pci_devs>
-    <board_private>
-      <rootfs>/dev/nvme0n1p3</rootfs>
-      <bootargs>
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1
-        </bootargs>
-    </board_private>
   </vm>
   <vm id="1">
     <vm_type>POST_STD_VM</vm_type>

--- a/misc/config_tools/library/scenario_cfg_lib.py
+++ b/misc/config_tools/library/scenario_cfg_lib.py
@@ -197,22 +197,6 @@ def get_pci_dev_num_per_vm():
     return pci_dev_num_per_vm
 
 
-def check_board_private_info():
-
-    if 'SERVICE_VM' not in common.VM_TYPES.values():
-        return
-    branch_tag = "board_private"
-    private_info = {}
-    dev_private_tags = ['rootfs']
-    for tag_str in dev_private_tags:
-        dev_setting = common.get_leaf_tag_map(common.SCENARIO_INFO_FILE, branch_tag, tag_str)
-        private_info[tag_str] = dev_setting
-
-    if not private_info['rootfs'] and err_dic:
-        ERR_LIST['vm:id=0,boot_private,rootfs'] = "The board have to chose one rootfs partition"
-        ERR_LIST.update(err_dic)
-
-
 def vm_name_check(vm_names, item):
     """
     Check vm name
@@ -471,23 +455,6 @@ def os_kern_mod_check(id_kern_mod_dic, prime_item, item):
         if len(kern_mod) > 32 or len(kern_mod) == 0:
             key = "vm:id={},{},{}".format(id_key, prime_item, item)
             ERR_LIST[key] = "VM os config kernel mod tag should be in range [1,32] bytes"
-
-
-def os_kern_args_check(id_kern_args_dic, prime_item, item):
-    """
-    Check os kernel args
-    :param prime_item: the prime item in xml file
-    :param item: vm os config args item in xml
-    :return: None
-    """
-
-    for vm_i,vm_type in common.VM_TYPES.items():
-        if vm_i not in id_kern_args_dic.keys():
-            continue
-        kern_args = id_kern_args_dic[vm_i]
-        if "SERVICE_" in vm_type and kern_args != "SERVICE_VM_OS_BOOTARGS":
-            key = "vm:id={},{},{}".format(vm_i, prime_item, item)
-            ERR_LIST[key] = "VM os config kernel service os should be SERVICE_VM_OS_BOOTARGS"
 
 
 def os_kern_load_addr_check(kern_type, id_kern_load_addr_dic, prime_item, item):

--- a/misc/config_tools/scenario_config/scenario_cfg_gen.py
+++ b/misc/config_tools/scenario_config/scenario_cfg_gen.py
@@ -63,7 +63,6 @@ def get_scenario_item_values(board_info, scenario_info):
     scenario_item_values["vm,communication_vuart,base"] = ['INVALID_PCI_BASE', 'PCI_VUART']
 
     # board
-    (scenario_item_values["vm,board_private,rootfs"], num) = board_cfg_lib.get_rootfs(board_info)
 
     scenario_item_values["hv,DEBUG_OPTIONS,RELEASE"] = hv_cfg_lib.N_Y
     scenario_item_values["hv,DEBUG_OPTIONS,NPK_LOGLEVEL"] = hv_cfg_lib.get_select_range("DEBUG_OPTIONS", "LOG_LEVEL")

--- a/misc/config_tools/scenario_config/scenario_item.py
+++ b/misc/config_tools/scenario_config/scenario_item.py
@@ -108,7 +108,6 @@ class CfgOsKern:
         scenario_cfg_lib.os_kern_name_check(self.kern_name, "os_config", "name")
         scenario_cfg_lib.os_kern_type_check(self.kern_type, "os_config", "kern_type")
         scenario_cfg_lib.os_kern_mod_check(self.kern_mod, "os_config", "kern_mod")
-        scenario_cfg_lib.os_kern_args_check(self.kern_args, "os_config", "kern_args")
         scenario_cfg_lib.os_kern_load_addr_check(self.kern_type, self.kern_load_addr, "os_config", "kern_load_addr")
         scenario_cfg_lib.os_kern_entry_addr_check(self.kern_type, self.kern_entry_addr, "os_config", "kern_entry_addr")
 
@@ -140,7 +139,6 @@ class VuartInfo:
         Check all items in this class
         :return: None
         """
-        scenario_cfg_lib.check_board_private_info()
         scenario_cfg_lib.check_vuart(self.v0_vuart, self.v1_vuart)
         scenario_cfg_lib.check_pci_vuart(self.pci_vuarts, self.v0_vuart, self.v1_vuart)
 

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -183,7 +183,7 @@ must exactly match the module tag in the GRUB multiboot cmdline.</xs:documentati
       </xs:annotation>
     </xs:element>
     <xs:element name="bootargs" type="xs:string">
-      <xs:annotation acrn:configurable="../../vm_type[starts-with(text(), 'PRE')]">
+      <xs:annotation>
         <xs:documentation>Configurable boot argument for pre-launched VM of hybrid or hybrid_rt mode.</xs:documentation>
       </xs:annotation>
     </xs:element>
@@ -368,21 +368,6 @@ to the pre-launched VM.</xs:documentation>
     <xs:element name="pci_dev" type="xs:string" maxOccurs="unbounded">
       <xs:annotation>
         <xs:documentation>A passthrough PCI device.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
-  </xs:sequence>
-</xs:complexType>
-
-<xs:complexType name="BoardPrivateConfiguration">
-  <xs:sequence>
-    <xs:element name="rootfs" type="xs:string" default="/dev/nvme0n1p3">
-      <xs:annotation>
-        <xs:documentation>Rootfs for the Linux kernel.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
-    <xs:element name="bootargs" type="xs:string">
-      <xs:annotation>
-        <xs:documentation>Specify kernel boot arguments for Service VM OS.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:sequence>

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -410,7 +410,6 @@ its ``id`` attribute. When it is enabled, specify which target VM's vUART the cu
         <xs:documentation>PCI devices list.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="board_private" type="BoardPrivateConfiguration" minOccurs="0" />
     <xs:element name="PTM" type="Boolean" default="y" minOccurs="0">
       <xs:annotation>
         <xs:documentation>Enable and disable PTM(Precision Timing Measurement) feature.</xs:documentation>


### PR DESCRIPTION
1. remove the board_private tag in the schema and all existing scenario XML files,
and remove the related value check about board_private.rootfs and bootargs.
2. merge board_private.rootfs and board_private.bootargs to os_config.bootargs.
and no change to the related contents of the .c/.h files except the order of define SERVICE_VM_ROOTFS.
3. update the schema to make os_config.bootargs configurable for service VM in UI.

Tracked-On: #6690
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>