### PR TITLE
doc: update some dynamic parameters from acrn-dm usage 

### DIFF
--- a/doc/developer-guides/hld/hld-devicemodel.rst
+++ b/doc/developer-guides/hld/hld-devicemodel.rst
@@ -58,7 +58,7 @@ options:
                [--enable_trusty] [--intr_monitor param_setting]
                [--acpidev_pt HID] [--mmiodev_pt MMIO_regions]
                [--vtpm2 sock_path] [--virtio_poll interval] [--mac_seed seed_string]
-               [--cpu_affinity pCPUs] [--lapic_pt] [--rtvm] [--windows]
+               [--cpu_affinity lapic_ids] [--lapic_pt] [--rtvm] [--windows]
                [--debugexit] [--logger-setting param_setting]
                [--ssram] <vm>
        -B: bootargs for kernel
@@ -74,7 +74,8 @@ options:
        --mac_seed: set a platform unique string as a seed for generate mac address
        --ovmf: ovmf file path
        --ssram: Enable Software SRAM
-       --cpu_affinity: list of pCPUs assigned to this VM
+       --cpu_affinity: comma-separated of Service VM vCPUs assigned to this VM. A Service VM vCPU is
+            identified by its lapic ID.\n"
        --enable_trusty: enable trusty for guest
        --debugexit: enable debug exit function
        --intr_monitor: enable interrupt storm monitor

--- a/doc/reference/config-options-launch.rst
+++ b/doc/reference/config-options-launch.rst
@@ -89,7 +89,8 @@ define post-launched User VM settings. This document describes these option sett
   ``[@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]``.
 
 ``cpu_affinity``:
-  List of pCPU that this VM's vCPUs are pinned to.
+  A comma-separated list of Service VM vCPUs assigned to this VM. A Service VM vCPU is identified
+  by its lapic ID.
 
 .. note::
 

--- a/doc/reference/config-options-launch.rst
+++ b/doc/reference/config-options-launch.rst
@@ -29,15 +29,6 @@ define post-launched User VM settings. This document describes these option sett
   emulated by the device model; if set to ``Disable``, the vUART0 is
   emulated by the hypervisor if it is configured in the scenario XML.
 
-``poweroff_channel``:
-  Specify whether the User VM power off channel is through the IOC,
-  power button, or vUART.
-
-``allow_trigger_s5``:
-  Allow the VM to trigger S5 shutdown flow. This flag works with
-  ``poweroff_channel``
-  ``vuart1(pty)`` and ``vuart1(tty)`` only.
-
 ``enable_ptm``:
   Enable the Precision Timing Measurement (PTM) feature.
 

--- a/doc/tutorials/cpu_sharing.rst
+++ b/doc/tutorials/cpu_sharing.rst
@@ -51,7 +51,7 @@ to the pCPU with lowest pCPU ID, vCPU1 maps to the second lowest pCPU ID, and
 so on.
 
 For post-launched VMs, acrn-dm could choose to launch a subset of pCPUs that
-are defined in cpu_affinity by specifying the assigned pCPUs
+are defined in cpu_affinity by specifying the assigned Service VM vCPU's lapic_id
 (``--cpu_affinity`` option). But it can't assign any pCPUs that are not
 included in the VM's cpu_affinity.
 

--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -193,14 +193,17 @@ Here are descriptions for each of these ``acrn-dm`` command line parameters:
 
 ----
 
-``--cpu_affinity <list of pCPUs>``
-   list of pCPUs assigned to this VM.
+``--cpu_affinity <list of lapic_ids>``
+   comma-separated list of vCPUs assigned to this VM. Each CPU has a Local Programmable
+   Interrupt Controller (LAPIC). The unique ID of the LAPIC (lapic_id) is used to identify vCPU.
+   The ``lapic_id`` for a vCPU can be found in the service VM file ``/proc/cpuinfo``
+   identified as ``apicid``.
 
    Example::
 
       --cpu_affinity 1,3
 
-   to assign physical CPUs (pCPUs) 1 and 3 to this VM.
+   to assign vCPUs with lapic_id 1 and 3 to this VM.
 
 ----
 


### PR DESCRIPTION
1. Cpu affinty was set by pCPU ID which can't be obtained explictly by user. Use lapic ID instead which can be easily read from `/proc/cpuinfo` as `apicid`. (please refer to PR #7040)
2. Since PR #7035 has removed "pm_notify_channel" and "pm_by_vuart" in the launch script generation logic, this patch also removes the related elements("poweroff_channel" and "allow_trigger_s5") in the documentation.