### PR TITLE
hv: improve vmexit array size to avoid overflow

### DIFF
--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -27,7 +27,6 @@
  * According to "SDM APPENDIX C VMX BASIC EXIT REASONS",
  * there are 65 Basic Exit Reasons.
  */
-#define NR_VMX_EXIT_REASONS	70U
 
 static int32_t triple_fault_vmexit_handler(struct acrn_vcpu *vcpu);
 static int32_t unhandled_vmexit_handler(struct acrn_vcpu *vcpu);

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -2026,7 +2026,7 @@ static int shell_show_vmexit_profile(__unused int argc, __unused char **argv)
 /* to sample vmexit tsc data */
 void sample_vmexit_end(uint32_t basic_exit_reason, struct acrn_vcpu *vcpu)
 {
-	if (!sample_vmexit_enabled)
+	if (!sample_vmexit_enabled || (basic_exit_reason >= NR_VMX_EXIT_REASONS))
 		return;
 
 	if (vcpu->vmexit_begin != 0UL) {
@@ -2060,7 +2060,7 @@ void sample_vmexit_end(uint32_t basic_exit_reason, struct acrn_vcpu *vcpu)
 
 void sample_vmexit_begin(uint32_t basic_exit_reason, struct acrn_vcpu *vcpu)
 {
-	if (!sample_vmexit_enabled)
+	if (!sample_vmexit_enabled || (basic_exit_reason >= NR_VMX_EXIT_REASONS))
 		return;
 
 	vcpu->vmexit_begin = rdtsc();

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -21,6 +21,7 @@
 #include <asm/guest/virtual_cr.h>
 #include <asm/guest/vlapic.h>
 #include <asm/guest/vmtrr.h>
+#include <asm/guest/vmexit.h>
 #include <schedule.h>
 #include <event.h>
 #include <io_req.h>
@@ -311,8 +312,8 @@ struct acrn_vcpu {
 #ifdef HV_DEBUG
 	uint64_t vmexit_begin;
 
-	uint64_t vmexit_cnt[64][TOTAL_ARRAY_LEVEL];
-	uint64_t vmexit_time[64][2]; /*0 for total latency, 1 for max latency */
+	uint64_t vmexit_cnt[NR_VMX_EXIT_REASONS][TOTAL_ARRAY_LEVEL];
+	uint64_t vmexit_time[NR_VMX_EXIT_REASONS][2]; /*0 for total latency, 1 for max latency */
 #endif
 
 } __aligned(PAGE_SIZE);

--- a/hypervisor/include/arch/x86/asm/guest/vmexit.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmexit.h
@@ -7,6 +7,8 @@
 #ifndef VMEXIT_H_
 #define VMEXIT_H_
 
+#define NR_VMX_EXIT_REASONS	70U
+
 struct vm_exit_dispatch {
 	int32_t (*handler)(struct acrn_vcpu *);
 	uint32_t need_exit_qualification;

--- a/hypervisor/include/arch/x86/asm/per_cpu.h
+++ b/hypervisor/include/arch/x86/asm/per_cpu.h
@@ -30,8 +30,8 @@ struct per_cpu_region {
 	struct shared_buf *sbuf[ACRN_SBUF_ID_MAX];
 	char logbuf[LOG_MESSAGE_MAX_SIZE];
 
-	uint64_t vmexit_cnt[64][TOTAL_ARRAY_LEVEL];
-	uint64_t vmexit_time[64][2]; /*0 for total latency, 1 for max latency */
+	uint64_t vmexit_cnt[NR_VMX_EXIT_REASONS][TOTAL_ARRAY_LEVEL];
+	uint64_t vmexit_time[NR_VMX_EXIT_REASONS][2]; /*0 for total latency, 1 for max latency */
 
 	uint32_t npk_log_ref;
 #endif


### PR DESCRIPTION
change vmexit data array size according to vmexit dispatch_table size.
also add a size check to avoid array overflow.

Tracked-On: #7043
Signed-off-by: Minggui Cao <minggui.cao@intel.com>