### PR TITLE
doc: remove dm dynamic param '-A'

### DIFF
--- a/doc/developer-guides/hld/hld-devicemodel.rst
+++ b/doc/developer-guides/hld/hld-devicemodel.rst
@@ -51,7 +51,7 @@ options:
 
 .. code-block:: none
 
-   acrn-dm [-hAWYv] [-B bootargs] [-E elf_image_path]
+   acrn-dm [-hWYv] [-B bootargs] [-E elf_image_path]
                [-k kernel_image_path]
                [-l lpc] [-m mem] [-r ramdisk_image_path]
                [-s pci] [--ovmf ovmf_file_path]
@@ -61,7 +61,6 @@ options:
                [--cpu_affinity pCPUs] [--lapic_pt] [--rtvm] [--windows]
                [--debugexit] [--logger-setting param_setting]
                [--ssram] <vm>
-       -A: create ACPI tables
        -B: bootargs for kernel
        -E: elf image path
        -h: help
@@ -105,7 +104,7 @@ Here's an example showing how to run a VM with:
 
 .. code-block:: bash
 
-   acrn-dm -A -m 2048M \
+   acrn-dm -m 2048M \
      -s 0:0,hostbridge \
      -s 1:0,lpc -l com1,stdio \
      -s 5,virtio-console,@pty:pty_port \
@@ -166,11 +165,9 @@ DM Initialization
    dedicated ``vdev_init()`` function. For more details on the DM PCI
    emulation, refer to `PCI Emulation`_.
 
--  **ACPI Build**: If there is an "-A" option in the ``acrn-dm`` command line,
-   the DM
-   will build an ACPI table into its VM's F-Segment (0xf2400). This
-   ACPI table includes full tables for RSDP, RSDT, XSDT, MADT, FADT,
-   HPET, MCFG, FACS, and DSDT. All these items are programed
+-  **ACPI Build**: The DM will build an ACPI table into its VM's
+   F-Segment (0xf2400). This ACPI table includes full tables for RSDP, RSDT,
+   XSDT, MADT, FADT, HPET, MCFG, FACS, and DSDT. All these items are programed
    according to the ``acrn-dm`` command-line configuration and derived from
    their default value.
 
@@ -770,7 +767,7 @@ example:
 
 .. code-block:: bash
 
-   acrn-dm -A -m 2048M \
+   acrn-dm -m 2048M \
      -s 0:0,hostbridge \
      -s 1:0,lpc -l com1,stdio \
      -s 5,virtio-console,@pty:pty_port \

--- a/doc/developer-guides/hld/hostbridge-virt-hld.rst
+++ b/doc/developer-guides/hld/hostbridge-virt-hld.rst
@@ -16,7 +16,7 @@ PCI Host Bridge and Hierarchy
 
 There is PCI host bridge emulation in DM. The bus hierarchy is determined by ``acrn-dm`` command line input. Using this command line, as an example::
 
-        acrn-dm -A -m $mem_size -s 0:0,hostbridge \
+        acrn-dm -m $mem_size -s 0:0,hostbridge \
         -s 5,virtio-console,@stdio:stdio_port \
         -s 6,virtio-hyper_dmabuf \
         -s 3,virtio-blk,/home/acrn/UserVM.img \

--- a/doc/developer-guides/hld/hv-dev-passthrough.rst
+++ b/doc/developer-guides/hld/hv-dev-passthrough.rst
@@ -434,7 +434,7 @@ passthrough and enables PTM on it:
    echo ${passthru_bdf["ethptm"]} > /sys/bus/pci/devices/${passthru_bdf["ethptm"]}/driver/unbind
    echo ${passthru_bdf["ethptm"]} > /sys/bus/pci/drivers/pci-stub/bind
 
-   acrn-dm -A -m $mem_size -s 0:0,hostbridge \
+   acrn-dm -m $mem_size -s 0:0,hostbridge \
       -s 3,virtio-blk,user-vm-test.img \
       -s 4,virtio-net,tap0 \
       -s 5,virtio-console,@stdio:stdio_port \
@@ -504,7 +504,7 @@ If supported, follow these steps to enable PTM in the post-launched VM:
    .. code-block:: bash
       :emphasize-lines: 5
 
-      $ acrn-dm -A -m $mem_size -s 0:0,hostbridge \
+      $ acrn-dm -m $mem_size -s 0:0,hostbridge \
           -s 3,virtio-blk,user-vm-test.img \
           -s 4,virtio-net,tap0 \
           -s 5,virtio-console,@stdio:stdio_port \

--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -786,7 +786,7 @@ Launch the User VM
    .. code-block:: bash
       :emphasize-lines: 4
 
-      acrn-dm -A -m $mem_size -s 0:0,hostbridge \
+      acrn-dm -m $mem_size -s 0:0,hostbridge \
          --mac_seed $mac_seed \
          $logger_setting \
          -s 9,virtio-blk,./YaaG.img \
@@ -802,7 +802,7 @@ Launch the User VM
    .. code-block:: bash
       :emphasize-lines: 4
 
-      acrn-dm -A -m $mem_size -s 0:0,hostbridge \
+      acrn-dm -m $mem_size -s 0:0,hostbridge \
          --mac_seed $mac_seed \
          $logger_setting \
          -s 9,virtio-blk,/home/acrn/acrn-work/ubuntu-18.04.6-desktop-amd64.iso \

--- a/doc/tutorials/acrn_on_qemu.rst
+++ b/doc/tutorials/acrn_on_qemu.rst
@@ -265,7 +265,7 @@ Bring Up User VM (L2 Guest)
       fi
       #for memsize setting
       mem_size=1024M
-      acrn-dm -A -m $mem_size -s 0:0,hostbridge \
+      acrn-dm -m $mem_size -s 0:0,hostbridge \
       -s 3,virtio-blk,~/UserVM.img \
       -s 4,virtio-net,tap0 \
       --cpu_affinity 1 \

--- a/doc/tutorials/enable_ivshmem.rst
+++ b/doc/tutorials/enable_ivshmem.rst
@@ -135,7 +135,7 @@ Linux-based post-launched VMs (VM1 and VM2).
      .. code-block:: none
         :emphasize-lines: 6
 
-        acrn-dm -A -m $mem_size -s 0:0,hostbridge \
+        acrn-dm -m $mem_size -s 0:0,hostbridge \
          -s 5,virtio-console,@stdio:stdio_port \
          -s 6,virtio-hyper_dmabuf \
          -s 3,virtio-blk,/home/acrn/UserVM1.img \
@@ -151,7 +151,7 @@ Linux-based post-launched VMs (VM1 and VM2).
      .. code-block:: none
         :emphasize-lines: 4
 
-        acrn-dm -A -m $mem_size -s 0:0,hostbridge \
+        acrn-dm -m $mem_size -s 0:0,hostbridge \
          -s 3,virtio-blk,/home/acrn/UserVM2.img \
          -s 4,virtio-net,tap0 \
          -s 5,ivshmem,dm:/test,2 \
@@ -218,7 +218,7 @@ Linux-based VMs (VM0 is a pre-launched VM and VM2 is a post-launched VM).
      .. code-block:: none
         :emphasize-lines: 4
 
-        acrn-dm -A -m $mem_size -s 0:0,hostbridge \
+        acrn-dm -m $mem_size -s 0:0,hostbridge \
          -s 3,virtio-blk,/home/acrn/UserVM2.img \
          -s 4,virtio-net,tap0 \
          -s 5,ivshmem,hv:/shm_region_0,2 \

--- a/doc/tutorials/gpu-passthru.rst
+++ b/doc/tutorials/gpu-passthru.rst
@@ -79,7 +79,7 @@ Passthrough the GPU to Guest
 
 3. Modify the ``install_win.sh`` script to enable GVT-d:
 
-   Add the following commands before ``acrn-dm -A -m $mem_size -s 0:0,hostbridge \``
+   Add the following commands before ``acrn-dm -m $mem_size -s 0:0,hostbridge \``
 
    ::
 

--- a/doc/tutorials/launch_uos.sh
+++ b/doc/tutorials/launch_uos.sh
@@ -130,7 +130,7 @@ fi
 #threshold/s,probe-period(s),intr-inject-delay-time(ms),delay-duration(ms)
 intr_storm_monitor="--intr_monitor 10000,10,1,100"
 
-acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
+acrn-dm -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 5,virtio-console,@pty:pty_port \
   -s 6,virtio-hyper_dmabuf \
   -s 8,wdt-i6300esb \
@@ -312,7 +312,7 @@ ACRN project
 #threshold/s,probe-period(s),intr-inject-delay-time(ms),delay-duration(ms)
 intr_storm_monitor="--intr_monitor 10000,10,1,100"
 
- acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio $npk_virt\
+ acrn-dm -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio $npk_virt\
    -s 9,virtio-net,$tap \
    -s 3,virtio-blk,/data/$5/$5.img \
    -s 7,xhci,1-1:1-2:1-3:2-1:2-2:2-3:cap=apl \

--- a/doc/tutorials/using_windows_as_user_vm.rst
+++ b/doc/tutorials/using_windows_as_user_vm.rst
@@ -103,7 +103,7 @@ Prepare the Script to Create an Image
    echo "0000:00:02.0" > /sys/bus/pci/drivers/pci-stub/bind
    #for memsize setting
    mem_size=4096M
-   acrn-dm -A -m $mem_size -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
+   acrn-dm -m $mem_size -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
      -s 2,passthru,0/2/0 \
      -s 8,virtio-net,tap0 \
      -s 4,virtio-blk,/home/acrn/work/win10-ltsc.img

--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -10,15 +10,6 @@ emulation based on command line configurations, as introduced in
 
 Here are descriptions for each of these ``acrn-dm`` command line parameters:
 
-``-A``, ``--acpi``
-   Create ACPI tables.  With this option, DM will build an ACPI table into its
-   VMs F-Segment (0xf2400).  This ACPI table includes full tables for RSDP,
-   RSDT, XSDT, MADT, FADT, HPET, MCFG, FACS, and DSDT.  All these items are
-   programmed according to acrn-dm command line configuration and derived from
-   their default value.
-
-----
-
 ``-B``, ``--bootargs <bootargs>``
    Set the User VM kernel command-line arguments. The maximum length is 1023.
    The bootargs string will be passed to the kernel as its cmdline.


### PR DESCRIPTION
Update document to remove 'acrn-dm' dynamic param '-A'.

Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>