### PR TITLE
dm: Dm rm dynamic param '-W'

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -140,7 +140,7 @@ static void
 usage(int code)
 {
 	fprintf(stderr,
-		"Usage: %s [-hWYv] [-B bootargs] [-E elf_image_path]\n"
+		"Usage: %s [-hYv] [-B bootargs] [-E elf_image_path]\n"
 		"       %*s [-k kernel_image_path]\n"
 		"       %*s [-l lpc] [-m mem] [-r ramdisk_image_path]\n"
 		"       %*s [-s pci] [--ovmf ovmf_file_path]\n"
@@ -159,7 +159,6 @@ usage(int code)
 		"       -r: ramdisk image path\n"
 		"       -s: <slot,driver,configinfo> PCI slot config\n"
 		"       -v: version\n"
-		"       -W: force virtio to use single-vector MSI\n"
 		"       --mac_seed: set a platform unique string as a seed for generate mac address\n"
 		"       --ovmf: ovmf file path\n"
 		"       --ssram: Congfiure Software SRAM parameters\n"
@@ -176,7 +175,8 @@ usage(int code)
 		"       --rtvm: indicate that the guest is rtvm\n"
 		"       --logger_setting: params like console,level=4;kmsg,level=3\n"
 		"       --windows: support Oracle virtio-blk, virtio-net and virtio-input devices\n"
-		"            for windows guest with secure boot\n",
+		"            for windows guest with secure boot\n"
+		"       --virtio_msi: force virtio to use single-vector MSI\n",
 		progname, (int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
@@ -769,6 +769,7 @@ enum {
 	CMD_OPT_PM_NOTIFY_CHANNEL,
 	CMD_OPT_PM_BY_VUART,
 	CMD_OPT_WINDOWS,
+	CMD_OPT_FORCE_VIRTIO_MSI,
 };
 
 static struct option long_options[] = {
@@ -777,7 +778,6 @@ static struct option long_options[] = {
 	{"lpc",			required_argument,	0, 'l' },
 	{"pci_slot",		required_argument,	0, 's' },
 	{"memsize",		required_argument,	0, 'm' },
-	{"virtio_msix",		no_argument,		0, 'W' },
 	{"mptgen",		no_argument,		0, 'Y' },
 	{"kernel",		required_argument,	0, 'k' },
 	{"ramdisk",		required_argument,	0, 'r' },
@@ -809,10 +809,11 @@ static struct option long_options[] = {
 	{"pm_notify_channel",	required_argument,	0, CMD_OPT_PM_NOTIFY_CHANNEL},
 	{"pm_by_vuart",	required_argument,	0, CMD_OPT_PM_BY_VUART},
 	{"windows",		no_argument,		0, CMD_OPT_WINDOWS},
+	{"virtio_msi",		no_argument,		0, CMD_OPT_FORCE_VIRTIO_MSI},
 	{0,			0,			0,  0  },
 };
 
-static char optstr[] = "hWYvE:k:r:B:s:m:l:U:G:i:";
+static char optstr[] = "hYvE:k:r:B:s:m:l:U:G:i:";
 
 int
 main(int argc, char *argv[])
@@ -867,9 +868,6 @@ main(int argc, char *argv[])
 		case 'm':
 			if (vm_parse_memsize(optarg, &memsize) != 0)
 				errx(EX_USAGE, "invalid memsize '%s'", optarg);
-			break;
-		case 'W':
-			virtio_msix = 0;
 			break;
 		case 'Y': /* obsolete parameter */
 			mptgen = 0;
@@ -990,6 +988,9 @@ main(int argc, char *argv[])
 			break;
 		case CMD_OPT_WINDOWS:
 			is_winvm = true;
+			break;
+		case CMD_OPT_FORCE_VIRTIO_MSI:
+			virtio_msix = 0;
 			break;
 		case 'h':
 			usage(0);

--- a/doc/developer-guides/hld/hld-devicemodel.rst
+++ b/doc/developer-guides/hld/hld-devicemodel.rst
@@ -51,7 +51,7 @@ options:
 
 .. code-block:: none
 
-   acrn-dm [-hWYv] [-B bootargs] [-E elf_image_path]
+   acrn-dm [-hYv] [-B bootargs] [-E elf_image_path]
                [-k kernel_image_path]
                [-l lpc] [-m mem] [-r ramdisk_image_path]
                [-s pci] [--ovmf ovmf_file_path]
@@ -70,7 +70,6 @@ options:
        -r: ramdisk image path
        -s: <slot,driver,configinfo> PCI slot config
        -v: version
-       -W: force virtio to use single-vector MSI
        -Y: disable MPtable generation
        --mac_seed: set a platform unique string as a seed for generate mac address
        --ovmf: ovmf file path
@@ -89,6 +88,7 @@ options:
        --logger_setting: params like console,level=4;kmsg,level=3
        --windows: support Oracle virtio-blk, virtio-net, and virtio-input devices
             for windows guest with secure boot
+       --virtio_msi: force virtio to use single-vector MSI
 
 See :ref:`acrn-dm_parameters` for more detailed descriptions of these
 configuration options.

--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -250,7 +250,7 @@ Here are descriptions for each of these ``acrn-dm`` command line parameters:
 
 ----
 
-``-W, --virtio_msix``
+``--virtio_msi``
    This option forces virtio to use single-vector MSI.  By default, any
    virtio-based devices will use MSI-X as its interrupt method.  If you want
    to use single-vector MSI interrupt, you can do so using this option.


### PR DESCRIPTION
    Rename '--virtio_msix' to '--virtio_msi' for this param
    means 'force virtio to use singel-vector MSI'.

    `-W` is the short version of `--virtio_msi`. But it's
    confusing that `-W` and `--virtio_msi` are irrelevant literally.
    So remove the short version `W` to prompt user friendliness.

