### PR TITLE
Process both forms of ACPI PRT entries

### DIFF
--- a/misc/config_tools/board_inspector/extractors/60-pci.py
+++ b/misc/config_tools/board_inspector/extractors/60-pci.py
@@ -148,6 +148,8 @@ def parse_device(bus_node, device_path):
         mapping = device_node.xpath(f"../interrupt_pin_routing/routing[@address='{prt_address}']/mapping[@pin='{pin_name}']")
         if len(mapping) > 0:
             res_node.set("source", mapping[0].get("source"))
+            if "index" in mapping[0].keys():
+                res_node.set("index", mapping[0].get("index"))
 
     # Secondary bus
     if cfg.header.header_type == 1:

--- a/misc/config_tools/static_allocators/intx.py
+++ b/misc/config_tools/static_allocators/intx.py
@@ -104,9 +104,17 @@ def get_irqs_of_device(device_node):
 
     # PCI interrupt pin
     for res in device_node.xpath("resource[@type='interrupt_pin']"):
-        irq = res.get("source", None)
-        if irq is not None:
-            irqs.add(int(irq))
+        source = res.get("source", None)
+        if source is not None:
+            if source.isdigit():
+                # Interrupts from the global interrupt pool
+                irqs.add(int(source))
+            else:
+                # Interrupts from another device
+                index = res.get("index", "0")
+                irq = common.get_node(f"//device[acpi_object='{source}']/resource[@id='res{index}' and @type='irq']/@int", device_node.getroottree())
+                if irq is not None:
+                    irqs.add(int(irq))
 
     return irqs
 


### PR DESCRIPTION
According to ACPI spec, an entry in ACPI PRT (PCI Routing Table) can                                                                                                                                               specify an interrupt line either by an integer or by a pair of a device                                                                                                                                            object and an index. In the later case, the interrupt line is specified by                                                                                                                                         the index'th entry in the current resource list (as reported by the _CRS                                                                                                                                           method) of that device object.       

Today we see most BIOS simply use an integer in the ACPI namespace (at                                                                                                                                             least in APIC mode), but now in Qemu "device-object + index" pairs are used                                                                                                                                        in PRT, leading to build-time failure when building ACRN to run on top of                                                                                                                                          Qemu/KVM.            

This patch series adds the support to process both forms of ACPI PRT                                                                                                                                               entries properly.                                                    