### PR TITLE
config-tools: update qemu board xml

### DIFF
--- a/misc/config_tools/data/qemu/qemu.xml
+++ b/misc/config_tools/data/qemu/qemu.xml
@@ -1,221 +1,221 @@
 <acrn-config board="qemu">
   <BIOS_INFO>
-	BIOS Information
-	Vendor: SeaBIOS
-	Version: rel-1.12.1-0-ga5cab58e9a3f-prebuilt.qemu.org
-	Release Date: 04/01/2014
-	BIOS Revision: 0.0
-	</BIOS_INFO>
+        BIOS Information
+        Vendor: SeaBIOS
+        Version: 1.13.0-1ubuntu1.1
+        Release Date: 04/01/2014
+        BIOS Revision: 0.0
+        </BIOS_INFO>
   <BASE_BOARD_INFO>
-	</BASE_BOARD_INFO>
+        </BASE_BOARD_INFO>
   <PCI_DEVICE>
-	00:00.0 Host bridge: Intel Corporation 82G33/G31/P35/P31 Express DRAM Controller
-	00:01.0 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
-	Region 0: Memory at fde00000 (32-bit, non-prefetchable) [size=4K]
-	00:01.1 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
-	Region 0: Memory at fde01000 (32-bit, non-prefetchable) [size=4K]
-	00:01.2 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
-	Region 0: Memory at fde02000 (32-bit, non-prefetchable) [size=4K]
-	00:01.3 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
-	Region 0: Memory at fde03000 (32-bit, non-prefetchable) [size=4K]
-	00:01.4 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
-	Region 0: Memory at fde04000 (32-bit, non-prefetchable) [size=4K]
-	00:01.5 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
-	Region 0: Memory at fde05000 (32-bit, non-prefetchable) [size=4K]
-	00:1d.0 USB controller: Intel Corporation 82801I (ICH9 Family) USB UHCI Controller #1 (rev 03)
-	00:1d.1 USB controller: Intel Corporation 82801I (ICH9 Family) USB UHCI Controller #2 (rev 03)
-	00:1d.2 USB controller: Intel Corporation 82801I (ICH9 Family) USB UHCI Controller #3 (rev 03)
-	00:1d.7 USB controller: Intel Corporation 82801I (ICH9 Family) USB2 EHCI Controller #1 (rev 03)
-	Region 0: Memory at fde06000 (32-bit, non-prefetchable) [size=4K]
-	00:1f.0 ISA bridge: Intel Corporation 82801IB (ICH9) LPC Interface Controller (rev 02)
-	00:1f.2 SATA controller: Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode] (rev 02)
-	Region 5: Memory at fde07000 (32-bit, non-prefetchable) [size=4K]
-	00:1f.3 SMBus: Intel Corporation 82801I (ICH9 Family) SMBus Controller (rev 02)
-	01:00.0 Ethernet controller: Red Hat, Inc. Virtio network device (rev 01)
-	Region 1: Memory at fdc40000 (32-bit, non-prefetchable) [size=4K]
-	Region 4: Memory at fea00000 (64-bit, prefetchable) [size=16K]
-	02:00.0 Communication controller: Red Hat, Inc. Virtio console (rev 01)
-	Region 1: Memory at fda00000 (32-bit, non-prefetchable) [size=4K]
-	Region 4: Memory at fe800000 (64-bit, prefetchable) [size=16K]
-	03:00.0 SCSI storage controller: Red Hat, Inc. Virtio block device (rev 01)
-	Region 1: Memory at fd800000 (32-bit, non-prefetchable) [size=4K]
-	Region 4: Memory at fe600000 (64-bit, prefetchable) [size=16K]
-	04:00.0 Unclassified device [00ff]: Red Hat, Inc. Virtio memory balloon (rev 01)
-	Region 4: Memory at fe400000 (64-bit, prefetchable) [size=16K]
-	05:00.0 Unclassified device [00ff]: Red Hat, Inc. Virtio RNG (rev 01)
-	Region 4: Memory at fe200000 (64-bit, prefetchable) [size=16K]
-	</PCI_DEVICE>
+        00:00.0 Host bridge: Intel Corporation 82G33/G31/P35/P31 Express DRAM Controller
+        00:01.0 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
+        Region 0: Memory at fde00000 (32-bit, non-prefetchable) [size=4K]
+        00:01.1 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
+        Region 0: Memory at fde01000 (32-bit, non-prefetchable) [size=4K]
+        00:01.2 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
+        Region 0: Memory at fde02000 (32-bit, non-prefetchable) [size=4K]
+        00:01.3 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
+        Region 0: Memory at fde03000 (32-bit, non-prefetchable) [size=4K]
+        00:01.4 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
+        Region 0: Memory at fde04000 (32-bit, non-prefetchable) [size=4K]
+        00:01.5 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
+        Region 0: Memory at fde05000 (32-bit, non-prefetchable) [size=4K]
+        00:1d.0 USB controller: Intel Corporation 82801I (ICH9 Family) USB UHCI Controller #1 (rev 03)
+        00:1d.1 USB controller: Intel Corporation 82801I (ICH9 Family) USB UHCI Controller #2 (rev 03)
+        00:1d.2 USB controller: Intel Corporation 82801I (ICH9 Family) USB UHCI Controller #3 (rev 03)
+        00:1d.7 USB controller: Intel Corporation 82801I (ICH9 Family) USB2 EHCI Controller #1 (rev 03)
+        Region 0: Memory at fde06000 (32-bit, non-prefetchable) [size=4K]
+        00:1f.0 ISA bridge: Intel Corporation 82801IB (ICH9) LPC Interface Controller (rev 02)
+        00:1f.2 SATA controller: Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode] (rev 02)
+        Region 5: Memory at fde07000 (32-bit, non-prefetchable) [size=4K]
+        00:1f.3 SMBus: Intel Corporation 82801I (ICH9 Family) SMBus Controller (rev 02)
+        01:00.0 Ethernet controller: Red Hat, Inc. Virtio network device (rev 01)
+        Region 1: Memory at fdc80000 (32-bit, non-prefetchable) [size=4K]
+        Region 4: Memory at fea00000 (64-bit, prefetchable) [size=16K]
+        02:00.0 Communication controller: Red Hat, Inc. Virtio console (rev 01)
+        Region 1: Memory at fda00000 (32-bit, non-prefetchable) [size=4K]
+        Region 4: Memory at fe800000 (64-bit, prefetchable) [size=16K]
+        03:00.0 SCSI storage controller: Red Hat, Inc. Virtio block device (rev 01)
+        Region 1: Memory at fd800000 (32-bit, non-prefetchable) [size=4K]
+        Region 4: Memory at fe600000 (64-bit, prefetchable) [size=16K]
+        04:00.0 Unclassified device [00ff]: Red Hat, Inc. Virtio memory balloon (rev 01)
+        Region 4: Memory at fe400000 (64-bit, prefetchable) [size=16K]
+        05:00.0 Unclassified device [00ff]: Red Hat, Inc. Virtio RNG (rev 01)
+        Region 4: Memory at fe200000 (64-bit, prefetchable) [size=16K]
+        </PCI_DEVICE>
   <PCI_VID_PID>
-	00:00.0 0600: 8086:29c0
-	00:01.0 0604: 1b36:000c
-	00:01.1 0604: 1b36:000c
-	00:01.2 0604: 1b36:000c
-	00:01.3 0604: 1b36:000c
-	00:01.4 0604: 1b36:000c
-	00:01.5 0604: 1b36:000c
-	00:1d.0 0c03: 8086:2934 (rev 03)
-	00:1d.1 0c03: 8086:2935 (rev 03)
-	00:1d.2 0c03: 8086:2936 (rev 03)
-	00:1d.7 0c03: 8086:293a (rev 03)
-	00:1f.0 0601: 8086:2918 (rev 02)
-	00:1f.2 0106: 8086:2922 (rev 02)
-	00:1f.3 0c05: 8086:2930 (rev 02)
-	01:00.0 0200: 1af4:1041 (rev 01)
-	02:00.0 0780: 1af4:1043 (rev 01)
-	03:00.0 0100: 1af4:1042 (rev 01)
-	04:00.0 00ff: 1af4:1045 (rev 01)
-	05:00.0 00ff: 1af4:1044 (rev 01)
-	</PCI_VID_PID>
+        00:00.0 0600: 8086:29c0
+        00:01.0 0604: 1b36:000c
+        00:01.1 0604: 1b36:000c
+        00:01.2 0604: 1b36:000c
+        00:01.3 0604: 1b36:000c
+        00:01.4 0604: 1b36:000c
+        00:01.5 0604: 1b36:000c
+        00:1d.0 0c03: 8086:2934 (rev 03)
+        00:1d.1 0c03: 8086:2935 (rev 03)
+        00:1d.2 0c03: 8086:2936 (rev 03)
+        00:1d.7 0c03: 8086:293a (rev 03)
+        00:1f.0 0601: 8086:2918 (rev 02)
+        00:1f.2 0106: 8086:2922 (rev 02)
+        00:1f.3 0c05: 8086:2930 (rev 02)
+        01:00.0 0200: 1af4:1041 (rev 01)
+        02:00.0 0780: 1af4:1043 (rev 01)
+        03:00.0 0100: 1af4:1042 (rev 01)
+        04:00.0 00ff: 1af4:1045 (rev 01)
+        05:00.0 00ff: 1af4:1044 (rev 01)
+        </PCI_VID_PID>
   <WAKE_VECTOR_INFO>
-	#define WAKE_VECTOR_32          0x7FFDFD8CUL
-	#define WAKE_VECTOR_64          0x7FFDFD98UL
-	</WAKE_VECTOR_INFO>
+        #define WAKE_VECTOR_32          0x7FFE000CUL
+        #define WAKE_VECTOR_64          0x7FFE0018UL
+        </WAKE_VECTOR_INFO>
   <RESET_REGISTER_INFO>
-	#define RESET_REGISTER_ADDRESS  0xCF9UL
-	#define RESET_REGISTER_SPACE_ID SPACE_SYSTEM_IO
-	#define RESET_REGISTER_VALUE    0xfU
-	</RESET_REGISTER_INFO>
+        #define RESET_REGISTER_ADDRESS  0xCF9UL
+        #define RESET_REGISTER_SPACE_ID SPACE_SYSTEM_IO
+        #define RESET_REGISTER_VALUE    0xfU
+        </RESET_REGISTER_INFO>
   <PM_INFO>
-	#define PM1A_EVT_SPACE_ID       SPACE_SYSTEM_IO
-	#define PM1A_EVT_BIT_WIDTH      0x20U
-	#define PM1A_EVT_BIT_OFFSET     0x0U
-	#define PM1A_EVT_ADDRESS        0x600UL
-	#define PM1A_EVT_ACCESS_SIZE    0x0U
-	#define PM1B_EVT_SPACE_ID       SPACE_SYSTEM_MEMORY
-	#define PM1B_EVT_BIT_WIDTH      0x0U
-	#define PM1B_EVT_BIT_OFFSET     0x0U
-	#define PM1B_EVT_ADDRESS        0x0UL
-	#define PM1B_EVT_ACCESS_SIZE    0x0U
-	#define PM1A_CNT_SPACE_ID       SPACE_SYSTEM_IO
-	#define PM1A_CNT_BIT_WIDTH      0x10U
-	#define PM1A_CNT_BIT_OFFSET     0x0U
-	#define PM1A_CNT_ADDRESS        0x604UL
-	#define PM1A_CNT_ACCESS_SIZE    0x0U
-	#define PM1B_CNT_SPACE_ID       SPACE_SYSTEM_MEMORY
-	#define PM1B_CNT_BIT_WIDTH      0x0U
-	#define PM1B_CNT_BIT_OFFSET     0x0U
-	#define PM1B_CNT_ADDRESS        0x0UL
-	#define PM1B_CNT_ACCESS_SIZE    0x0U
-	</PM_INFO>
+        #define PM1A_EVT_SPACE_ID       SPACE_SYSTEM_IO
+        #define PM1A_EVT_BIT_WIDTH      0x20U
+        #define PM1A_EVT_BIT_OFFSET     0x0U
+        #define PM1A_EVT_ADDRESS        0x600UL
+        #define PM1A_EVT_ACCESS_SIZE    0x0U
+        #define PM1B_EVT_SPACE_ID       SPACE_SYSTEM_MEMORY
+        #define PM1B_EVT_BIT_WIDTH      0x0U
+        #define PM1B_EVT_BIT_OFFSET     0x0U
+        #define PM1B_EVT_ADDRESS        0x0UL
+        #define PM1B_EVT_ACCESS_SIZE    0x0U
+        #define PM1A_CNT_SPACE_ID       SPACE_SYSTEM_IO
+        #define PM1A_CNT_BIT_WIDTH      0x10U
+        #define PM1A_CNT_BIT_OFFSET     0x0U
+        #define PM1A_CNT_ADDRESS        0x604UL
+        #define PM1A_CNT_ACCESS_SIZE    0x0U
+        #define PM1B_CNT_SPACE_ID       SPACE_SYSTEM_MEMORY
+        #define PM1B_CNT_BIT_WIDTH      0x0U
+        #define PM1B_CNT_BIT_OFFSET     0x0U
+        #define PM1B_CNT_ADDRESS        0x0UL
+        #define PM1B_CNT_ACCESS_SIZE    0x0U
+        </PM_INFO>
   <S3_INFO>
-	</S3_INFO>
+        </S3_INFO>
   <S5_INFO>
-	</S5_INFO>
+        </S5_INFO>
   <DRHD_INFO>
-	#define DRHD_COUNT              1U
+        #define DRHD_COUNT              1U
 
-	#define DRHD0_DEV_CNT           0x1U
-	#define DRHD0_SEGMENT           0x0U
-	#define DRHD0_FLAGS             0x1U
-	#define DRHD0_REG_BASE          0xFED90000UL
-	#define DRHD0_IGNORE            false
-	#define DRHD0_DEVSCOPE0_TYPE    0x3U
-	#define DRHD0_DEVSCOPE0_ID      0x0U
-	#define DRHD0_DEVSCOPE0_BUS     0xffU
-	#define DRHD0_DEVSCOPE0_PATH    0x0U
+        #define DRHD0_DEV_CNT           0x1U
+        #define DRHD0_SEGMENT           0x0U
+        #define DRHD0_FLAGS             0x1U
+        #define DRHD0_REG_BASE          0xFED90000UL
+        #define DRHD0_IGNORE            false
+        #define DRHD0_DEVSCOPE0_TYPE    0x3U
+        #define DRHD0_DEVSCOPE0_ID      0x0U
+        #define DRHD0_DEVSCOPE0_BUS     0xffU
+        #define DRHD0_DEVSCOPE0_PATH    0x0U
 
-	</DRHD_INFO>
+        </DRHD_INFO>
   <CPU_BRAND>
-	"Intel Atom Processor (Denverton)"
-	</CPU_BRAND>
+        "Intel Atom Processor (Denverton)"
+        </CPU_BRAND>
   <CX_INFO>
-	/* Cx data is not available */
-	</CX_INFO>
+        /* Cx data is not available */
+        </CX_INFO>
   <PX_INFO>
-	/* Px data is not available */
-	</PX_INFO>
+        /* Px data is not available */
+        </PX_INFO>
   <MMCFG_BASE_INFO>
-	/* PCI mmcfg base of MCFG */
-	#define DEFAULT_PCI_MMCFG_BASE   0xb0000000UL
-	</MMCFG_BASE_INFO>
+        /* PCI mmcfg base of MCFG */
+        #define DEFAULT_PCI_MMCFG_BASE   0xb0000000UL
+        </MMCFG_BASE_INFO>
   <TPM_INFO>
-	/* no TPM device */
-	</TPM_INFO>
+        /* no TPM device */
+        </TPM_INFO>
   <CLOS_INFO>
-	</CLOS_INFO>
+        </CLOS_INFO>
   <IOMEM_INFO>
-	00000000-00000fff : Reserved
-	00001000-0009fbff : System RAM
-	0009fc00-0009ffff : Reserved
-	000a0000-000bffff : PCI Bus 0000:00
-	000c0000-000c0dff : Video ROM
-	000f0000-000fffff : Reserved
-	  000f0000-000fffff : System ROM
-	00100000-7ffd8fff : System RAM
-	  5ac00000-5b8031d0 : Kernel code
-	  5b8031d1-5c26cebf : Kernel data
-	  5c4ee000-5c796fff : Kernel bss
-	7ffd9000-7fffffff : Reserved
-	80000000-afffffff : PCI Bus 0000:00
-	b0000000-bfffffff : PCI MMCONFIG 0000 [bus 00-ff]
-	  b0000000-bfffffff : Reserved
-	c0000000-febfffff : PCI Bus 0000:00
-	  fd200000-fd3fffff : PCI Bus 0000:06
-	  fd400000-fd5fffff : PCI Bus 0000:05
-	  fd600000-fd7fffff : PCI Bus 0000:04
-	  fd800000-fd9fffff : PCI Bus 0000:03
-	    fd800000-fd800fff : 0000:03:00.0
-	  fda00000-fdbfffff : PCI Bus 0000:02
-	    fda00000-fda00fff : 0000:02:00.0
-	  fdc00000-fddfffff : PCI Bus 0000:01
-	    fdc00000-fdc3ffff : 0000:01:00.0
-	    fdc40000-fdc40fff : 0000:01:00.0
-	  fde00000-fde00fff : 0000:00:01.0
-	  fde01000-fde01fff : 0000:00:01.1
-	  fde02000-fde02fff : 0000:00:01.2
-	  fde03000-fde03fff : 0000:00:01.3
-	  fde04000-fde04fff : 0000:00:01.4
-	  fde05000-fde05fff : 0000:00:01.5
-	  fde06000-fde06fff : 0000:00:1d.7
-	    fde06000-fde06fff : ehci_hcd
-	  fde07000-fde07fff : 0000:00:1f.2
-	    fde07000-fde07fff : ahci
-	  fe000000-fe1fffff : PCI Bus 0000:06
-	  fe200000-fe3fffff : PCI Bus 0000:05
-	    fe200000-fe203fff : 0000:05:00.0
-	      fe200000-fe203fff : virtio-pci-modern
-	  fe400000-fe5fffff : PCI Bus 0000:04
-	    fe400000-fe403fff : 0000:04:00.0
-	      fe400000-fe403fff : virtio-pci-modern
-	  fe600000-fe7fffff : PCI Bus 0000:03
-	    fe600000-fe603fff : 0000:03:00.0
-	      fe600000-fe603fff : virtio-pci-modern
-	  fe800000-fe9fffff : PCI Bus 0000:02
-	    fe800000-fe803fff : 0000:02:00.0
-	      fe800000-fe803fff : virtio-pci-modern
-	  fea00000-febfffff : PCI Bus 0000:01
-	    fea00000-fea03fff : 0000:01:00.0
-	      fea00000-fea03fff : virtio-pci-modern
-	fec00000-fec003ff : IOAPIC 0
-	fed00000-fed003ff : HPET 0
-	  fed00000-fed003ff : PNP0103:00
-	fed1c000-fed1ffff : Reserved
-	  fed1f410-fed1f414 : iTCO_wdt.0.auto
-	fed90000-fed90fff : dmar0
-	fee00000-fee00fff : Local APIC
-	feffc000-feffffff : Reserved
-	fffc0000-ffffffff : Reserved
-	100000000-17fffffff : System RAM
-	180000000-97fffffff : PCI Bus 0000:00
-	</IOMEM_INFO>
+        00000000-00000fff : Reserved
+        00001000-0009fbff : System RAM
+        0009fc00-0009ffff : Reserved
+        000a0000-000bffff : PCI Bus 0000:00
+        000c0000-000c0dff : Video ROM
+        000f0000-000fffff : Reserved
+          000f0000-000fffff : System ROM
+        00100000-7ffd7fff : System RAM
+        7ffd8000-7fffffff : Reserved
+        80000000-afffffff : PCI Bus 0000:00
+        b0000000-bfffffff : PCI MMCONFIG 0000 [bus 00-ff]
+          b0000000-bfffffff : Reserved
+        c0000000-febfffff : PCI Bus 0000:00
+          fd200000-fd3fffff : PCI Bus 0000:06
+          fd400000-fd5fffff : PCI Bus 0000:05
+          fd600000-fd7fffff : PCI Bus 0000:04
+          fd800000-fd9fffff : PCI Bus 0000:03
+            fd800000-fd800fff : 0000:03:00.0
+          fda00000-fdbfffff : PCI Bus 0000:02
+            fda00000-fda00fff : 0000:02:00.0
+          fdc00000-fddfffff : PCI Bus 0000:01
+            fdc00000-fdc7ffff : 0000:01:00.0
+            fdc80000-fdc80fff : 0000:01:00.0
+          fde00000-fde00fff : 0000:00:01.0
+          fde01000-fde01fff : 0000:00:01.1
+          fde02000-fde02fff : 0000:00:01.2
+          fde03000-fde03fff : 0000:00:01.3
+          fde04000-fde04fff : 0000:00:01.4
+          fde05000-fde05fff : 0000:00:01.5
+          fde06000-fde06fff : 0000:00:1d.7
+            fde06000-fde06fff : ehci_hcd
+          fde07000-fde07fff : 0000:00:1f.2
+            fde07000-fde07fff : ahci
+          fe000000-fe1fffff : PCI Bus 0000:06
+          fe200000-fe3fffff : PCI Bus 0000:05
+            fe200000-fe203fff : 0000:05:00.0
+              fe200000-fe203fff : virtio-pci-modern
+          fe400000-fe5fffff : PCI Bus 0000:04
+            fe400000-fe403fff : 0000:04:00.0
+              fe400000-fe403fff : virtio-pci-modern
+          fe600000-fe7fffff : PCI Bus 0000:03
+            fe600000-fe603fff : 0000:03:00.0
+              fe600000-fe603fff : virtio-pci-modern
+          fe800000-fe9fffff : PCI Bus 0000:02
+            fe800000-fe803fff : 0000:02:00.0
+              fe800000-fe803fff : virtio-pci-modern
+          fea00000-febfffff : PCI Bus 0000:01
+            fea00000-fea03fff : 0000:01:00.0
+              fea00000-fea03fff : virtio-pci-modern
+        fec00000-fec003ff : IOAPIC 0
+        fed00000-fed003ff : HPET 0
+          fed00000-fed003ff : PNP0103:00
+        fed1c000-fed1ffff : Reserved
+          fed1f410-fed1f414 : iTCO_wdt.0.auto
+        fed90000-fed90fff : dmar0
+        fee00000-fee00fff : Local APIC
+        feffc000-feffffff : Reserved
+        fffc0000-ffffffff : Reserved
+        100000000-17fffffff : System RAM
+          116200000-116e031d0 : Kernel code
+          116e031d1-11786ce3f : Kernel data
+          117aef000-117d97fff : Kernel bss
+        180000000-97fffffff : PCI Bus 0000:00
+        </IOMEM_INFO>
   <BLOCK_DEVICE_INFO>
-	/dev/vda1: TYPE="ext4"
-	</BLOCK_DEVICE_INFO>
+        /dev/vda1: TYPE="ext4"
+        </BLOCK_DEVICE_INFO>
   <TTYS_INFO>
-	seri:/dev/ttyS0 type:portio base:0x3F8 irq:4
-	</TTYS_INFO>
+        seri:/dev/ttyS0 type:portio base:0x3F8 irq:4
+        </TTYS_INFO>
   <AVAILABLE_IRQ_INFO>
-	3, 5, 6, 7, 10, 11, 13, 14, 15
-	</AVAILABLE_IRQ_INFO>
+        3, 5, 6, 7, 10, 11, 13, 14, 15
+        </AVAILABLE_IRQ_INFO>
   <TOTAL_MEM_INFO>
-	4038724 kB
-	</TOTAL_MEM_INFO>
+        4038724 kB
+        </TOTAL_MEM_INFO>
   <CPU_PROCESSOR_INFO>
-	0, 1, 2, 3
-	</CPU_PROCESSOR_INFO>
+        0, 1, 2, 3
+        </CPU_PROCESSOR_INFO>
   <MAX_MSIX_TABLE_NUM>
-	3
-	</MAX_MSIX_TABLE_NUM>
+        3
+        </MAX_MSIX_TABLE_NUM>
   <processors>
     <model description="Intel Atom Processor (Denverton)">
       <family_id>0x6</family_id>
@@ -573,9 +573,16 @@
   </caches>
   <memory>
     <range start="0x0000000000000000" end="0x000000000009fbff" size="654336"/>
-    <range start="0x0000000000100000" end="0x000000007ffd8fff" size="2146275328"/>
+    <range start="0x0000000000100000" end="0x000000007ffd7fff" size="2146271232"/>
     <range start="0x0000000100000000" end="0x000000017fffffff" size="2147483648"/>
   </memory>
+  <ioapics>
+    <ioapic id="0x0">
+      <address>0xfec00000</address>
+      <gsi_base>0x0</gsi_base>
+      <gsi_number>24</gsi_number>
+    </ioapic>
+  </ioapics>
   <devices>
     <bus type="system">
       <acpi_object>\_SB_</acpi_object>
@@ -800,7 +807,7 @@
           <class>0x060400</class>
           <acpi_object>\_SB_.PCI0.S08_</acpi_object>
           <aml_template>5b821a5c2f035f53425f504349305330385f085f4144520c00000100</aml_template>
-          <resource type="interrupt_pin" pin="INTA#" source="21"/>
+          <resource type="interrupt_pin" pin="INTA#" source="\_SB_.GSIF"/>
           <resource type="io_port" min="0x1000" max="0x1fff" len="0x1000"/>
           <resource type="memory" min="0xfdc00000" max="0xfddfffff" len="0x200000"/>
           <resource type="memory" min="0xfde00000" max="0xfde00fff" len="0x1000" id="bar0" width="32" prefetchable="0"/>
@@ -823,7 +830,7 @@
               <subsystem_identifier>0x1100</subsystem_identifier>
               <class>0x020000</class>
               <resource type="interrupt_pin" pin="INTA#"/>
-              <resource type="memory" min="0xfdc40000" max="0xfdc40fff" len="0x1000" id="bar1" width="32" prefetchable="0"/>
+              <resource type="memory" min="0xfdc80000" max="0xfdc80fff" len="0x1000" id="bar1" width="32" prefetchable="0"/>
               <resource type="memory" min="0xfea00000" max="0xfea03fff" len="0x4000" id="bar4" width="64" prefetchable="1"/>
               <capability id="MSI-X">
                 <table_size>3</table_size>
@@ -846,7 +853,7 @@
           <vendor>0x1b36</vendor>
           <identifier>0x000c</identifier>
           <class>0x060400</class>
-          <resource type="interrupt_pin" pin="INTA#" source="21"/>
+          <resource type="interrupt_pin" pin="INTA#" source="\_SB_.GSIF"/>
           <resource type="io_port" min="0x2000" max="0x2fff" len="0x1000"/>
           <resource type="memory" min="0xfda00000" max="0xfdbfffff" len="0x200000"/>
           <resource type="memory" min="0xfde01000" max="0xfde01fff" len="0x1000" id="bar0" width="32" prefetchable="0"/>
@@ -892,7 +899,7 @@
           <vendor>0x1b36</vendor>
           <identifier>0x000c</identifier>
           <class>0x060400</class>
-          <resource type="interrupt_pin" pin="INTA#" source="21"/>
+          <resource type="interrupt_pin" pin="INTA#" source="\_SB_.GSIF"/>
           <resource type="io_port" min="0x3000" max="0x3fff" len="0x1000"/>
           <resource type="memory" min="0xfd800000" max="0xfd9fffff" len="0x200000"/>
           <resource type="memory" min="0xfde02000" max="0xfde02fff" len="0x1000" id="bar0" width="32" prefetchable="0"/>
@@ -938,7 +945,7 @@
           <vendor>0x1b36</vendor>
           <identifier>0x000c</identifier>
           <class>0x060400</class>
-          <resource type="interrupt_pin" pin="INTA#" source="21"/>
+          <resource type="interrupt_pin" pin="INTA#" source="\_SB_.GSIF"/>
           <resource type="io_port" min="0x4000" max="0x4fff" len="0x1000"/>
           <resource type="memory" min="0xfd600000" max="0xfd7fffff" len="0x200000"/>
           <resource type="memory" min="0xfde03000" max="0xfde03fff" len="0x1000" id="bar0" width="32" prefetchable="0"/>
@@ -976,7 +983,7 @@
           <vendor>0x1b36</vendor>
           <identifier>0x000c</identifier>
           <class>0x060400</class>
-          <resource type="interrupt_pin" pin="INTA#" source="21"/>
+          <resource type="interrupt_pin" pin="INTA#" source="\_SB_.GSIF"/>
           <resource type="io_port" min="0x5000" max="0x5fff" len="0x1000"/>
           <resource type="memory" min="0xfd400000" max="0xfd5fffff" len="0x200000"/>
           <resource type="memory" min="0xfde04000" max="0xfde04fff" len="0x1000" id="bar0" width="32" prefetchable="0"/>
@@ -1014,7 +1021,7 @@
           <vendor>0x1b36</vendor>
           <identifier>0x000c</identifier>
           <class>0x060400</class>
-          <resource type="interrupt_pin" pin="INTA#" source="21"/>
+          <resource type="interrupt_pin" pin="INTA#" source="\_SB_.GSIF"/>
           <resource type="io_port" min="0x6000" max="0x6fff" len="0x1000"/>
           <resource type="memory" min="0xfd200000" max="0xfd3fffff" len="0x200000"/>
           <resource type="memory" min="0xfde05000" max="0xfde05fff" len="0x1000" id="bar0" width="32" prefetchable="0"/>
@@ -1039,7 +1046,7 @@
           <class>0x0c0300</class>
           <acpi_object>\_SB_.PCI0.SE8_</acpi_object>
           <aml_template>5b821a5c2f035f53425f504349305345385f085f4144520c00001d00</aml_template>
-          <resource type="interrupt_pin" pin="INTA#" source="16"/>
+          <resource type="interrupt_pin" pin="INTA#" source="\_SB_.GSIA"/>
           <resource type="io_port" min="0xc040" max="0xc05f" len="0x20" id="bar4"/>
         </device>
         <device address="0x1d0001" id="0x2935" description="USB controller: Intel Corporation 82801I (ICH9 Family) USB UHCI Controller #2">
@@ -1048,7 +1055,7 @@
           <subsystem_vendor>0x1af4</subsystem_vendor>
           <subsystem_identifier>0x1100</subsystem_identifier>
           <class>0x0c0300</class>
-          <resource type="interrupt_pin" pin="INTB#" source="17"/>
+          <resource type="interrupt_pin" pin="INTB#" source="\_SB_.GSIB"/>
           <resource type="io_port" min="0xc060" max="0xc07f" len="0x20" id="bar4"/>
         </device>
         <device address="0x1d0002" id="0x2936" description="USB controller: Intel Corporation 82801I (ICH9 Family) USB UHCI Controller #3">
@@ -1057,7 +1064,7 @@
           <subsystem_vendor>0x1af4</subsystem_vendor>
           <subsystem_identifier>0x1100</subsystem_identifier>
           <class>0x0c0300</class>
-          <resource type="interrupt_pin" pin="INTC#" source="18"/>
+          <resource type="interrupt_pin" pin="INTC#" source="\_SB_.GSIC"/>
           <resource type="io_port" min="0xc080" max="0xc09f" len="0x20" id="bar4"/>
         </device>
         <device address="0x1d0007" id="0x293a" description="USB controller: Intel Corporation 82801I (ICH9 Family) USB2 EHCI Controller #1">
@@ -1066,7 +1073,7 @@
           <subsystem_vendor>0x1af4</subsystem_vendor>
           <subsystem_identifier>0x1100</subsystem_identifier>
           <class>0x0c0320</class>
-          <resource type="interrupt_pin" pin="INTD#" source="19"/>
+          <resource type="interrupt_pin" pin="INTD#" source="\_SB_.GSID"/>
           <resource type="memory" min="0xfde06000" max="0xfde06fff" len="0x1000" id="bar0" width="32" prefetchable="0"/>
         </device>
         <device address="0x1f0000" id="0x2918" description="ISA bridge: Intel Corporation 82801IB (ICH9) LPC Interface Controller">
@@ -1113,7 +1120,7 @@
           <subsystem_vendor>0x1af4</subsystem_vendor>
           <subsystem_identifier>0x1100</subsystem_identifier>
           <class>0x010601</class>
-          <resource type="interrupt_pin" pin="INTA#" source="16"/>
+          <resource type="interrupt_pin" pin="INTA#" source="\_SB_.GSIA"/>
           <resource type="io_port" min="0xc0a0" max="0xc0bf" len="0x20" id="bar4"/>
           <resource type="memory" min="0xfde07000" max="0xfde07fff" len="0x1000" id="bar5" width="32" prefetchable="0"/>
           <capability id="MSI">
@@ -1130,7 +1137,7 @@
           <class>0x0c0500</class>
           <acpi_object>\_SB_.PCI0.SMB0</acpi_object>
           <aml_template>5b82245c2f035f53425f50434930534d4230085f4849440c06100005085f4144520c03001f00</aml_template>
-          <resource type="interrupt_pin" pin="INTA#" source="16"/>
+          <resource type="interrupt_pin" pin="INTA#" source="\_SB_.GSIA"/>
           <resource type="io_port" min="0x700" max="0x73f" len="0x40" id="bar4"/>
         </device>
         <device id="QEMU0002">
@@ -1164,7 +1171,7 @@
       <device id="ACPI0010">
         <acpi_object>\_SB_.CPUS</acpi_object>
         <compatible_id>PNP0A05</compatible_id>
-        <aml_template>5b82215c2e5f53425f43505553085f5354410a0f085f4849440d414350493030313000</aml_template>
+        <aml_template>5b822b5c2e5f53425f43505553085f5354410a0f085f4849440d414350493030313000085f4349440c41d00a05</aml_template>
         <status>
           <present>y</present>
           <enabled>y</enabled>


### PR DESCRIPTION
qemu build fail with the old board xml.
this should be re-generated by the latest board inspector tool
which include the changes in PR#7067

Tracked-On: #7058
Signed-off-by: zhongzhenx.liu <zhongzhenx.liu@intel.com>