### PR TITLE
dm: remove the 'd3hot_reset' parameter

### DIFF
--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -593,7 +593,6 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	char *opt;
 	bool keep_gsi = false;
 	bool need_reset = true;
-	bool d3hot_reset = false;
 	bool enable_ptm = false;
 	int vrp_sec_bus = 0;
 	int vmsix_on_msi_bar_id = -1;
@@ -620,8 +619,6 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 			keep_gsi = true;
 		else if (!strncmp(opt, "no_reset", 8))
 			need_reset = false;
-		else if (!strncmp(opt, "d3hot_reset", 11))
-			d3hot_reset = true;
 		else if (!strncmp(opt, "vmsix_on_msi", 12)) {
 			opt = strsep(&opts, ",");
 			if (parse_vmsix_on_msi_bar_id(opt, &vmsix_on_msi_bar_id, 10) != 0) {
@@ -644,7 +641,7 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 
 	ptdev->phys_bdf = PCI_BDF(bus, slot, func);
 	ptdev->need_reset = need_reset;
-	ptdev->d3hot_reset = d3hot_reset;
+	ptdev->d3hot_reset = is_winvm;
 	update_pt_info(ptdev->phys_bdf);
 
 	error = pciaccess_init();

--- a/doc/tutorials/using_windows_as_user_vm.rst
+++ b/doc/tutorials/using_windows_as_user_vm.rst
@@ -109,7 +109,7 @@ Prepare the Script to Create an Image
      -s 4,virtio-blk,/home/acrn/work/win10-ltsc.img
      -s 5,ahci,cd:/home/acrn/work/Windows10.iso \
      -s 6,ahci,cd:/home/acrn/work/winvirtio.iso \
-     -s 7,passthru,0/14/0,d3hot_reset \
+     -s 7,passthru,0/14/0 \
      --ovmf /home/acrn/work/OVMF.fd \
      --windows \
      $vm_name
@@ -284,8 +284,8 @@ Explanation for acrn-dm Popular Command Lines
 * ``-s 6,ahci,cd:/home/acrn/work/winvirtio.iso``:
   This is CD-ROM device to install the virtio Windows driver. Make sure it points to your VirtIO ISO path.
 
-* ``-s 7,passthru,0/14/0,d3hot_reset``:
-  This is to passthrough the USB controller to Windows;d3hot_reset is needed for WaaG reboot when USB controller is passthroughed to Windows.
+* ``-s 7,passthru,0/14/0``:
+  This is to passthrough the USB controller to Windows.
   You may need to change ``0/14/0`` to match the BDF of the USB controller on
   your platform.
 

--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -477,8 +477,6 @@ arguments used for configuration.  Here is a table describing these emulated dev
        * ``no_reset``: passthrough PCI devices are reset by default when
          assigning them to a post-launched VM. This parameter prevents this
          reset for debugging purposes.
-       * ``d3hot_reset``: when launching a  Windows post-launched VM, this
-         parameter should be appended to enable a Windows UEFI ACPI bug fix.
        * ``gpu``: create the dedicated ``igd-lpc`` on ``00:1f.0`` for IGD
          passthrough.
        * ``vmsix_on_msi,<bar_id>``: enables vMSI-X emulation based on MSI

--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -386,11 +386,8 @@ def set_dm_pt(names, sel, vmid, config, dm):
     user_vm_type = names['user_vm_types'][vmid]
 
     if sel.bdf['usb_xdci'][vmid] and sel.slot['usb_xdci'][vmid]:
-        sub_attr = ''
-        if user_vm_type == "WINDOWS":
-            sub_attr = ',d3hot_reset'
         print('   -s {},passthru,{}/{}/{}{} \\'.format(sel.slot["usb_xdci"][vmid], sel.bdf["usb_xdci"][vmid][0:2],\
-            sel.bdf["usb_xdci"][vmid][3:5], sel.bdf["usb_xdci"][vmid][6:7], sub_attr), file=config)
+            sel.bdf["usb_xdci"][vmid][3:5], sel.bdf["usb_xdci"][vmid][6:7]), file=config)
 
     # pass through audio/audio_codec
     if sel.bdf['audio'][vmid]:


### PR DESCRIPTION
We do not need to keep the 'd3hot_reset' optional parameter for acrn-dm.
This option is used when running Windows in the User VM, we can
therefore use the 'is_winvm' flag instead directly.

Tracked-On: #6665
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>