### PR TITLE
Multiple fixes to the board inspector and build system

### DIFF
--- a/misc/config_tools/board_inspector/extractors/10-processors.py
+++ b/misc/config_tools/board_inspector/extractors/10-processors.py
@@ -74,8 +74,8 @@ def extract_topology(processors_node):
         while True:
             leaf_topo = parse_cpuid(topo_leaf, subleaf, cpu_id)
             if leaf_topo.level_type == 0:
-                if last_node.tag != "package":
-                    n, _ = get_or_create_parent(processors_node, "die", "0")
+                if last_node.tag != level_types[-1]:
+                    n, _ = get_or_create_parent(processors_node, level_types[-1], "0x0")
                     n.append(last_node)
                     last_node = n
                 processors_node.append(last_node)

--- a/misc/config_tools/library/board_cfg_lib.py
+++ b/misc/config_tools/library/board_cfg_lib.py
@@ -435,7 +435,11 @@ def parser_pci():
             if "size=" not in line:
                  continue
 
-            bar_addr = int(get_value_after_str(line, "at"), 16)
+            try:
+                bar_addr = int(get_value_after_str(line, "at"), 16)
+            except ValueError:
+                continue
+
             bar_num = line.split()[1].strip(':')
             if bar_addr >= common.SIZE_4G or bar_addr < common.SIZE_2G:
                 if not tmp_bar_attr.remappable:

--- a/misc/config_tools/xforms/board_info.h.xsl
+++ b/misc/config_tools/xforms/board_info.h.xsl
@@ -61,7 +61,7 @@
   </xsl:template>
 
   <xsl:template name="MAX_PCPU_NUM">
-    <xsl:value-of select="acrn:define('MAX_PCPU_NUM', count(//processors/die/core/thread), 'U')" />
+    <xsl:value-of select="acrn:define('MAX_PCPU_NUM', count(//processors//thread), 'U')" />
   </xsl:template>
 
   <xsl:template name="MAX_VMSIX_ON_MSI_PDEVS_NUM">

--- a/misc/config_tools/xforms/config.h.xsl
+++ b/misc/config_tools/xforms/config.h.xsl
@@ -43,18 +43,17 @@
       </xsl:otherwise>
     </xsl:choose>
     <xsl:value-of select="$key" />
-    <xsl:text> </xsl:text>
     <xsl:choose>
       <xsl:when test="$value != ''">
+	<xsl:text> </xsl:text>
 	<xsl:value-of select="$value" />
-	<xsl:text>&#xa;</xsl:text>
       </xsl:when>
       <xsl:when test="$default != ''">
 	<xsl:text> </xsl:text>
 	<xsl:value-of select="$default" />
-	<xsl:text>&#xa;</xsl:text>
       </xsl:when>
     </xsl:choose>
+    <xsl:value-of select="$newline" />
   </xsl:template>
 
   <xsl:template name="boolean-by-key-value">

--- a/misc/config_tools/xforms/config.h.xsl
+++ b/misc/config_tools/xforms/config.h.xsl
@@ -49,7 +49,8 @@
 	<xsl:value-of select="$value" />
 	<xsl:text>&#xa;</xsl:text>
       </xsl:when>
-      <xsl:when test="($value = '') and ($default != '')">
+      <xsl:when test="$default != ''">
+	<xsl:text> </xsl:text>
 	<xsl:value-of select="$default" />
 	<xsl:text>&#xa;</xsl:text>
       </xsl:when>

--- a/misc/config_tools/xforms/config.mk.xsl
+++ b/misc/config_tools/xforms/config.mk.xsl
@@ -41,13 +41,12 @@
     <xsl:choose>
       <xsl:when test="$value != ''">
 	<xsl:value-of select="$value" />
-	<xsl:text>&#xa;</xsl:text>
       </xsl:when>
       <xsl:when test="$default != ''">
 	<xsl:value-of select="$default" />
-	<xsl:text>&#xa;</xsl:text>
       </xsl:when>
     </xsl:choose>
+    <xsl:value-of select="$newline" />
   </xsl:template>
 
   <xsl:template name="boolean-by-key-value">

--- a/misc/config_tools/xforms/config.mk.xsl
+++ b/misc/config_tools/xforms/config.mk.xsl
@@ -43,7 +43,7 @@
 	<xsl:value-of select="$value" />
 	<xsl:text>&#xa;</xsl:text>
       </xsl:when>
-      <xsl:when test="($value = '') and ($default != '')">
+      <xsl:when test="$default != ''">
 	<xsl:value-of select="$default" />
 	<xsl:text>&#xa;</xsl:text>
       </xsl:when>

--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -329,7 +329,7 @@
 	  <xsl:with-param name="value" select="concat($value, $integer-suffix)" />
 	</xsl:call-template>
       </xsl:when>
-      <xsl:when test="($value = '') and ($default != '')">
+      <xsl:when test="$default != ''">
 	<xsl:call-template name="entry-by-key-value">
 	  <xsl:with-param name="prefix" select="$prefix" />
 	  <xsl:with-param name="key" select="$key" />

--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -17,11 +17,13 @@
     </xsl:call-template>
     <xsl:call-template name="integer-by-key-value">
       <xsl:with-param name="key" select="'MAX_IOAPIC_NUM'" />
-      <xsl:with-param name="value" select="count(//ioapic)" />
+      <xsl:with-param name="value" select="//config-data//MAX_IOAPIC_NUM/text()" />
+      <xsl:with-param name="default" select="count(.//ioapic)" />
     </xsl:call-template>
     <xsl:call-template name="integer-by-key-value">
       <xsl:with-param name="key" select="'MAX_IOAPIC_LINES'" />
-      <xsl:with-param name="value" select="math:max(//gsi_number/text() | exslt:node-set(0))" />
+      <xsl:with-param name="value" select="//config-data//MAX_IOAPIC_LINES/text()" />
+      <xsl:with-param name="default" select="math:max(.//ioapic/gsi_number/text() | exslt:node-set(0))" />
     </xsl:call-template>
     <xsl:call-template name="msi-msix-max" />
   </xsl:template>

--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -208,26 +208,26 @@
 	<xsl:variable name="bus" select="substring-before($bdf, ':')" />
 	<xsl:variable name="device" select="substring-before(substring-after($bdf, ':'), '.')" />
 	<xsl:variable name="function" select="substring-after($bdf, '.')" />
+	<xsl:variable name="serial_bdf">
+	  <xsl:text>0b</xsl:text>
+	  <xsl:call-template name="hex-to-bin">
+	    <xsl:with-param name="s" select="$bus" />
+	    <xsl:with-param name="width" select="4" />
+	  </xsl:call-template>
+	  <xsl:call-template name="hex-to-bin">
+	    <xsl:with-param name="s" select="$device" />
+	    <xsl:with-param name="width" select="1" />
+	  </xsl:call-template>
+	  <xsl:call-template name="hex-to-bin">
+	    <xsl:with-param name="s" select="$function" />
+	    <xsl:with-param name="width" select="3" />
+	  </xsl:call-template>
+	</xsl:variable>
 
 	<xsl:call-template name="integer-by-key-value">
 	  <xsl:with-param name="key" select="'SERIAL_PCI_BDF'" />
+	  <xsl:with-param name="value" select="$serial_bdf" />
 	</xsl:call-template>
-
-	<xsl:text>0b</xsl:text>
-	<xsl:call-template name="hex-to-bin">
-	  <xsl:with-param name="s" select="$bus" />
-	  <xsl:with-param name="width" select="4" />
-	</xsl:call-template>
-	<xsl:call-template name="hex-to-bin">
-	  <xsl:with-param name="s" select="$device" />
-	  <xsl:with-param name="width" select="1" />
-	</xsl:call-template>
-	<xsl:call-template name="hex-to-bin">
-	  <xsl:with-param name="s" select="$function" />
-	  <xsl:with-param name="width" select="3" />
-	</xsl:call-template>
-	<xsl:value-of select="$integer-suffix" />
-	<xsl:text>&#xa;</xsl:text>
       </xsl:when>
       <xsl:otherwise>
 	<xsl:call-template name="boolean-by-key-value">


### PR DESCRIPTION
This PR contains fixes to the following issues:

* The board inspector adds another level of `die` node even though the hardware reports die topology in CPUID.
* Build fails when the board contains any unprogrammed BAR.
* Values of `IOAPIC_MAX_NUM` and `IOAPIC_MAX_LINES` in scenario XML do not override auto-calculated values.