### PR TITLE
dm: rtvm enable lapic_pt automatically

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -932,10 +932,10 @@ main(int argc, char *argv[])
 			break;
 		case CMD_OPT_LAPIC_PT:
 			lapic_pt = true;
-			is_rtvm = true;
 			break;
 		case CMD_OPT_RTVM:
 			is_rtvm = true;
+			lapic_pt = true;
 			break;
 		case CMD_OPT_SOFTWARE_SRAM:
 			if (parse_vssram_buf_params(optarg) != 0)
@@ -1003,6 +1003,10 @@ main(int argc, char *argv[])
 		usage(1);
         }
 
+	if (lapic_pt == true && is_rtvm == false) {
+		lapic_pt = false;
+		pr_warn("Only a Realtime VM can use local APIC pass through, '--lapic_pt' is invalid here.\n");
+	}
 	vmname = argv[0];
 
 	if (strnlen(vmname, MAX_VM_NAME_LEN) >= MAX_VM_NAME_LEN) {

--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -582,6 +582,7 @@ def dm_arg_set(names, sel, virt_io, dm, sriov, vmid, config):
             print("   --rtvm \\", file=config)
 
         if dm['rtos_type'][vmid] == "Hard RT":
+            print("   --rtvm \\", file=config)
             print("   --lapic_pt \\", file=config)
 
     # windows


### PR DESCRIPTION
Enable `lapic_pt` automatically for rtvm for better performance.

Reserve `--lapic_pt` for future use. If VM is not in realtime mode,
`--lapic_pt` will cause a warning.

Tracked-On: #6690
Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>