### PR TITLE
dm: refine the mac check logic for virtio-net

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_net.c
+++ b/devicemodel/hw/pci/virtio/virtio_net.c
@@ -869,7 +869,7 @@ virtio_net_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		while ((opt = strsep(&vtopts, ",")) != NULL) {
 			if (strcmp("vhost", opt) == 0)
 				net->use_vhost = true;
-			else {
+			else if (!strncmp(opt, "mac=", 4)) {
 				err = virtio_net_parsemac(opt,
 					net->config.mac);
 				if (err != 0) {
@@ -914,7 +914,7 @@ virtio_net_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		name = strsep(&tmp, ",");
 	}
 
-	if (strncmp(tmp, "mac_seed",8) == 0) {
+	if ((tmp != NULL) && (strncmp(tmp, "mac_seed",8) == 0)) {
 		strsep(&tmp, "=");
 		mac_seed = tmp;
 	}


### PR DESCRIPTION
The current mac detection logic only check whether there are parameters
after tap opt. Don't care whether the parameter is MAC or not, then
mac_provided will be set to 1, which will disable the mac_seed setting
when using sub parameters

This patch will check opt and fix the above issue.

Tracked-On: #6690
Acked-by: Wang, Yu1 <yu1.wang@intel.com>
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>