### PR TITLE
hv: remove HC_GET_PLATFORM_INFO hypercall support

### DIFF
--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -38,8 +38,6 @@ static const struct hc_dispatch hc_dispatch_table[] = {
 		.handler = hcall_service_vm_offline_cpu},
 	[HC_IDX(HC_SET_CALLBACK_VECTOR)] = {
 		.handler = hcall_set_callback_vector},
-	[HC_IDX(HC_GET_PLATFORM_INFO)] = {
-		.handler = hcall_get_platform_info},
 	[HC_IDX(HC_CREATE_VM)] = {
 		.handler = hcall_create_vm},
 	[HC_IDX(HC_DESTROY_VM)] = {
@@ -183,7 +181,6 @@ struct acrn_vm *parse_target_vm(struct acrn_vm *service_vm, uint64_t hcall_id, u
 	case HC_GET_API_VERSION:
 	case HC_SERVICE_VM_OFFLINE_CPU:
 	case HC_SET_CALLBACK_VECTOR:
-	case HC_GET_PLATFORM_INFO:
 	case HC_SETUP_SBUF:
 	case HC_SETUP_HV_NPK_LOG:
 	case HC_PROFILING_OPS:

--- a/hypervisor/include/arch/x86/asm/vm_config.h
+++ b/hypervisor/include/arch/x86/asm/vm_config.h
@@ -152,9 +152,7 @@ struct pt_intx_config {
 struct acrn_vm_config {
 	enum acrn_vm_load_order load_order;		/* specify the load order of VM */
 	char name[MAX_VM_NAME_LEN];				/* VM name identifier */
-	uint8_t reserved[2];				/* Temporarily reserve it so that don't need to update
-							 * the users of get_platform_info frequently.
-							 */
+	uint8_t reserved[2];
 	uint8_t severity;				/* severity of the VM */
 	uint64_t cpu_affinity;				/* The set bits represent the pCPUs the vCPUs of
 							 * the VM may run on.

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -53,21 +53,6 @@ int32_t hcall_service_vm_offline_cpu(struct acrn_vcpu *vcpu, struct acrn_vm *tar
  */
 int32_t hcall_get_api_version(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
-/**
- * @brief Get basic platform information.
- *
- * The function returns basic hardware or configuration information
- * for the current platform.
- *
- * @param vcpu Pointer to vCPU that initiates the hypercall.
- * @param target_vm not used
- * @param param1 GPA pointer to struct acrn_platform_info.
- * @param param2 not used
- *
- * @pre is_service_vm(vcpu->vm)
- * @return 0 on success, -1 in case of error.
- */
-int32_t hcall_get_platform_info(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief create virtual machine

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -29,7 +29,6 @@
 #define HC_GET_API_VERSION          BASE_HC_ID(HC_ID, HC_ID_GEN_BASE + 0x00UL)
 #define HC_SERVICE_VM_OFFLINE_CPU   BASE_HC_ID(HC_ID, HC_ID_GEN_BASE + 0x01UL)
 #define HC_SET_CALLBACK_VECTOR      BASE_HC_ID(HC_ID, HC_ID_GEN_BASE + 0x02UL)
-#define HC_GET_PLATFORM_INFO        BASE_HC_ID(HC_ID, HC_ID_GEN_BASE + 0x03UL)
 
 /* VM management */
 #define HC_ID_VM_BASE               0x10UL
@@ -288,64 +287,6 @@ struct hc_api_version {
 } __aligned(8);
 
 #define ACRN_PLATFORM_LAPIC_IDS_MAX	64U
-/**
- * Hypervisor API, return it for HC_GET_PLATFORM_INFO hypercall
- */
-struct acrn_platform_info {
-	/** Hardware Information */
-	struct {
-		/** Physical CPU number */
-		uint16_t cpu_num;
-		/** version of this structure */
-		uint16_t version;
-
-		uint32_t l2_cat_shift;
-		uint32_t l3_cat_shift;
-
-		/** pLAPIC ID list */
-		uint8_t  lapic_ids[ACRN_PLATFORM_LAPIC_IDS_MAX];
-
-		/**
-		 * sizeof(uint8_t reserved0[]) + sizeof(l2_cat_shift)
-		 * + sizeof(l3_cat_shift) + sizeof(uint8_t lapic_ids[]) = 124
-		 *
-		 * Note:
-		 * 1. DM needs to use the same logic as hypervisor to calculate vLAPIC IDs
-		 * based on physical APIC IDs and CPU affinity setting.
-		 *
-		 * 2. Can only support at most 116 cores. And it assumes LAPIC ID is 8bits
-		 * (X2APIC mode supports 32 bits)
-		 */
-		uint8_t  reserved[52];
-	} hw;
-
-	/** Configuration Information */
-	struct {
-		/** Maximum vCPU number for one VM. */
-		uint16_t max_vcpus_per_vm;
-		/** Number of configured VMs */
-		uint16_t max_vms;
-		/**
-		 * The size of acrn_vm_config is various on different platforms.
-		 * This is the size of this struct which is used by the caller
-		 * to parse the vm_configs array.
-		 */
-		uint32_t vm_config_size;
-
-		/**
-		 * Address to an array of struct acrn_vm_config, containing all
-		 * the configurations of all VMs. HSM treats it as an opaque data
-		 * structure.
-		 *
-		 * The size of one array element is vm_config_entry_size while
-		 * the number of elements is max_vms.
-		 */
-		uint64_t vm_configs_addr;
-
-		/** Align the size of Configuration info to 128Bytes. */
-		uint8_t  reserved[112];
-	} sw;
-} __aligned(8);
 
 /**
  * Trusty boot params, used for HC_INITIALIZE_TRUSTY


### PR DESCRIPTION
 HC_GET_PLATFORM_INFO hypercall is not supported anymore,
 hence to remove related function and data structure definition.

Tracked-On: #6690
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>