### PR TITLE
config_tools: fix illegal access to the level_types dictionary

### DIFF
--- a/misc/config_tools/board_inspector/extractors/10-processors.py
+++ b/misc/config_tools/board_inspector/extractors/10-processors.py
@@ -74,8 +74,9 @@ def extract_topology(processors_node):
         while True:
             leaf_topo = parse_cpuid(topo_leaf, subleaf, cpu_id)
             if leaf_topo.level_type == 0:
-                if last_node.tag != level_types[-1]:
-                    n, _ = get_or_create_parent(processors_node, level_types[-1], "0x0")
+                highest_level = max(level_types.keys())
+                if last_node.tag != level_types[highest_level]:
+                    n, _ = get_or_create_parent(processors_node, level_types[highest_level], "0x0")
                     n.append(last_node)
                     last_node = n
                 processors_node.append(last_node)


### PR DESCRIPTION
In 10-processors.py, level_types is an unordered dictionary from level type
encodings to human-readable terms, not a list. It is thus illegal to access the
highest level using the `[-1]` notation.

This patch fixes this by calculating the highest level in level_types and use
that level as the index instead.

Tracked-On: #6689
Fixes: b5b22bf98 ("board_inspector: avoid hard-coded topo level names")
Signed-off-by: Junjie Mao <junjie.mao@intel.com>