### PR TITLE
doc: show source file link on html pages

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -243,7 +243,7 @@ def setup(app):
 html_show_sphinx = False
 
 # If true, links to the reST sources are added to the pages.
-html_show_sourcelink = False
+html_show_sourcelink = True
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page
 # bottom,


### PR DESCRIPTION
A shortcut to find the :ref:`labelname` value to link to an HTML page is
to view the source .rst file for that page.  This patch tweaks the
conf.py to do just that.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>