### PR TITLE
Add command monitor in DM

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -171,6 +171,10 @@ SRCS += core/main.c
 SRCS += core/hugetlb.c
 SRCS += core/vrpmb.c
 SRCS += core/timer.c
+SRCS += core/cmd_monitor/socket.c
+SRCS += core/cmd_monitor/command.c
+SRCS += core/cmd_monitor/command_handler.c
+SRCS += core/cmd_monitor/cmd_monitor.c
 
 # arch
 SRCS += arch/x86/pm.c

--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -81,6 +81,7 @@ LIBS += -lpciaccess
 LIBS += -luuid
 LIBS += -lusb-1.0
 LIBS += -lacrn-mngr
+LIBS += -lcjson
 
 # lib
 SRCS += lib/dm_string.c

--- a/devicemodel/core/cmd_monitor/cmd_monitor.c
+++ b/devicemodel/core/cmd_monitor/cmd_monitor.c
@@ -115,3 +115,15 @@ void deinit_cmd_monitor(void)
 		deinit_socket(sock_server);
 	}
 }
+int acrn_parse_cmd_monitor(char *arg)
+{
+	int err = -1;
+	size_t len = strnlen(arg, UNIX_SOCKET_PATH_MAX);
+
+	if (len < UNIX_SOCKET_PATH_MAX) {
+		strncpy(socket_path, arg, len + 1);
+		pr_notice("Command monitor: using soket path %s\n", socket_path);
+		err = 0;
+	}
+	return err;
+}

--- a/devicemodel/core/cmd_monitor/cmd_monitor.c
+++ b/devicemodel/core/cmd_monitor/cmd_monitor.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2022 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <pthread.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/un.h>
+#include <cjson/cJSON.h>
+#include "socket.h"
+#include "command.h"
+#include "vmmapi.h"
+#include "cmd_monitor.h"
+#include "log.h"
+#include "dm.h"
+#include "command_handler.h"
+
+struct socket_dev *sock_server; /* socket server instance */
+static char socket_path[UNIX_SOCKET_PATH_MAX];
+
+static struct command *parse_command(char *cmd_msg, int fd)
+{
+	struct command *cmd = NULL;
+	const cJSON *execute;
+	const cJSON *arguments;
+	cJSON *cmd_json;
+
+	cmd_json = cJSON_Parse(cmd_msg);
+	if (cmd_json == NULL) {
+		const char *error_ptr = cJSON_GetErrorPtr();
+		if (error_ptr != NULL) {
+			fprintf(stderr, "Error before: %s\n", error_ptr);
+        }
+        return NULL;
+	}
+	execute = cJSON_GetObjectItemCaseSensitive(cmd_json, "command");
+	if (cJSON_IsString(execute) && (execute->valuestring != NULL)) {
+		pr_info("Command name: \"%s\"\n", execute->valuestring);
+
+		cmd = find_command(execute->valuestring);
+		if (cmd != NULL) {
+			cmd->para.fd = fd;
+			arguments = cJSON_GetObjectItemCaseSensitive(cmd_json, "arguments");
+			if (cJSON_IsString(arguments) && (arguments->valuestring != NULL)) {
+				pr_info("Command arguments: \"%s\"\n", arguments->valuestring);
+				strncpy(cmd->para.option, arguments->valuestring, CMD_ARG_MAX - 1U);
+			}
+		} else {
+			pr_err("Command [%s] is not supported.\n", execute->valuestring);
+		}
+	}
+	cJSON_Delete(cmd_json);
+	return cmd;
+}
+static void monitor_cmd_dispatch(char *cmd_msg, int fd)
+{
+	struct command *cmd;
+
+	cmd = parse_command(cmd_msg, fd);
+	if (cmd != NULL) {
+		dispatch_command_handlers(cmd);
+	}
+	return;
+}
+
+int init_socket_server(void)
+{
+	int ret = 0;
+
+	if (strnlen(socket_path, UNIX_SOCKET_PATH_MAX) == 0) {
+		pr_err("Failed to initialize command monitor due to invalid socket path.\n");
+	}
+
+	sock_server = init_socket(socket_path);
+	if (sock_server == NULL)
+		return -1;
+	ret = open_socket(sock_server, monitor_cmd_dispatch);
+	if (ret < 0)
+		return ret;
+	return ret;
+}
+
+static void register_socket_message_handlers(struct vmctx *ctx)
+{
+	struct handler_args arg;
+	arg.channel_arg = sock_server;
+	arg.ctx_arg = ctx;
+	register_command_handler(user_vm_destroy_handler, &arg, DESTROY);
+	register_command_handler(user_vm_blkrescan_handler, &arg, BLKRESCAN);
+}
+
+int init_cmd_monitor(struct vmctx *ctx)
+{
+	int ret;
+	ret = init_socket_server();
+	register_socket_message_handlers(ctx);
+	return ret;
+}
+void deinit_cmd_monitor(void)
+{
+	if (sock_server != NULL) {
+		close_socket(sock_server);
+		deinit_socket(sock_server);
+	}
+}

--- a/devicemodel/core/cmd_monitor/command.c
+++ b/devicemodel/core/cmd_monitor/command.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <pthread.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/un.h>
+#include "command.h"
+#include "vmmapi.h"
+#include "log.h"
+
+#define GEN_CMD_OBJ(cmd_name) \
+	{.name = cmd_name,}
+#define CMD_OBJS \
+	GEN_CMD_OBJ(DESTROY), \
+	GEN_CMD_OBJ(BLKRESCAN), \
+
+struct command dm_command_list[CMDS_NUM] = {CMD_OBJS};
+
+int dispatch_command_handlers(void *arg)
+{
+	struct command *cmd = (struct command *)arg;
+	int ret = 0;
+
+	pr_info("Handle command %s in command monitor.\n", cmd->name);
+	if (cmd->cmd_handler.fn) {
+		ret = cmd->cmd_handler.fn(cmd->cmd_handler.arg, &cmd->para);
+		pr_info("Command handler ret=%d.\n", ret);
+	} else {
+		pr_info("No handler for command: %s.\r\n", cmd->name);
+	}
+
+	return 0;
+}
+struct command *find_command(const char *name)
+{
+	for (int i = 0; (i < CMDS_NUM) && (name != NULL); i++) {
+		if (strcmp(dm_command_list[i].name, name) == 0)
+			return &dm_command_list[i];
+	}
+	return NULL;
+}
+
+int register_command_handler(cmd_handler *fn, struct handler_args *arg, const char *cmd_name)
+{
+	struct command *cmd;
+	struct handler_args *handler_arg;
+
+	if ((!fn) || (!arg) || (!cmd_name)) {
+		pr_err("%s : Failed to register command_handler.\n", __func__);
+		return -EINVAL;
+	}
+
+	cmd = find_command(cmd_name);
+	if (cmd == NULL) {
+		pr_err("%s : invalid command name %s.\r\n", __func__, cmd_name);
+		return -EINVAL;
+	}
+
+	if (cmd->cmd_handler.fn != NULL) {
+		pr_err("Failed to register command handler since the handler have already been registered.\n");
+		return -EINVAL;
+	}
+	cmd->cmd_handler.fn = fn;
+
+	handler_arg = calloc(1, sizeof(*handler_arg));
+	if (!handler_arg) {
+		pr_err("Failed to allocate command handler argument.\r\n");
+		return -ENOMEM;
+	}
+	cmd->cmd_handler.arg = handler_arg;
+	cmd->cmd_handler.arg->channel_arg = arg->channel_arg;
+	cmd->cmd_handler.arg->ctx_arg = arg->ctx_arg;
+
+	return 0;
+}

--- a/devicemodel/core/cmd_monitor/command.h
+++ b/devicemodel/core/cmd_monitor/command.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _COMMAND_H_
+#define _COMMAND_H_
+#include <pthread.h>
+#include <sys/queue.h>
+
+
+#define DESTROY "destroy"
+#define BLKRESCAN "blkrescan"
+
+#define CMDS_NUM 2U
+#define CMD_NAME_MAX 32U
+#define CMD_ARG_MAX 320U
+
+typedef int (cmd_handler)(void *arg, void *command_para);
+struct handler_args {
+	void *channel_arg;
+	void *ctx_arg;
+};
+struct command_handler {
+	struct handler_args *arg;
+	cmd_handler *fn;
+};
+struct command_parameters {
+	int fd;
+	char option[CMD_ARG_MAX];
+};
+struct command {
+	const char name[CMD_NAME_MAX]; /**< command name */
+	struct command_parameters para;
+
+	/* command handler */
+	struct command_handler cmd_handler;
+};
+/**
+ * @brief register command handler, other module can use this interface to
+ * register multiple handler for one command.
+ *
+ * @param fn the command handler which will be registered
+ * @param arg the parameter which will be passed into hanlder
+ * @param cmd_name the command name
+ */
+int register_command_handler(cmd_handler *fn, struct handler_args *arg, const char *cmd_name);
+/**
+ * @brief find a command instance by name
+ *
+ * @param name the command name
+ * @return command instance
+ */
+struct command *find_command(const char *name);
+/**
+ * @brief dispatch the command and invoke registered handler.
+ *
+ * @param arg command instance
+ * @return the flag indicates the state of command handler execution
+ */
+int dispatch_command_handlers(void *arg);
+#endif

--- a/devicemodel/core/cmd_monitor/command_handler.c
+++ b/devicemodel/core/cmd_monitor/command_handler.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2022 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/un.h>
+#include <libgen.h>
+#include <cjson/cJSON.h>
+#include "command.h"
+#include "socket.h"
+#include "command_handler.h"
+#include "dm.h"
+#include "pm.h"
+#include "vmmapi.h"
+#include "log.h"
+#include "monitor.h"
+
+#define SUCCEEDED 0
+#define FAILED -1
+
+static char *generate_ack_message(int ret_val)
+{
+	char *ack_msg;
+	cJSON *val;
+	cJSON *ret_obj = cJSON_CreateObject();
+
+	if (ret_obj == NULL)
+		return NULL;
+	val = cJSON_CreateNumber(ret_val);
+	if (val == NULL)
+		return NULL;
+	cJSON_AddItemToObject(ret_obj, "ack", val);
+	ack_msg = cJSON_Print(ret_obj);
+	if (ack_msg == NULL)
+		fprintf(stderr, "Failed to generate ACK message.\n");
+	cJSON_Delete(ret_obj);
+	return ack_msg;
+}
+static int send_socket_ack(struct socket_dev *sock, int fd, bool normal)
+{
+	int ret = 0, val;
+	char *ack_message;
+	struct socket_client *client = NULL;
+
+	client = find_socket_client(sock, fd);
+	if (client == NULL)
+		return -1;
+	val = normal ? SUCCEEDED : FAILED;
+	ack_message = generate_ack_message(val);
+
+	if (ack_message != NULL) {
+		memset(client->buf, 0, CLIENT_BUF_LEN);
+		memcpy(client->buf, ack_message, strlen(ack_message));
+		client->len = strlen(ack_message);
+		ret = write_socket_char(client);
+		free(ack_message);
+	} else {
+		pr_err("Failed to generate ACK message.\n");
+		ret = -1;
+	}
+	return ret;
+}
+
+int user_vm_destroy_handler(void *arg, void *command_para)
+{
+	int ret;
+	struct command_parameters *cmd_para = (struct command_parameters *)command_para;
+	struct handler_args *hdl_arg = (struct handler_args *)arg;
+	struct socket_dev *sock = (struct socket_dev *)hdl_arg->channel_arg;
+	struct socket_client *client = NULL;
+	bool cmd_completed = false;
+
+	client = find_socket_client(sock, cmd_para->fd);
+	if (client == NULL)
+		return -1;
+
+	if (!is_rtvm) {
+		pr_info("%s: setting VM state to %s.\n", __func__, vm_state_to_str(VM_SUSPEND_POWEROFF));
+		vm_set_suspend_mode(VM_SUSPEND_POWEROFF);
+		cmd_completed = true;
+	} else {
+		pr_err("Failed to destroy post-launched RTVM.\n");
+		ret = -1;
+	}
+
+	ret = send_socket_ack(sock, cmd_para->fd, cmd_completed);
+	if (ret < 0) {
+		pr_err("Failed to send ACK message by socket.\n");
+	}
+	return ret;
+}
+
+int user_vm_blkrescan_handler(void *arg, void *command_para)
+{
+	int ret = 0;
+	struct command_parameters *cmd_para = (struct command_parameters *)command_para;
+	struct handler_args *hdl_arg = (struct handler_args *)arg;
+	struct socket_dev *sock = (struct socket_dev *)hdl_arg->channel_arg;
+	struct socket_client *client = NULL;
+	bool cmd_completed = false;
+
+	client = find_socket_client(sock, cmd_para->fd);
+	if (client == NULL)
+		return -1;
+
+	ret = vm_monitor_blkrescan(hdl_arg->ctx_arg, cmd_para->option);
+	if (ret >= 0) {
+		cmd_completed = true;
+	} else {
+		pr_err("Failed to rescan virtio-blk device.\n");
+	}
+
+	ret = send_socket_ack(sock, cmd_para->fd, cmd_completed);
+	if (ret < 0) {
+		pr_err("Failed to send ACK by socket.\n");
+	}
+	return ret;
+}

--- a/devicemodel/core/cmd_monitor/command_handler.h
+++ b/devicemodel/core/cmd_monitor/command_handler.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2022 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _COMMAND_HANDLER_H_
+#define _COMMAND_HANDLER_H_
+
+extern struct socket_dev *sock_server;
+
+int user_vm_destroy_handler(void *arg, void *command_para);
+int user_vm_blkrescan_handler(void *arg, void *command_para);
+#endif

--- a/devicemodel/core/cmd_monitor/socket.c
+++ b/devicemodel/core/cmd_monitor/socket.c
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2022 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include "socket.h"
+#include "log.h"
+#include "mevent.h"
+
+static int setup_and_listen_unix_socket(const char *sock_path, int num)
+{
+	struct sockaddr_un s_un;
+	int sock_fd, ret;
+
+	sock_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (sock_fd < 0)
+		goto err;
+	s_un.sun_family = AF_UNIX;
+	ret = snprintf(s_un.sun_path, sizeof(s_un.sun_path), "%s",
+			sock_path);
+	if (ret < 0 || ret >= sizeof(s_un.sun_path))
+		goto err_close_socket;
+
+	if (bind(sock_fd, (struct sockaddr *)&s_un, sizeof(s_un)) < 0)
+		goto err_close_socket;
+	if (listen(sock_fd, num) < 0)
+		goto err_close_socket;
+	pr_info("Listening on: %s, socket fd = %d.\r\n", sock_path, sock_fd);
+	return sock_fd;
+err_close_socket:
+	close(sock_fd);
+err:
+	return -1;
+}
+static void free_socket_client(struct socket_dev *sock, struct socket_client *client)
+{
+	pthread_mutex_lock(&sock->client_mtx);
+	LIST_REMOVE(client, list);
+	pthread_mutex_unlock(&sock->client_mtx);
+
+	close(client->fd);
+	client->fd = -1;
+	free(client);
+}
+
+int write_socket_char(struct socket_client *client)
+{
+	struct msghdr msg;
+	struct iovec iov[1];
+	int ret;
+	char control[CMSG_SPACE(sizeof(int))];
+	struct cmsghdr *cmsg;
+
+	memset(&msg, 0, sizeof(msg));
+	memset(control, 0, sizeof(control));
+
+	iov[0].iov_base = (void *)client->buf;
+	iov[0].iov_len = client->len;
+
+	msg.msg_iov = iov;
+	msg.msg_iovlen = 1;
+
+	msg.msg_control = control;
+	msg.msg_controllen = sizeof(control);
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	memcpy(CMSG_DATA(cmsg), &client->fd, sizeof(int));
+
+	do {
+		ret = sendmsg(client->fd, &msg, 0);
+	} while (ret < 0 && errno == EINTR);
+
+	return ret;
+}
+
+int read_socket_char(struct socket_dev *sock, struct socket_client *client)
+{
+	struct iovec iov;
+	struct msghdr msg;
+	struct cmsghdr *cmsg;
+	char buf[CMSG_SPACE(sizeof(int))];
+	int fdflags_recvmsg = MSG_CMSG_CLOEXEC;
+
+	memset(&msg, 0, sizeof(msg));
+	memset(client->buf, '\0', CLIENT_BUF_LEN);
+	iov.iov_base = client->buf;
+	iov.iov_len = CLIENT_BUF_LEN;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_name = NULL;
+	msg.msg_namelen = 0;
+
+	msg.msg_control = buf;
+	msg.msg_controllen = sizeof(buf);
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+
+	client->len = recvmsg(client->fd, &msg, fdflags_recvmsg);
+	if (client->len <= 0) {
+		pr_err("Socket Disconnect: %d.\r\n", client->fd);
+		free_socket_client(sock, client);
+		sock->num_client--;
+		return -1;
+	}
+	if (client->len == CLIENT_BUF_LEN) {
+		pr_err("Socket buffer overflow!\r\n");
+		return -1;
+	}
+	for (unsigned int i = 0U; i < CLIENT_BUF_LEN; i++)
+		if (client->buf[i] == 0xa)
+			client->buf[i] = '\0';
+	pr_info("Receive data:(%s)\n", client->buf);
+	if (sock->data_handler != NULL)
+		sock->data_handler(client->buf, client->fd);
+	return 0;
+}
+static struct socket_client *new_socket_client(struct socket_dev *sock)
+{
+	struct socket_client *client;
+
+	client = calloc(1, sizeof(*client));
+	if (!client) {
+		pr_err("%s: failed to allocate memory for client\n",
+					__func__);
+		goto alloc_client;
+	}
+
+	client->addr_len = sizeof(client->addr);
+	client->fd =
+	    accept(sock->sock_fd, (struct sockaddr *)&client->addr,
+		   &client->addr_len);
+	if (client->fd < 0) {
+		if (sock->listening)
+			pr_err("%s: Failed to accept from fd %d, err: %s\n",
+					__func__, sock->sock_fd, strerror(errno));
+		goto accept_con;
+	}
+
+	pthread_mutex_lock(&sock->client_mtx);
+	LIST_INSERT_HEAD(&sock->client_head, client, list);
+	pthread_mutex_unlock(&sock->client_mtx);
+
+	return client;
+
+ accept_con:
+	free(client);
+ alloc_client:
+	return NULL;
+}
+static void *listen_socket_client(void *arg)
+{
+	struct socket_dev *sock = (struct socket_dev *)arg;
+	struct socket_client *client;
+
+	pr_info("Socket Listening %d...\n", sock->sock_fd);
+	while (sock->listening) {
+		/* wait connection */
+		if (sock->num_client >= SOCKET_MAX_CLIENT) {
+			usleep(500000);
+			continue;
+		}
+
+		client = new_socket_client(sock);
+		if (!client) {
+			usleep(500000);
+			continue;
+		}
+		pr_info("Socket Connected:%d\n", client->fd);
+		sock->num_client++;
+	}
+	pr_info("Stop listening %d.\n", sock->sock_fd);
+	return NULL;
+}
+static void *socket_poll_events(void *arg)
+{
+	struct socket_dev *sock = (struct socket_dev *)arg;
+	struct socket_client *client;
+	fd_set rfd;
+	int max_fd = 0;
+	struct timeval timeout;
+	struct socket_client *poll_client[SOCKET_MAX_CLIENT];
+	int nfd, i;
+
+	pr_info("Polling socket %d.\n", sock->sock_fd);
+	while (sock->polling) {
+		max_fd = 0;
+		nfd = 0;
+		pthread_mutex_lock(&sock->client_mtx);
+		FD_ZERO(&rfd);
+		LIST_FOREACH(client, &sock->client_head, list) {
+			FD_SET(client->fd, &rfd);
+			poll_client[nfd] = client;
+			nfd++;
+			if (client->fd > max_fd)
+				max_fd = client->fd;
+		}
+		pthread_mutex_unlock(&sock->client_mtx);
+
+		timeout.tv_sec = 0;
+		timeout.tv_usec = 10000;
+		select(max_fd + 1, &rfd, NULL, NULL, &timeout);
+
+		for (i = 0; i < nfd; i++) {
+			client = poll_client[i];
+			if (!FD_ISSET(client->fd, &rfd))
+				continue;
+
+			if (read_socket_char(sock, client) < 0)
+				continue;
+		}
+	}
+	pr_info("Stop polling on socket %d.\n", sock->sock_fd);
+
+	return NULL;
+}
+struct socket_client *find_socket_client(struct socket_dev *sock, int fd)
+{
+	struct socket_client *client = NULL;
+	pthread_mutex_lock(&sock->client_mtx);
+	LIST_FOREACH(client, &sock->client_head, list) {
+		if (client->fd == fd)
+			break;
+	}
+	pthread_mutex_unlock(&sock->client_mtx);
+	return client;
+}
+int open_socket(struct socket_dev *sock, data_handler_f *fn)
+{
+	sock->listening = true;
+	sock->polling = true;
+	sock->data_handler = fn;
+	pthread_mutex_init(&sock->client_mtx, NULL);
+	unlink(sock->unix_sock_path);
+	sock->sock_fd = setup_and_listen_unix_socket(sock->unix_sock_path, SOCKET_MAX_CLIENT);
+	if (sock->sock_fd < 0)
+		return -1;
+	pthread_create(&sock->listen_thread, NULL, listen_socket_client, sock);
+	pthread_create(&sock->connect_thread, NULL, socket_poll_events, sock);
+	return 0;
+}
+
+void close_socket(struct socket_dev *sock)
+{
+	struct socket_client *client, *tclient;
+
+	sock->listening = false;
+	sock->polling = false;
+	shutdown(sock->sock_fd, SHUT_RDWR);
+
+	pthread_join(sock->listen_thread, NULL);
+	pthread_join(sock->connect_thread, NULL);
+
+	pthread_mutex_lock(&sock->client_mtx);
+	list_foreach_safe(client, &sock->client_head, list, tclient) {
+		LIST_REMOVE(client, list);
+		close(client->fd);
+		client->fd = -1;
+		free(client);
+	}
+	pthread_mutex_unlock(&sock->client_mtx);
+
+	close(sock->sock_fd);
+	unlink(sock->unix_sock_path);
+}
+struct socket_dev *init_socket(char *path)
+{
+	struct socket_dev *sock;
+
+	sock = calloc(1, sizeof(*sock));
+	if (!sock) {
+		pr_err("%s: Failed to allocate memory for socket\n", __func__);
+		return NULL;
+	}
+	memset(sock, 0x0, sizeof(struct socket_dev));
+	strncpy(sock->unix_sock_path, path, UNIX_SOCKET_PATH_MAX - 1);
+	return sock;
+}
+void deinit_socket(struct socket_dev *sock)
+{
+	if (sock != NULL)
+		free(sock);
+}

--- a/devicemodel/core/cmd_monitor/socket.h
+++ b/devicemodel/core/cmd_monitor/socket.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _SOCKET_H_
+#define _SOCKET_H_
+#include <sys/queue.h>
+#include <pthread.h>
+#include <sys/un.h>
+
+#define BUFFER_SIZE 16U
+#define UNIX_SOCKET_PATH_MAX 1024U
+#define CLIENT_BUF_LEN 4096U
+#define SOCKET_MAX_CLIENT		1
+
+typedef void data_handler_f(char *cmd_name, int fd);
+
+struct socket_client {
+	struct sockaddr_un addr;
+	int fd;
+	socklen_t addr_len;
+	char buf[CLIENT_BUF_LEN];
+	int len; /* buf len */
+
+	LIST_ENTRY(socket_client) list;
+};
+
+struct socket_dev {
+	char unix_sock_path[UNIX_SOCKET_PATH_MAX];
+	int sock_fd;
+	int logfd;
+
+	data_handler_f *data_handler;
+
+	bool listening;
+	bool polling;
+	pthread_t listen_thread;
+	pthread_t connect_thread;
+
+	LIST_HEAD(client_list, socket_client) client_head;        /* clients for this server */
+	pthread_mutex_t client_mtx;
+	int num_client;
+};
+
+/**
+ * @brief Send message through unix domain socket server
+ */
+int write_socket_char(struct socket_client *client);
+/**
+ * @brief Find socket client instance according to fd
+ */
+struct socket_client *find_socket_client(struct socket_dev *sock, int fd);
+/**
+ * @brief Open one unix domain socket server, initialize a socket,
+ * create one thread to listen to client, another thread to poll message from client.
+ */
+int open_socket(struct socket_dev *sock, data_handler_f *fn);
+/**
+ * @brief Close one unix domain socket server
+ */
+void close_socket(struct socket_dev *sock);
+/**
+ * @brief Initialize a socket
+ *
+ * @param path the socket path
+ * @return struct socket_dev* the socket instance
+ */
+struct socket_dev *init_socket(char *path);
+/**
+ * @brief Deinit a socket
+ *
+ * @param sock The pointer of socket instance
+ */
+void deinit_socket(struct socket_dev *sock);
+
+#endif

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -68,6 +68,7 @@
 #include "log.h"
 #include "pci_util.h"
 #include "vssram.h"
+#include "cmd_monitor.h"
 
 #define	VM_MAXCPU		16	/* maximum virtual cpus */
 
@@ -102,6 +103,7 @@ static int guest_ncpus;
 static int virtio_msix = 1;
 static bool debugexit_enabled;
 static int pm_notify_channel;
+static bool cmd_monitor;
 
 static char *progname;
 static const int BSP;
@@ -165,6 +167,8 @@ usage(int code)
 		"       --debugexit: enable debug exit function\n"
 		"       --intr_monitor: enable interrupt storm monitor\n"
 		"            its params: threshold/s,probe-period(s),delay_time(ms),delay_duration(ms)\n"
+		"       --cmd_monitor: enable command monitor\n"
+		"            its params: unix domain socket path\n"
 		"       --virtio_poll: enable virtio poll mode with poll interval with ns\n"
 		"       --acpidev_pt: acpi device ID args: HID in ACPI Table\n"
 		"       --mmiodev_pt: MMIO resources args: physical MMIO regions\n"
@@ -486,6 +490,9 @@ vm_init_vdevs(struct vmctx *ctx)
 	if (ret < 0)
 		goto monitor_fail;
 
+	if ((cmd_monitor) && init_cmd_monitor(ctx) < 0)
+		goto monitor_fail;
+
 	ret = init_mmio_devs(ctx);
 	if (ret < 0)
 		goto mmio_dev_fail;
@@ -757,6 +764,7 @@ enum {
 	CMD_OPT_VMCFG,
 	CMD_OPT_DUMP,
 	CMD_OPT_INTR_MONITOR,
+	CMD_OPT_CMD_MONITOR,
 	CMD_OPT_ACPIDEV_PT,
 	CMD_OPT_MMIODEV_PT,
 	CMD_OPT_VTPM2,
@@ -796,6 +804,7 @@ static struct option long_options[] = {
 	{"virtio_poll",		required_argument,	0, CMD_OPT_VIRTIO_POLL_ENABLE},
 	{"debugexit",		no_argument,		0, CMD_OPT_DEBUGEXIT},
 	{"intr_monitor",	required_argument,	0, CMD_OPT_INTR_MONITOR},
+	{"cmd_monitor",		required_argument,	0, CMD_OPT_CMD_MONITOR},
 	{"acpidev_pt",		required_argument,	0, CMD_OPT_ACPIDEV_PT},
 	{"mmiodev_pt",		required_argument,	0, CMD_OPT_MMIODEV_PT},
 	{"vtpm2",		required_argument,	0, CMD_OPT_VTPM2},
@@ -958,6 +967,11 @@ main(int argc, char *argv[])
 		case CMD_OPT_INTR_MONITOR:
 			if (acrn_parse_intr_monitor(optarg) != 0)
 				errx(EX_USAGE, "invalid intr-monitor params %s", optarg);
+			break;
+		case CMD_OPT_CMD_MONITOR:
+			if (acrn_parse_cmd_monitor(optarg) != 0)
+				errx(EX_USAGE, "invalid command monitor params %s", optarg);
+			cmd_monitor = true;
 			break;
 		case CMD_OPT_LOGGER_SETTING:
 			if (init_logger_setting(optarg) != 0)
@@ -1131,6 +1145,8 @@ fail:
 	vm_pause(ctx);
 	vm_destroy(ctx);
 create_fail:
+	if (cmd_monitor)
+		deinit_cmd_monitor();
 	uninit_hugetlb();
 	deinit_loggers();
 	exit(ret);

--- a/devicemodel/include/cmd_monitor.h
+++ b/devicemodel/include/cmd_monitor.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2022 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _CMD_MONITOR_H_
+#define _CMD_MONITOR_H_
+
+int init_cmd_monitor(struct vmctx *ctx);
+void deinit_cmd_monitor(void);
+#endif

--- a/devicemodel/include/cmd_monitor.h
+++ b/devicemodel/include/cmd_monitor.h
@@ -7,4 +7,5 @@
 
 int init_cmd_monitor(struct vmctx *ctx);
 void deinit_cmd_monitor(void);
+int acrn_parse_cmd_monitor(char *arg);
 #endif

--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -126,6 +126,7 @@ To set up the ACRN build environment on the development computer:
            e2fslibs-dev \
            pkg-config \
            libnuma-dev \
+           libcjson-dev \
            liblz4-tool \
            flex \
            bison \

--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -70,6 +70,7 @@ def create_acrn_deb(board, scenario, version, build_dir):
 
     listcontrol=['Package: acrn-hypervisor\n',
                 'version: %s \n'% version,
+		'Depends: libcjson1\n',
                 'Section: free \n',
                 'Priority: optional \n',
                 'Architecture: amd64 \n',


### PR DESCRIPTION
This command monitor in DM is to handle commands from external
systems (such libvirt, kata container) directly.

In current design, external system should send DM through acrnctl,
acrnctl will be replaced by libvirt in ACRN soon.
In this patch set, command monitor is introduced to make external
system can interact with DM directly through unix domain socket;
older command handling in DM is also refined to just keep two
commands (force shutdown, blkrescan), make adding new commands more
easy.