### PR TITLE
hv: align boot stack to 4-byte boundary

### DIFF
--- a/hypervisor/bsp/ld/link_ram.ld.in
+++ b/hypervisor/bsp/ld/link_ram.ld.in
@@ -75,8 +75,8 @@ SECTIONS
     {
     /* 4K for the boot stack */
         . += 4096;
-        stack_for_boot = .;
         . = ALIGN(4);
+        stack_for_boot = .;
     } > ram
 
     .bss_noinit (NOLOAD):


### PR DESCRIPTION
Let stack_for_boot to be 4 byte aligned to avoid unaligned stack
accesses in early boot stage.

Signed-off-by: Qiang Zhang <qiang4.zhang@intel.com>