### PR TITLE
Makefile: put 'serial.conf' in final location

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -406,7 +406,7 @@ install: $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
 		install -D $(HV_OBJDIR)/acpi/*.bin -t $(DESTDIR)$(libdir)/acrn/acpi/; \
 	fi
 	@if [ -e "$(HV_OBJDIR)/serial.conf" ];then \
-		install -D $(HV_OBJDIR)/serial.conf -t $(DESTDIR)$(libdir)/acrn/; \
+		install -D -b $(HV_OBJDIR)/serial.conf -t $(DESTDIR)$(sysconfdir)/; \
 	fi
 
 install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out

--- a/paths.make
+++ b/paths.make
@@ -6,3 +6,4 @@ nonarchlibdir ?= $(prefix)/lib
 datadir ?= $(prefix)/share
 includedir ?= $(prefix)/include
 systemd_unitdir ?= $(prefix)/lib/systemd
+sysconfdir ?= /etc


### PR DESCRIPTION
The 'serial.conf' file need to be put in /etc/, but it is currently being
installed in $(libdir)/acrn/. We therefore ask the user to manually copy that
file over to the /etc/ folder. This patch fixes that by installing
'serial.conf' directly there.

Tracked-On: #7107
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>