### PR TITLE
hv: replace the CONFIG_PLATFORM_RAM_SIZE with get_e820_ram_size

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -158,6 +158,9 @@ void init_pcpu_pre(bool is_bsp)
 
 		init_e820();
 
+		/* reserve ppt buffer from e820 */
+		allocate_ppt_pages();
+
 		/* Initialize the hypervisor paging */
 		init_paging();
 

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -289,7 +289,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 		/*
 		 * Reserve memory from platform E820 for shadow EPT 4K pages
 		 */
-		reserve_buffer_for_sept_pages();
+		allocate_buffer_for_sept_pages();
 
 		pcpu_sync = ALL_CPUS_MASK;
 		/* Start all secondary cores */

--- a/hypervisor/arch/x86/e820.c
+++ b/hypervisor/arch/x86/e820.c
@@ -20,6 +20,7 @@
  */
 
 static uint32_t hv_e820_entries_nr;
+static uint64_t hv_e820_ram_size;
 /* Describe the memory layout the hypervisor uses */
 static struct e820_entry hv_e820[E820_MAX_ENTRIES];
 
@@ -158,7 +159,6 @@ static uint64_t e820_alloc_region(uint64_t addr, uint64_t size)
 static void init_e820_from_efi_mmap(void)
 {
 	uint32_t i, e820_idx = 0U;
-	uint64_t top_addr_space = CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE;
 	const struct efi_memory_desc *efi_mmap_entry = get_efi_mmap_entry();
 
 	for (i = 0U; i < get_efi_mmap_entries_count(); i++) {
@@ -169,13 +169,6 @@ static void init_e820_from_efi_mmap(void)
 
 		hv_e820[e820_idx].baseaddr = efi_mmap_entry[i].phys_addr;
 		hv_e820[e820_idx].length = efi_mmap_entry[i].num_pages * PAGE_SIZE;
-		if (hv_e820[e820_idx].baseaddr >= top_addr_space) {
-			hv_e820[e820_idx].length = 0UL;
-		} else {
-			if ((hv_e820[e820_idx].baseaddr + hv_e820[e820_idx].length) > top_addr_space) {
-				hv_e820[e820_idx].length = top_addr_space - hv_e820[e820_idx].baseaddr;
-			}
-		}
 
 		/* The EFI BOOT Service releated regions need to be set to reserved and avoid being touched by
 		 * hypervisor, because at least below software modules rely on them:
@@ -241,7 +234,6 @@ static void init_e820_from_efi_mmap(void)
 static void init_e820_from_mmap(struct acrn_boot_info *abi)
 {
 	uint32_t i;
-	uint64_t top_addr_space = CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE;
 
 	struct abi_mmap *mmap = abi->mmap_entry;
 
@@ -251,13 +243,6 @@ static void init_e820_from_mmap(struct acrn_boot_info *abi)
 		abi->mmap_entry, hv_e820_entries_nr);
 
 	for (i = 0U; i < hv_e820_entries_nr; i++) {
-		if (mmap[i].baseaddr >= top_addr_space) {
-			mmap[i].length = 0UL;
-		} else {
-			if ((mmap[i].baseaddr + mmap[i].length) > top_addr_space) {
-				mmap[i].length = top_addr_space - mmap[i].baseaddr;
-			}
-		}
 
 		hv_e820[i].baseaddr = mmap[i].baseaddr;
 		hv_e820[i].length = mmap[i].length;
@@ -266,6 +251,22 @@ static void init_e820_from_mmap(struct acrn_boot_info *abi)
 		dev_dbg(DBG_LEVEL_E820, "mmap hv_e820[%d]: type: 0x%x Base: 0x%016lx length: 0x%016lx", i,
 			mmap[i].type, mmap[i].baseaddr, mmap[i].length);
 	}
+}
+
+static void calculate_e820_ram_size(void)
+{
+        uint32_t i;
+
+        for(i = 0; i < hv_e820_entries_nr; i++){
+                dev_dbg(DBG_LEVEL_E820, "hv_e820[%d]:type: 0x%x Base: 0x%016lx length: 0x%016lx", i,
+                                hv_e820[i].type, hv_e820[i].baseaddr, hv_e820[i].length);
+
+                if (hv_e820[i].type == E820_TYPE_RAM) {
+                        hv_e820_ram_size += hv_e820[i].baseaddr + hv_e820[i].length;
+                }
+        }
+
+        dev_dbg(DBG_LEVEL_E820, "ram size: 0x%016lx ",hv_e820_ram_size);
 }
 
 static void alloc_mods_memory(void)
@@ -292,8 +293,14 @@ void init_e820(void)
 		init_e820_from_mmap(abi);
 	}
 
+	calculate_e820_ram_size();
 	/* reserve multiboot modules memory */
 	alloc_mods_memory();
+}
+
+uint64_t get_e820_ram_size(void)
+{
+        return hv_e820_ram_size;
 }
 
 uint32_t get_e820_entries_count(void)

--- a/hypervisor/arch/x86/guest/vept.c
+++ b/hypervisor/arch/x86/guest/vept.c
@@ -26,27 +26,42 @@ static spinlock_t nept_desc_bucket_lock;
  * and sharing of memory between L2 VMs.
  *
  * Page table entry need 8 bytes to represent every 4K page frame.
- * Total number of bytes = (CONFIG_PLATFORM_RAM_SIZE/4096) * 8
- * Number of pages needed = Total number of bytes needed/4096
+ * Total number of bytes = (get_e820_ram_size() / PAGE_SIZE) * 8
+ * Number of pages needed = Total number of bytes needed/PAGE_SIZE
  */
-#define TOTAL_SEPT_4K_PAGES_SIZE	((CONFIG_PLATFORM_RAM_SIZE * 8UL) / 4096UL)
-#define TOTAL_SEPT_4K_PAGES_NUM		(TOTAL_SEPT_4K_PAGES_SIZE / PAGE_SIZE)
+static uint64_t get_total_vept_4k_page_size(void)
+{
+	return (get_e820_ram_size() * 8UL) / PAGE_SIZE;
+}
+
+static uint64_t get_total_vept_4k_page_num(void)
+{
+	return get_total_vept_4k_page_size() / PAGE_SIZE;
+}
 
 static struct page_pool sept_page_pool;
 static struct page *sept_pages;
-static uint64_t sept_page_bitmap[TOTAL_SEPT_4K_PAGES_NUM / 64U];
+static uint64_t *sept_page_bitmap;
+
+static void allocate_vept_bitmap(void)
+{
+	sept_page_bitmap = e820_alloc_memory((get_total_4k_page_num() / 64U), ~0UL);
+}
 
 /*
  * @brief Reserve space for SEPT 4K pages from platform E820 table
  * 	  At moment, we only support nested VMX for Service VM.
  */
-void reserve_buffer_for_sept_pages(void)
+void allocate_buffer_for_sept_pages(void)
 {
 	uint64_t page_base;
 
-	page_base = e820_alloc_memory(TOTAL_SEPT_4K_PAGES_SIZE, ~0UL);
-	set_paging_supervisor(page_base, TOTAL_SEPT_4K_PAGES_SIZE);
+	page_base = e820_alloc_memory(get_total_vept_4k_page_size(), ~0UL);
+
+	set_paging_supervisor(page_base, get_total_vept_4k_page_size());
+
 	sept_pages = (struct page *)page_base;
+	allocate_vept_bitmap();
 }
 
 static bool is_present_ept_entry(uint64_t ept_entry)
@@ -535,7 +550,7 @@ int32_t invept_vmexit_handler(struct acrn_vcpu *vcpu)
 void init_vept(void)
 {
 	sept_page_pool.start_page = sept_pages;
-	sept_page_pool.bitmap_size = TOTAL_SEPT_4K_PAGES_NUM / 64U;
+	sept_page_pool.bitmap_size = get_total_vept_4k_page_num() / 64U;
 	sept_page_pool.bitmap = sept_page_bitmap;
 	sept_page_pool.dummy_page = NULL;
 	spinlock_init(&sept_page_pool.lock);

--- a/hypervisor/include/arch/x86/asm/e820.h
+++ b/hypervisor/include/arch/x86/asm/e820.h
@@ -38,6 +38,7 @@ struct mem_range {
 void init_e820(void);
 
 uint64_t e820_alloc_memory(uint64_t size_arg, uint64_t max_addr);
+uint64_t get_e820_ram_size(void);
 /* get total number of the e820 entries */
 uint32_t get_e820_entries_count(void);
 

--- a/hypervisor/include/arch/x86/asm/guest/vept.h
+++ b/hypervisor/include/arch/x86/asm/guest/vept.h
@@ -38,7 +38,7 @@ struct nept_desc {
 	uint32_t ref_count;
 };
 
-void reserve_buffer_for_sept_pages(void);
+void allocate_buffer_for_sept_pages(void);
 void init_vept(void);
 uint64_t get_shadow_eptp(uint64_t guest_eptp);
 struct nept_desc *get_nept_desc(uint64_t guest_eptp);
@@ -46,6 +46,6 @@ void put_nept_desc(uint64_t guest_eptp);
 bool handle_l2_ept_violation(struct acrn_vcpu *vcpu);
 int32_t invept_vmexit_handler(struct acrn_vcpu *vcpu);
 #else
-static inline void reserve_buffer_for_sept_pages(void) {};
+static inline void allocate_buffer_for_sept_pages(void) {};
 #endif /* CONFIG_NVMX_ENABLED */
 #endif /* VEPT_H */

--- a/hypervisor/include/arch/x86/asm/mmu.h
+++ b/hypervisor/include/arch/x86/asm/mmu.h
@@ -200,6 +200,7 @@ void flush_tlb_range(uint64_t addr, uint64_t size);
 void flush_invalidate_all_cache(void);
 void flush_cacheline(const volatile void *p);
 void flush_cache_range(const volatile void *p, uint64_t size);
+void allocate_ppt_pages(void);
 
 /**
  * @}


### PR DESCRIPTION
The e820 module could get the RAM info on run time, but the RAM size
and MAX address was limited by CONFIG_PLATFORM_RAM_SIZE which was
predefined by config tool.

Current solution can't support single binary for different boards or
platforms and the CONFIG_PLATFORM_RAM_SIZE can't matching the RAM size
if user have not update config tools setting after the device changed.

So this patch remove the CONFIG_PLATFORM_RAM_SIZE and calculate ram
size on run time, then replace the CONFIG_PLATFORM_RAM_SIZE with
get_e820_ram_size for mmu, ept and vept.

Tracked-On: #6690
Acked-by: Anthony Xu <anthony.xu@intel.com>
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>