### PR TITLE
config_tools: category based on different log levels

### DIFF
--- a/misc/config_tools/board_inspector/acpiparser/aml/context.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/context.py
@@ -253,7 +253,7 @@ class Context:
                 elif new_tree.label == "DefExternal":
                     pass
                 else:
-                    logging.warning(f"{symbol.name} is redefined as {new_tree.label} (previously was {old_tree.label})")
+                    logging.debug(f"{symbol.name} is redefined as {new_tree.label} (previously was {old_tree.label})")
                     self.__register_symbol(symbol)
         else:
             self.__register_symbol(symbol)

--- a/misc/config_tools/board_inspector/acpiparser/aml/interpreter.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/interpreter.py
@@ -302,7 +302,7 @@ class ConcreteInterpreter(Interpreter):
         return Device(sym)
 
     def DefExternal(self, tree):
-        logging.info(f"The loaded tables do not have a definition of {tree.children[0].value}")
+        logging.debug(f"The loaded tables do not have a definition of {tree.children[0].value}")
         return None
 
     def DefField(self, tree):
@@ -502,7 +502,7 @@ class ConcreteInterpreter(Interpreter):
         if isinstance(ref, ObjectReference):
             return ref.get()
         else:
-            logging.warn(f"Attempt to dereference an object of type {ref.__class__.__name__}")
+            logging.debug(f"Attempt to dereference an object of type {ref.__class__.__name__}")
             return ref
 
     def DefDivide(self, tree):

--- a/misc/config_tools/board_inspector/acpiparser/aml/parser.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/parser.py
@@ -28,14 +28,10 @@ class Factory:
         self.label = "unknown"
 
     def mark_begin(self):
-        if hasattr(self, "seq") and len(self.seq) > 1:
-            logging.debug(f"%s-> {self.label}" % ("  " * self.level))
         self.level += 1
 
     def mark_end(self):
         self.level -= 1
-        if hasattr(self, "seq") and len(self.seq) > 1:
-            logging.debug(f"%s<- {self.label}" % ("  " * self.level))
 
     def match(self, context, stream, tree):
         raise NotImplementedError
@@ -431,7 +427,7 @@ class DeferredExpansion(Transformer):
                 tree.factory = None
                 tree.complete_parsing()
             except (DecodeError, DeferLater, ScopeMismatch, UndefinedSymbol) as e:
-                logging.info(f"expansion of {tree.label} at {hex(tree.deferred_range[0])} failed due to: " + str(e))
+                logging.debug(f"expansion of {tree.label} at {hex(tree.deferred_range[0])} failed due to: " + str(e))
 
             self.context.pop_scope()
 

--- a/misc/config_tools/board_inspector/acpiparser/tpm2.py
+++ b/misc/config_tools/board_inspector/acpiparser/tpm2.py
@@ -19,8 +19,8 @@ def tpm2_optional_data(data_len):
         has_log_area = True
     else:
         start_method_data_len = 12
-        logging.warning(f"TPM2 data length: {data_len + 52} is greater than 64 bytes but less than 76 bytes.")
-        logging.warning(f"The TPM2 data is still processed but the 65 to {data_len + 52} bytes are discard.")
+        logging.debug(f"TPM2 data length: {data_len + 52} is greater than 64 bytes but less than 76 bytes.")
+        logging.debug(f"The TPM2 data is still processed but the 65 to {data_len + 52} bytes are discard.")
     return start_method_data_len, has_log_area
 
 def tpm2_factory(start_method_data_len, has_log_area):

--- a/misc/config_tools/board_inspector/cpuparser/platformbase.py
+++ b/misc/config_tools/board_inspector/cpuparser/platformbase.py
@@ -203,7 +203,9 @@ class msrfield(property):
                     field = "[{0}]".format(msb)
                 else:
                     field = "[{0}:{1}]".format(msb, lsb)
-                raise OverflowError("Value {value:#x} too big for MSR {self.addr:#x} field {field}".format(**locals()))
+                raise OverflowError("Internal error: Value {value:#x} too big for MSR {self.addr:#x} field {field}.  " \
+                "Rerun the Board Inspector with `--loglevel debug`.  If this issue persists," \
+                "log a new issue at https://github.com/projectacrn/acrn-hypervisor/issues and attach the full logs.".format(**locals()))
             self.value = (self.value & ~field_mask) | (value << lsb)
 
         super(msrfield, self).__init__(getter, setter, doc=doc)

--- a/misc/config_tools/board_inspector/extractors/20-cache.py
+++ b/misc/config_tools/board_inspector/extractors/20-cache.py
@@ -75,7 +75,7 @@ def extract_tcc_capabilities(caches_node):
                 if entry.type == acpiparser.rtct.ACPI_RTCT_V1_TYPE_SoftwareSRAM:
                     cache_node = get_node(caches_node, f"cache[@level='{entry.cache_level}' and processors/processor='{hex(entry.apic_id_tbl[0])}']")
                     if cache_node is None:
-                        logging.warning(f"Cannot find the level {entry.cache_level} cache of physical processor with apic ID {entry.apic_id_tbl[0]}")
+                        logging.debug(f"Cannot find the level {entry.cache_level} cache of physical processor with apic ID {entry.apic_id_tbl[0]}")
                         continue
                     cap = add_child(cache_node, "capability", None, id="Software SRAM")
                     add_child(cap, "start", "0x{:08x}".format(entry.base))
@@ -86,7 +86,7 @@ def extract_tcc_capabilities(caches_node):
                 if entry.type == acpiparser.rtct.ACPI_RTCT_V2_TYPE_SoftwareSRAM:
                     cache_node = get_node(caches_node, f"cache[@level='{entry.level}' and @id='{hex(entry.cache_id)}']")
                     if cache_node is None:
-                        logging.warning(f"Cannot find the level {entry.level} cache with cache ID {entry.cache_id}")
+                        logging.debug(f"Cannot find the level {entry.level} cache with cache ID {entry.cache_id}")
                         continue
                     cap = add_child(cache_node, "capability", None, id="Software SRAM")
                     add_child(cap, "start", "0x{:08x}".format(entry.base))

--- a/misc/config_tools/board_inspector/extractors/50-acpi-namespace.py
+++ b/misc/config_tools/board_inspector/extractors/50-acpi-namespace.py
@@ -130,8 +130,8 @@ def parse_tpm(elem):
             add_child(log_area, "log_area_minimum_length", hex(tpm2.log_area_minimum_length))
             add_child(log_area, "log_area_start_address", hex(tpm2.log_area_start_address))
     except Exception as e:
-        logging.info(f"Parse ACPI TPM2 failed: {str(e)}")
-        logging.info(f"Will not extract information from ACPI TPM2")
+        logging.debug(f"Parse ACPI TPM2 failed: {str(e)}")
+        logging.debug(f"Will not extract information from ACPI TPM2")
         return
 
 resource_parsers = {
@@ -338,7 +338,7 @@ def add_object_to_device(interpreter, device_path, obj_name, result):
             evaluated = (result != None)
             need_global = ("global" in deps.all.keys())
             formatter = lambda x: '+' if x else '-'
-            logging.info(f"{device_path}.{obj_name}: Evaluated{formatter(evaluated)} Copy{formatter(copy_object)} NeedGlobal{formatter(need_global)}")
+            logging.debug(f"{device_path}.{obj_name}: Evaluated{formatter(evaluated)} Copy{formatter(copy_object)} NeedGlobal{formatter(need_global)}")
             if result == None or copy_object:
                 if need_global:
                     global_objs = ', '.join(map(lambda x: x.name, deps.all["global"]))
@@ -402,7 +402,7 @@ def add_object_to_device(interpreter, device_path, obj_name, result):
                     except:
                         pass
     except NotImplementedError as e:
-        logging.info(f"{device_path}.{obj_name}: will not be added to vACPI, reason: {str(e)}")
+        logging.debug(f"{device_path}.{obj_name}: will not be added to vACPI, reason: {str(e)}")
 
 def fetch_device_info(devices_node, interpreter, namepath, args):
     logging.info(f"Fetch information about device object {namepath}")
@@ -493,7 +493,7 @@ def fetch_device_info(devices_node, interpreter, namepath, args):
             if isinstance(adr, int):
                 adr = hex(adr)
             if len(element.xpath(f"../*[@address='{adr}']")) > 0:
-                logging.info(f"{namepath} has siblings with duplicated address {adr}.")
+                logging.debug(f"{namepath} has siblings with duplicated address {adr}.")
             else:
                 element.set("address", hex(adr) if isinstance(adr, int) else adr)
             add_object_to_device(interpreter, namepath, "_ADR", result)
@@ -544,7 +544,7 @@ def fetch_device_info(devices_node, interpreter, namepath, args):
                 elif isinstance(mapping.source, context.DeviceDecl):
                     prt_info[mapping.address][mapping.pin] = (mapping.source.name, mapping.source_index)
                 else:
-                    logging.warning(f"The _PRT of {namepath} has a mapping with invalid source {mapping.source}")
+                    logging.debug(f"The _PRT of {namepath} has a mapping with invalid source {mapping.source}")
 
             pin_routing_element = add_child(element, "interrupt_pin_routing")
             for address, pins in prt_info.items():
@@ -570,8 +570,8 @@ def extract(args, board_etree):
     try:
         namespace = parse_dsdt()
     except Exception as e:
-        logging.warning(f"Parse ACPI DSDT/SSDT failed: {str(e)}")
-        logging.warning(f"Will not extract information from ACPI DSDT/SSDT")
+        logging.debug(f"Parse ACPI DSDT/SSDT failed: {str(e)}")
+        logging.debug(f"Will not extract information from ACPI DSDT/SSDT")
         return
 
     interpreter = ConcreteInterpreter(namespace)
@@ -587,7 +587,7 @@ def extract(args, board_etree):
         try:
             fetch_device_info(devices_node, interpreter, device.name, args)
         except Exception as e:
-            logging.info(f"Fetch information about device object {device.name} failed: {str(e)}")
+            logging.debug(f"Fetch information about device object {device.name} failed: {str(e)}")
 
     visitor = GenerateBinaryVisitor()
     for dev, objs in device_objects.items():

--- a/misc/config_tools/board_inspector/extractors/60-pci.py
+++ b/misc/config_tools/board_inspector/extractors/60-pci.py
@@ -107,7 +107,7 @@ def parse_device(bus_node, device_path):
         base = bar.base
         if os.path.exists(resource_path):
             if bar.base == 0:
-                logging.warning(f"PCI {device_name}: BAR {idx} exists but is programmed with all 0. This device cannot be passed through to any VM.")
+                logging.debug(f"PCI {device_name}: BAR {idx} exists but is programmed with all 0. This device cannot be passed through to any VM.")
             else:
                 resource_node = get_node(device_node, f"./resource[@type = '{resource_type}' and @min = '{hex(base)}']")
                 if resource_node is None:
@@ -121,7 +121,7 @@ def parse_device(bus_node, device_path):
                     resource_node.set("width", "64")
                     resource_node.set("prefetchable", str(bar.prefetchable))
         elif bar.base != 0:
-            logging.warning(f"PCI {device_name}: Cannot detect the size of BAR {idx}")
+            logging.debug(f"PCI {device_name}: Cannot detect the size of BAR {idx}")
         if isinstance(bar, MemoryBar64):
             idx += 2
         else:

--- a/misc/config_tools/board_inspector/extractors/helpers.py
+++ b/misc/config_tools/board_inspector/extractors/helpers.py
@@ -15,5 +15,8 @@ def add_child(element, tag, text=None, **kwargs):
 
 def get_node(etree, xpath):
     result = etree.xpath(xpath)
-    assert len(result) <= 1, "Internal error: cannot get texts from multiple nodes at a time"
+    assert len(result) <= 1, \
+        "Internal error: cannot get texts from multiple nodes at a time.  " \
+        "Rerun the Board Inspector with `--loglevel debug`.  If this issue persists, " \
+        "log a new issue at https://github.com/projectacrn/acrn-hypervisor/issues and attach the full logs."
     return result[0] if len(result) == 1 else None

--- a/misc/config_tools/board_inspector/legacy/board_parser.py
+++ b/misc/config_tools/board_inspector/legacy/board_parser.py
@@ -14,6 +14,7 @@ import acpi
 import clos
 import misc
 import parser_lib
+import logging
 
 OUTPUT = "./out/"
 PY_CACHE = "__pycache__"
@@ -23,7 +24,7 @@ CPU_VENDOR = "GenuineIntel"
 def check_permission():
     """Check if it is root permission"""
     if os.getuid():
-        parser_lib.print_red("You need run this tool with root privileges (sudo)!")
+        logging.critical("Run this tool with root privileges (sudo).")
         sys.exit(1)
 
 def vendor_check():
@@ -59,18 +60,19 @@ def check_env():
                             stderr=subprocess.PIPE, close_fds=True)
         err_msg = res.stderr.readline().decode('ascii')
         if err_msg:
-            parser_lib.print_red("{}".format(err_msg), err=True)
+            logging.critical("{}".format(err_msg))
             exit(-1)
     msr_info = check_msr_files(cpu_dirs)
     if msr_info:
         for cpu_num in msr_info:
-            parser_lib.print_red("Missing CPU msr file in the {}/{}/".format(cpu_dirs, cpu_num), err=True)
-        parser_lib.print_red("Missing CPU msr file, please check the value of CONFIG_X86_MSR in the kernel config.", err=True)
+            logging.critical("Missing CPU MSR file at {}/{}/msr".format(cpu_dirs, cpu_num))
+        logging.critical("Missing CPU MSR file /dev/cpu/#/msr. Check the value of CONFIG_X86_MSR in the kernel config." \
+        "  Set it to 'Y' and rebuild the OS. Then rerun the Board Inspector.")
         exit(-1)
 
     # check cpu vendor id
     if not vendor_check():
-        parser_lib.print_red("Please run this tools on {}!".format(CPU_VENDOR))
+        logging.critical(f"Unsupported processor {CPU_VENDOR} found.  ACRN requires using a {CPU_VENDOR} processor.")
         sys.exit(1)
 
     if os.path.exists(OUTPUT):

--- a/misc/config_tools/board_inspector/legacy/clos.py
+++ b/misc/config_tools/board_inspector/legacy/clos.py
@@ -4,6 +4,7 @@
 #
 
 import parser_lib
+import logging
 
 RDT_TYPE = {
         "L2":4,
@@ -64,7 +65,7 @@ def get_clos_info():
     rdt_res = dump_cpuid_reg(cmd, "ebx")
 
     if len(rdt_res) == 0:
-        parser_lib.print_yel("Resource Allocation is not supported!")
+        logging.debug("Resource Allocation is not supported!")
     else:
         for i in range(len(rdt_res)):
             if rdt_res[i] == "L2":

--- a/misc/config_tools/board_inspector/smbiosparser/smbios.py
+++ b/misc/config_tools/board_inspector/smbiosparser/smbios.py
@@ -9,6 +9,7 @@ import sys
 import ctypes
 import struct
 import uuid
+import logging
 import inspectorlib.bitfields as bitfields
 import inspectorlib.unpack as unpack
 
@@ -48,7 +49,7 @@ class SMBIOS(unpack.Struct):
                         matrix[types_present[index]] = [self.structures[index]]
             return matrix[num]
         except:
-            print("Failure: Type {} - not found".format(num))
+            logging.debug("Failure: Type {} - not found".format(num))
 
 class Header_2_1(unpack.Struct):
     def __new__(cls, u):
@@ -171,7 +172,7 @@ class BIOSInformation(SmbiosBaseStructure):
                 self.add_field('ec_minor_release', u.unpack_one("B"))
         except:
             self.decode_failure = True
-            print("Error parsing BIOSInformation")
+            logging.debug("Error parsing BIOSInformation")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -206,7 +207,7 @@ class SystemInformation(SmbiosBaseStructure):
                 self.add_field('family', u.unpack_one("B"), self.fmtstr)
         except:
             self.decode_failure = True
-            print("Error parsing SystemInformation")
+            logging.debug("Error parsing SystemInformation")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -265,7 +266,7 @@ class BaseboardInformation(SmbiosBaseStructure):
                     self.add_field('contained_object_handles', tuple(u.unpack_one("<H") for i in range(self.handle_count)))
         except:
             self.decode_failure = True
-            print("Error parsing BaseboardInformation")
+            logging.debug("Error parsing BaseboardInformation")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -349,7 +350,7 @@ class SystemEnclosure(SmbiosBaseStructure):
                 self.add_field('sku_number', u.unpack_one("B"), self.fmtstr)
         except:
             self.decode_failure = True
-            print("Error parsing SystemEnclosure")
+            logging.debug("Error parsing SystemEnclosure")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -470,7 +471,7 @@ class ProcessorInformation(SmbiosBaseStructure):
                 self.add_field('thread_count2', u.unpack_one("<H"))
         except:
             self.decode_failure = True
-            print("Error parsing Processor Information")
+            logging.debug("Error parsing Processor Information")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -517,7 +518,7 @@ class MemoryControllerInformation(SmbiosBaseStructure): #obsolete starting with 
             self.add_field('enabled_error_correcting_capabilities', u.unpack_one("B"))
         except:
             self.decode_failure = True
-            print("Error parsing MemoryControllerInformation")
+            logging.debug("Error parsing MemoryControllerInformation")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -549,7 +550,7 @@ class MemoryModuleInformation(SmbiosBaseStructure): #obsolete starting with v2.1
             self.add_field('uncorrectable_errors_received', bool(bitfields.getbits(self.error_status, 0)), unpack.format_table("error_status[0]={}", _mem_connection))
         except:
             self.decode_failure = True
-            print("Error parsing MemoryModuleInformation")
+            logging.debug("Error parsing MemoryModuleInformation")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -643,7 +644,7 @@ class CacheInformation(SmbiosBaseStructure):
 
         except:
             self.decode_failure = True
-            print("Error parsing CacheInformation")
+            logging.debug("Error parsing CacheInformation")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -744,7 +745,7 @@ class PortConnectorInfo(SmbiosBaseStructure):
             self.add_field('port_type', u.unpack_one("B"), unpack.format_table("{}", port_types))
         except:
             self.decodeFailure = True
-            print("Error parsing PortConnectorInfo")
+            logging.debug("Error parsing PortConnectorInfo")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -856,7 +857,7 @@ class SystemSlots(SmbiosBaseStructure):
                 self.add_field('function_number', bitfields.getbits(self.device_function_number, 2, 0), "device_function_number[2:0]={}")
         except:
             self.decodeFailure = True
-            print("Error parsing SystemSlots")
+            logging.debug("Error parsing SystemSlots")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -886,7 +887,7 @@ class OnBoardDevicesInformation(SmbiosBaseStructure):
             self.add_field('description_string', u.unpack_one("B"), self.fmtstr)
         except:
             self.decodeFailure = True
-            print("Error parsing OnBoardDevicesInformation")
+            logging.debug("Error parsing OnBoardDevicesInformation")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -901,7 +902,7 @@ class OEMStrings(SmbiosBaseStructure):
             self.add_field('count', u.unpack_one("B"))
         except:
             self.decodeFailure = True
-            print("Error parsing OEMStrings")
+            logging.debug("Error parsing OEMStrings")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -916,7 +917,7 @@ class SystemConfigOptions(SmbiosBaseStructure):
             self.add_field('count', u.unpack_one("B"))
         except:
             self.decodeFailure = True
-            print("Error parsing SystemConfigOptions")
+            logging.debug("Error parsing SystemConfigOptions")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -937,7 +938,7 @@ class BIOSLanguageInformation(SmbiosBaseStructure):
                 self.add_field('current_language', u.unpack_one('B'), self.fmtstr)
         except:
             self.decodeFailure = True
-            print("Error parsing BIOSLanguageInformation")
+            logging.debug("Error parsing BIOSLanguageInformation")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -954,7 +955,7 @@ class GroupAssociations(SmbiosBaseStructure):
             self.add_field('item_handle', u.unpack_one('<H'))
         except:
             self.decodeFailure = True
-            print("Error parsing GroupAssociations")
+            logging.debug("Error parsing GroupAssociations")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -997,15 +998,15 @@ class SystemEventLog(SmbiosBaseStructure):
             if self.length > 0x16:
                 self.add_field('length_log_type_descriptor', u.unpack_one('B'))
             if self.length != (0x17 + (self.num_supported_log_type_descriptors * self.length_log_type_descriptor)):
-                print("Error: structure length ({}) != 0x17 + (num_supported_log_type_descriptors ({}) * length_log_type_descriptor({}))".format(self.length, self.num_supported_log_type_descriptors, self.length_log_type_descriptor))
-                print("structure length = {}".format(self.length))
-                print("num_supported_log_type_descriptors = {}".format(self.num_supported_log_type_descriptors))
-                print("length_log_type_descriptor = {}".format(self.length_log_type_descriptor))
+                logging.debug(f"Error: structure length ({self.length}) != 0x17 + (num_supported_log_type_descriptors ({self.num_supported_log_type_descriptors}) * length_log_type_descriptor({self.length_log_type_descriptor}))")
+                logging.debug("structure length = {}".format(self.length))
+                logging.debug("num_supported_log_type_descriptors = {}".format(self.num_supported_log_type_descriptors))
+                logging.debug("length_log_type_descriptor = {}".format(self.length_log_type_descriptor))
                 self.decodeFailure = True
             self.add_field('descriptors', tuple(EventLogDescriptor.unpack(u) for i in range(self.num_supported_log_type_descriptors)), unpack.format_each("\n{!r}"))
         except:
             self.decodeFailure = True
-            print("Error parsing SystemEventLog")
+            logging.debug("Error parsing SystemEventLog")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1112,7 +1113,7 @@ class PhysicalMemoryArray(SmbiosBaseStructure):
                 self.add_field('extended_maximum_capacity', u.unpack_one('<Q'))
         except:
             self.decodeFailure = True
-            print("Error parsing PhysicalMemoryArray")
+            logging.debug("Error parsing PhysicalMemoryArray")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1217,7 +1218,7 @@ class MemoryDevice(SmbiosBaseStructure):
                 self.add_field('configured_voltage', u.unpack_one("<H"))
         except:
             self.decodeFailure = True
-            print("Error parsing MemoryDevice")
+            logging.debug("Error parsing MemoryDevice")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1274,7 +1275,7 @@ class MemoryErrorInfo32Bit(SmbiosBaseStructure):
                 self.add_field('error_resolution', u.unpack_one("<I"))
         except:
             self.decodeFailure = True
-            print("Error parsing MemoryErrorInfo32Bit")
+            logging.debug("Error parsing MemoryErrorInfo32Bit")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1306,7 +1307,7 @@ class MemoryArrayMappedAddress(SmbiosBaseStructure):
 
         except:
             self.decodeFailure = True
-            print("Error parsing MemoryArrayMappedAddress")
+            logging.debug("Error parsing MemoryArrayMappedAddress")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1343,7 +1344,7 @@ class MemoryDeviceMappedAddress(SmbiosBaseStructure):
                     u.skip(16)
         except:
             self.decodeFailure = True
-            print("Error parsing MemoryDeviceMappedAddress")
+            logging.debug("Error parsing MemoryDeviceMappedAddress")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1387,7 +1388,7 @@ class BuiltInPointingDevice(SmbiosBaseStructure):
                 self.add_field('num_buttons', u.unpack_one("B"))
         except:
             self.decodeFailure = True
-            print("Error parsing BuiltInPointingDevice")
+            logging.debug("Error parsing BuiltInPointingDevice")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1453,7 +1454,7 @@ class PortableBattery(SmbiosBaseStructure):
                 self.add_field('oem_specific', u.unpack_one("<I"))
         except:
             self.decodeFailure = True
-            print("Error parsing PortableBattery")
+            logging.debug("Error parsing PortableBattery")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1487,7 +1488,7 @@ class SystemReset(SmbiosBaseStructure):
                 self.add_field('timeout', u.unpack_one("<H"))
         except:
             self.decodeFailure = True
-            print("Error parsing SystemReset")
+            logging.debug("Error parsing SystemReset")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1513,7 +1514,7 @@ class HardwareSecurity(SmbiosBaseStructure):
                 self.add_field('front_panel_reset_status', bitfields.getbits(self.hardware_security_settings, 1, 0), unpack.format_table("hardware_security_settings[1:0]={}", _status))
         except:
             self.decodeFailure = True
-            print("Error parsing HardwareSecurity")
+            logging.debug("Error parsing HardwareSecurity")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1533,7 +1534,7 @@ class SystemPowerControls(SmbiosBaseStructure):
                 self.add_field('next_scheduled_poweron_second', u.unpack_one("B"))
         except:
             self.decodeFailure = True
-            print("Error parsing SystemPowerControls")
+            logging.debug("Error parsing SystemPowerControls")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1588,7 +1589,7 @@ class VoltageProbe(SmbiosBaseStructure):
                 self.add_field('nominal_value', u.unpack_one("<H"))
         except:
             self.decodeFailure = True
-            print("Error parsing VoltageProbe")
+            logging.debug("Error parsing VoltageProbe")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1637,7 +1638,7 @@ class CoolingDevice(SmbiosBaseStructure):
                self.add_field('description', u.unpack_one("B"), self.fmtstr)
         except:
             self.decodeFailure = True
-            print("Error parsing CoolingDevice")
+            logging.debug("Error parsing CoolingDevice")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1696,7 +1697,7 @@ class TemperatureProbe(SmbiosBaseStructure):
                 self.add_field('nominal_value', u.unpack_one("<H"))
         except:
             self.decodeFailure = True
-            print("Error parsing TemperatureProbe")
+            logging.debug("Error parsing TemperatureProbe")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1755,7 +1756,7 @@ class ElectricalCurrentProbe(SmbiosBaseStructure):
                 self.add_field('nominal_value', u.unpack_one("<H"))
         except:
             self.decodeFailure = True
-            print("Error parsing ElectricalCurrentProbe")
+            logging.debug("Error parsing ElectricalCurrentProbe")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1775,7 +1776,7 @@ class OutOfBandRemoteAccess(SmbiosBaseStructure):
                 self.add_field('inbound_connection_enabled', bool(bitfields.getbits(self.connections, 0)), "connections[0]={}")
         except:
             self.decodeFailure = True
-            print("Error parsing OutOfBandRemoteAccess")
+            logging.debug("Error parsing OutOfBandRemoteAccess")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1809,7 +1810,7 @@ class SystemBootInformation(SmbiosBaseStructure):
                 self.add_field('boot_status', u.unpack_one("B"), unpack.format_table("{}", _boot_status))
         except:
             self.decodeFailure = True
-            print("Error parsing SystemBootInformation")
+            logging.debug("Error parsing SystemBootInformation")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1866,7 +1867,7 @@ class MemoryErrorInfo64Bit(SmbiosBaseStructure):
                 self.add_field('error_resolution', u.unpack_one("<Q"))
         except:
             self.decodeFailure = True
-            print("Error parsing MemoryErrorInfo64Bit")
+            logging.debug("Error parsing MemoryErrorInfo64Bit")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1910,7 +1911,7 @@ class ManagementDevice(SmbiosBaseStructure):
                  self.add_field('address_type', u.unpack_one("B"), unpack.format_table("{}", _address_type))
         except:
             self.decodeFailure = True
-            print("Error parsing ManagementDevice")
+            logging.debug("Error parsing ManagementDevice")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1932,7 +1933,7 @@ class ManagementDeviceComponent(SmbiosBaseStructure):
                 self.add_field('threshold_handle', u.unpack_one("<H"))
         except:
             self.decodeFailure = True
-            print("Error parsing ManagementDeviceComponent")
+            logging.debug("Error parsing ManagementDeviceComponent")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1958,7 +1959,7 @@ class ManagementDeviceThresholdData(SmbiosBaseStructure):
                 self.add_field('upper_threshold_nonrecoverable', u.unpack_one("<H"))
         except:
             self.decodeFailure = True
-            print("Error parsing ManagementDeviceThresholdData")
+            logging.debug("Error parsing ManagementDeviceThresholdData")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -1988,7 +1989,7 @@ class MemoryChannel(SmbiosBaseStructure):
                 self.add_field('memory_device_handle', u.unpack_one("<H"))
         except:
             self.decodeFailure = True
-            print("Error parsing MemoryChannel")
+            logging.debug("Error parsing MemoryChannel")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -2039,7 +2040,7 @@ class IPMIDeviceInformation(SmbiosBaseStructure):
             self.add_field('interrupt_number', u.unpack_one("B"))
         except:
             self.decodeFailure = True
-            print("Error parsing IPMIDeviceInformation")
+            logging.debug("Error parsing IPMIDeviceInformation")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -2112,7 +2113,7 @@ class SystemPowerSupply(SmbiosBaseStructure):
                 self.add_field('input_current_probe_handle', u.unpack_one("<H"))
         except:
             self.decodeFailure = True
-            print("Error parsing SystemPowerSupply")
+            logging.debug("Error parsing SystemPowerSupply")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -2134,7 +2135,7 @@ class AdditionalInformation(SmbiosBaseStructure):
                 self.add_field('value', u.unpack_rest())
         except:
             self.decodeFailure = True
-            print("Error parsing AdditionalInformation")
+            logging.debug("Error parsing AdditionalInformation")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -2176,7 +2177,7 @@ class OnboardDevicesExtendedInformation(SmbiosBaseStructure):
                 self.add_field('function_number', bitfields.getbits(self.device_type, 2, 0), "device_and_function_number[2:0]={}")
         except:
             self.decodeFailure = True
-            print("Error parsing OnboardDevicesExtendedInformation")
+            logging.debug("Error parsing OnboardDevicesExtendedInformation")
             import traceback
             traceback.print_exc()
         self.fini()
@@ -2206,7 +2207,7 @@ class ManagementControllerHostInterface(SmbiosBaseStructure):
                 self.add_field('mc_host_interface_data', u.unpack_rest(), self.fmtstr)
         except:
             self.decodeFailure = True
-            print("Error parsing ManagementControllerHostInterface")
+            logging.debug("Error parsing ManagementControllerHostInterface")
             import traceback
             traceback.print_exc()
         self.fini()


### PR DESCRIPTION
category based on different log levels:
1) If the board inspector show CRITICAL error messages, it means that the
board inspector tool exit instantly and generate no file.
2) If the board inspector show ERROR messages, it means that the board
inspector will generate the board XML file successfully, but several conditions
may result in ACRN build or boot failure cannot continue execution due to the error.
3) If the board inspector show WARNING messages, this means that the board inspector
generate the board XML file successfully, but this board XML file is lack of
some feature which could still boot ACRN but loss some features.
4) If the board inspector show INFO messages, this means that board inspector
printed out some normal information.
5) If the board inspector show DEBUG messages, this means that it is used to
debug board inspector workflow.

v1->v2
1. Keep the assertions or exceptions under the acpiparser, inspectorlib
and smbiosparser directory.
2. Exit after all check_deps() completes instead of any unsatisfied dep
is identified.
3. As Amy's advice, Replace the message "{board_xml} saved successfully" with
the message "SUCCESS: Board configuration file <file name> generated successfully
and saved to <path>."

To do:
Print all messages using the colored font.

Tracked-On: #6689
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>