### PR TITLE
config-tools: bring all cores online

### DIFF
--- a/misc/config_tools/board_inspector/cpuparser/__init__.py
+++ b/misc/config_tools/board_inspector/cpuparser/__init__.py
@@ -60,14 +60,21 @@ def parse_cpuid(leaf, subleaf, cpu_id):
     else:
         return None
 
-def get_online_cpu_ids():
+def parse_cpu_ids(file):
     acc = list()
-    with open("/sys/devices/system/cpu/online", "r") as f:
+    with open(file, "r") as f:
         line = f.read().strip()
         for r in line.split(","):
             if r.find("-") > 0:
                 first, last = tuple(map(int, r.split("-")))
                 acc.extend(range(first, last + 1))
             else:
-                acc.append(int(r))
+                if r:
+                    acc.append(int(r))
     return acc
+
+def get_online_cpu_ids():
+    return parse_cpu_ids("/sys/devices/system/cpu/online")
+
+def get_offline_cpu_ids():
+    return parse_cpu_ids("/sys/devices/system/cpu/offline")


### PR DESCRIPTION
Bring all the cores up in the beginning of the board_inspector.py
It is expected to run board_inspector in clean and native environment.
To resolve the issue that user may run other jobs which puts cores
offline, bringing up all cores online so tool can run cpuid to extract
all available cores information.

Tracked-On: #7119
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>