### PR TITLE
doc: Remove FAQ from TOC

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _faq:
 
 Frequently Asked Questions

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -78,7 +78,6 @@ license.
    contribute
    release_notes/index
    asa
-   FAQ <faq>
    glossary
    genindex
 


### PR DESCRIPTION
Per issue #5265, removing the FAQ from the table of contents until we create more content

Signed-off-by: Reyes, Amy <amy.reyes@intel.com>