### PR TITLE
config tool: Redefine vm_type and add load_order

### DIFF
--- a/misc/config_tools/acpi_gen/asl_gen.py
+++ b/misc/config_tools/acpi_gen/asl_gen.py
@@ -800,8 +800,8 @@ def main(args):
     dict_pcpu_list = collections.OrderedDict()
     for vm in scenario_root.findall('vm'):
         vm_id = vm.attrib['id']
-        vm_type_node = vm.find('vm_type')
-        if (vm_type_node is not None) and (vm_type_node.text in ['PRE_STD_VM', 'SAFETY_VM', 'PRE_RT_VM']):
+        load_order_node = vm.find('load_order')
+        if (load_order_node is not None) and (load_order_node.text == 'PRE_LAUNCHED_VM'):
             dict_passthru_devices[vm_id] = []
             for pci_dev_node in vm.findall('pci_devs/pci_dev'):
                 if pci_dev_node is not None and pci_dev_node.text is not None and pci_dev_node.text.strip():
@@ -824,7 +824,8 @@ def main(args):
         for vm in scenario_root.findall('vm'):
             vm_id = vm.attrib['id']
             vm_type_node = vm.find('vm_type')
-            if (vm_type_node is not None) and (vm_type_node.text in ['PRE_RT_VM']):
+            load_order_node = vm.find('load_order')
+            if (load_order_node is not None) and (load_order_node.text == 'PRE_LAUNCHED_VM') and (vm_type_node.text == 'RTVM'):
                 PRELAUNCHED_RTVM_ID = vm_id
                 break
     except:

--- a/misc/config_tools/acpi_gen/bin_gen.py
+++ b/misc/config_tools/acpi_gen/bin_gen.py
@@ -82,7 +82,7 @@ def asl_to_aml(dest_vm_acpi_path, dest_vm_acpi_bin_path, scenario_etree, allocat
                 rtct = acpiparser.rtct.RTCT(os.path.join(dest_vm_acpi_path, acpi_table[0]))
                 outfile = os.path.join(dest_vm_acpi_bin_path, acpi_table[1])
                 # move the guest ssram area to the area next to ACPI region
-                pre_rt_vms = common.get_node("//vm[vm_type ='PRE_RT_VM']", scenario_etree)
+                pre_rt_vms = common.get_node("//vm[load_order ='PRE_LAUNCHED_VM' and vm_type ='RTVM']", scenario_etree)
                 vm_id = pre_rt_vms.get("id")
                 allocation_vm_node = common.get_node(f"/acrn-config/vm[@id = '{vm_id}']", allocation_etree)
                 ssram_start_gpa = common.get_node("./ssram/start_gpa/text()", allocation_vm_node)

--- a/misc/config_tools/board_config/board_cfg_gen.py
+++ b/misc/config_tools/board_config/board_cfg_gen.py
@@ -13,7 +13,6 @@ import board_info_h
 import pci_devices_h
 import acpi_platform_h
 import common
-import vbar_base_h
 
 ACRN_PATH = common.SOURCE_ROOT_DIR
 ACRN_CONFIG_DEF = ACRN_PATH + "misc/config_tools/data/"
@@ -42,7 +41,7 @@ def main(args):
     common.BOARD_INFO_FILE = params['--board']
     common.SCENARIO_INFO_FILE = params['--scenario']
     common.get_vm_num(params['--scenario'])
-    common.get_vm_types()
+    common.get_load_order()
 
     if common.VM_COUNT > common.MAX_VM_NUM:
         err_dic['vm count'] = "The number of VMs in the scenario XML file should be no greater than " \
@@ -84,7 +83,6 @@ def main(args):
     config_board = board_fix_dir + GEN_FILE[1]
     config_acpi =  board_fix_dir + GEN_FILE[2]
     config_board_h =  board_fix_dir + GEN_FILE[4]
-    config_vbar_base = scen_board_dir + GEN_FILE[5]
 
     # generate pci_devices.h
     with open(config_pci, 'w+') as config:
@@ -101,10 +99,6 @@ def main(args):
         err_dic = board_c.generate_file(config)
         if err_dic:
             return err_dic
-
-    # generate vbar_base.h
-    with open(config_vbar_base, 'w+') as config:
-        vbar_base_h.generate_file(config)
 
     # generate platform_acpi_info.h
     with open(config_acpi, 'w+') as config:

--- a/misc/config_tools/board_config/board_info_h.py
+++ b/misc/config_tools/board_config/board_info_h.py
@@ -92,8 +92,7 @@ def generate_file(config):
     find_hi_mmio_window(config)
 
     p2sb = common.get_leaf_tag_map_bool(common.SCENARIO_INFO_FILE, "mmio_resources", "p2sb")
-    if (common.VM_TYPES.get(0) is not None and
-        scenario_cfg_lib.VM_DB[common.VM_TYPES[0]]['load_type'] == "PRE_LAUNCHED_VM"
+    if (common.LOAD_ORDER.get(0) == "PRE_LAUNCHED_VM"
         and board_cfg_lib.is_p2sb_passthru_possible()
         and p2sb.get(0, False)):
         print("", file=config)

--- a/misc/config_tools/data/cfl-k700-i7/hybrid.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid.xml
@@ -54,7 +54,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>SAFETY_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>SAFETY_VM0</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -112,7 +113,8 @@
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -164,7 +166,8 @@
     </pci_devs>
   </vm>
   <vm id="2">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -202,7 +205,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="3">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM2</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -60,7 +60,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>PRE_RT_VM</vm_type>
+    <vm_type>RTVM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>PRE_RT_VM0</name>
     <guest_flags>
       <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
@@ -123,7 +124,8 @@
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -179,7 +181,8 @@
     </pci_devs>
   </vm>
   <vm id="2">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -221,7 +224,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="3">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM2</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/cfl-k700-i7/partitioned.xml
+++ b/misc/config_tools/data/cfl-k700-i7/partitioned.xml
@@ -54,7 +54,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>PRE_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>PRE_STD_VM0</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -115,7 +116,8 @@
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type>PRE_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>PRE_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/cfl-k700-i7/shared.xml
+++ b/misc/config_tools/data/cfl-k700-i7/shared.xml
@@ -47,7 +47,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -92,7 +93,8 @@
     </pci_devs>
   </vm>
   <vm id="1">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -131,7 +133,8 @@
     </communication_vuart>
   </vm>
   <vm id="2">
-    <vm_type>POST_RT_VM</vm_type>
+    <vm_type>RTVM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_RT_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -171,7 +174,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="3">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM2</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -211,7 +215,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="4">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM3</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -251,7 +256,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="5">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM4</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -291,7 +297,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="6">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM5</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/generic_board/hybrid.xml
+++ b/misc/config_tools/data/generic_board/hybrid.xml
@@ -54,7 +54,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>SAFETY_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>SAFETY_VM0</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -112,7 +113,8 @@
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -163,7 +165,8 @@
     </pci_devs>
   </vm>
   <vm id="2">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -201,7 +204,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="3">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM2</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/generic_board/hybrid_rt.xml
+++ b/misc/config_tools/data/generic_board/hybrid_rt.xml
@@ -73,7 +73,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>PRE_RT_VM</vm_type>
+    <vm_type>RTVM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>PRE_RT_VM0</name>
     <guest_flags>
       <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
@@ -133,7 +134,8 @@
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -182,7 +184,8 @@
     </pci_devs>
   </vm>
   <vm id="2">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -222,7 +225,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="3">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM2</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/generic_board/partitioned.xml
+++ b/misc/config_tools/data/generic_board/partitioned.xml
@@ -54,7 +54,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>PRE_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>PRE_STD_VM0</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -115,7 +116,8 @@
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type>PRE_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>PRE_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/generic_board/shared.xml
+++ b/misc/config_tools/data/generic_board/shared.xml
@@ -54,7 +54,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -99,7 +100,8 @@
     </pci_devs>
   </vm>
   <vm id="1">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -139,7 +141,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="2">
-    <vm_type>POST_RT_VM</vm_type>
+    <vm_type>RTVM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_RT_VM1</name>
     <guest_flags>
       <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
@@ -180,7 +183,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="3">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM2</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -220,7 +224,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="4">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM3</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -260,7 +265,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="5">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM4</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -300,7 +306,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="6">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM5</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid.xml
@@ -54,7 +54,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>SAFETY_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>SAFETY_VM0</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -112,7 +113,8 @@
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -163,7 +165,8 @@
     </pci_devs>
   </vm>
   <vm id="2">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -201,7 +204,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="3">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM2</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/nuc11tnbi5/partitioned.xml
+++ b/misc/config_tools/data/nuc11tnbi5/partitioned.xml
@@ -54,7 +54,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>PRE_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>PRE_STD_VM0</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -115,7 +116,8 @@
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type>PRE_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>PRE_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/nuc11tnbi5/shared.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared.xml
@@ -54,7 +54,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -99,7 +100,8 @@
     </pci_devs>
   </vm>
   <vm id="1">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -139,7 +141,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="2">
-    <vm_type>POST_RT_VM</vm_type>
+    <vm_type>RTVM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_RT_VM1</name>
     <guest_flags>
       <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
@@ -180,7 +183,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="3">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM2</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -220,7 +224,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="4">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM3</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -260,7 +265,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="5">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM4</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -300,7 +306,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="6">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM5</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/qemu/shared.xml
+++ b/misc/config_tools/data/qemu/shared.xml
@@ -47,7 +47,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -91,7 +92,8 @@
     </pci_devs>
   </vm>
   <vm id="1">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
@@ -54,7 +54,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>SAFETY_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>SAFETY_VM0</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -112,7 +113,8 @@
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -164,7 +166,8 @@
     </pci_devs>
   </vm>
   <vm id="2">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -202,7 +205,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="3">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM2</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/partitioned.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/partitioned.xml
@@ -54,7 +54,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>PRE_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>PRE_STD_VM0</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -115,7 +116,8 @@
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type>PRE_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>PRE_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared.xml
@@ -54,7 +54,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -107,7 +108,8 @@
     </pci_devs>
   </vm>
   <vm id="1">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -155,7 +157,8 @@
     <priority>PRIO_LOW</priority>
   </vm>
   <vm id="2">
-    <vm_type>POST_RT_VM</vm_type>
+    <vm_type>RTVM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_RT_VM1</name>
     <guest_flags>
       <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -46,7 +46,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>SAFETY_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>SAFETY_VM0</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -102,7 +103,8 @@
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -153,7 +155,8 @@
     </pci_devs>
   </vm>
   <vm id="2">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
@@ -59,7 +59,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>PRE_RT_VM</vm_type>
+    <vm_type>RTVM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>PRE_RT_VM0</name>
     <guest_flags>
       <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
@@ -122,7 +123,8 @@
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -171,7 +173,8 @@
     </pci_devs>
   </vm>
   <vm id="2">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -211,7 +214,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="3">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM2</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/whl-ipc-i5/partitioned.xml
+++ b/misc/config_tools/data/whl-ipc-i5/partitioned.xml
@@ -46,7 +46,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>PRE_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>PRE_STD_VM0</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -108,7 +109,8 @@
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type>PRE_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>PRE_LAUNCHED_VM</load_order>
     <name>PRE_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/whl-ipc-i5/sdc.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc.xml
@@ -46,7 +46,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -90,7 +91,8 @@
     </pci_devs>
   </vm>
   <vm id="1">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/data/whl-ipc-i5/shared.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared.xml
@@ -46,7 +46,8 @@
     </MISC_CFG>
   </hv>
   <vm id="0">
-    <vm_type>SERVICE_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -91,7 +92,8 @@
     </pci_devs>
   </vm>
   <vm id="1">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -130,7 +132,8 @@
     </communication_vuart>
   </vm>
   <vm id="2">
-    <vm_type>POST_RT_VM</vm_type>
+    <vm_type>RTVM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_RT_VM1</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -170,7 +173,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="3">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM2</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -210,7 +214,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="4">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM3</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -250,7 +255,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="5">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM4</name>
     <guest_flags>
       <guest_flag>0</guest_flag>
@@ -290,7 +296,8 @@
     <PTM>n</PTM>
   </vm>
   <vm id="6">
-    <vm_type>POST_STD_VM</vm_type>
+    <vm_type>STANDARD_VM</vm_type>
+    <load_order>POST_LAUNCHED_VM</load_order>
     <name>POST_STD_VM5</name>
     <guest_flags>
       <guest_flag>0</guest_flag>

--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -314,8 +314,8 @@ def main(board_xml, scenario_xml, launch_xml, user_vm_id, out_dir):
     scenario_etree = etree.parse(scenario_xml)
     launch_etree = etree.parse(launch_xml)
 
-    service_vm_id = eval_xpath(scenario_etree, "//vm[vm_type='SERVICE_VM']/@id")
-    post_vms = scenario_etree.xpath("//vm[starts-with(vm_type, 'POST_')]")
+    service_vm_id = eval_xpath(scenario_etree, "//vm[load_order='SERVICE_VM']/@id")
+    post_vms = scenario_etree.xpath("//vm[starts-with(load_order, 'POST_')]")
     if service_vm_id is None and len(post_vms) > 0:
         logging.error("The scenario does not define a service VM so no launch scripts will be generated for the post-launched VMs in the scenario.")
         return 1

--- a/misc/config_tools/library/common.py
+++ b/misc/config_tools/library/common.py
@@ -38,7 +38,8 @@ VM_COUNT = 0
 BOARD_INFO_FILE = ""
 SCENARIO_INFO_FILE = ""
 LAUNCH_INFO_FILE = ""
-VM_TYPES = {}
+LOAD_ORDER = {}
+RTVM = {}
 MAX_VM_NUM = 16
 
 MAX_VUART_NUM = 8
@@ -595,9 +596,13 @@ def num2int(str_value):
     return val
 
 
-def get_vm_types():
-    global VM_TYPES
-    VM_TYPES = get_leaf_tag_map(SCENARIO_INFO_FILE, "vm_type")
+def get_load_order():
+    global LOAD_ORDER
+    LOAD_ORDER = get_leaf_tag_map(SCENARIO_INFO_FILE, "load_order")
+
+def get_RTVM():
+    global RTVM
+    RTVM = get_leaf_tag_map(SCENARIO_INFO_FILE, "vm_type")
 
 
 def get_avl_dev_info(bdf_desc_map, pci_sub_class):

--- a/misc/config_tools/library/launch_cfg_lib.py
+++ b/misc/config_tools/library/launch_cfg_lib.py
@@ -163,8 +163,8 @@ def post_vm_cnt(config_file):
     """
     post_launch_cnt = 0
 
-    for vm_type in common.VM_TYPES.values():
-        if scenario_cfg_lib.VM_DB[vm_type]['load_type'] == "POST_LAUNCHED_VM":
+    for load_order in common.LOAD_ORDER.values():
+        if load_order == "POST_LAUNCHED_VM":
             post_launch_cnt += 1
 
     return post_launch_cnt
@@ -202,8 +202,8 @@ def is_config_file_match():
 def get_sos_vmid():
 
     sos_id = ''
-    for vm_i,vm_type in common.VM_TYPES.items():
-        if vm_type == "SERVICE_VM":
+    for vm_i,load_order in common.LOAD_ORDER.items():
+        if load_order == "SERVICE_VM":
             sos_id = vm_i
             break
 
@@ -592,16 +592,16 @@ def set_shm_regions(launch_item_values, scenario_info):
 
     try:
         raw_shmem_regions = common.get_hv_item_tag(scenario_info, "FEATURES", "IVSHMEM", "IVSHMEM_REGION")
-        vm_types = common.get_leaf_tag_map(scenario_info, "vm_type")
+        load_orders = common.get_leaf_tag_map(scenario_info, "load_order")
         shm_enabled = common.get_hv_item_tag(scenario_info, "FEATURES", "IVSHMEM", "IVSHMEM_ENABLED")
     except:
         return
 
     sos_vm_id = 0
-    for vm_id, vm_type in vm_types.items():
-        if vm_type in ['SERVICE_VM']:
+    for vm_id,load_order in load_orders.items():
+        if load_order in ['SERVICE_VM']:
             sos_vm_id = vm_id
-        elif vm_type in ['POST_STD_VM', 'POST_RT_VM']:
+        elif load_order in ['POST_LAUNCHED_VM']:
             user_vmid = vm_id - sos_vm_id
             shm_region_key = 'user_vm:id={},shm_regions,shm_region'.format(user_vmid)
             launch_item_values[shm_region_key] = ['']
@@ -623,13 +623,13 @@ def set_shm_regions(launch_item_values, scenario_info):
 def set_pci_vuarts(launch_item_values, scenario_info):
     try:
         launch_item_values['user_vm,console_vuart'] = DM_VUART0
-        vm_types = common.get_leaf_tag_map(scenario_info, 'vm_type')
+        load_orders = common.get_leaf_tag_map(scenario_info, 'load_order')
         sos_vm_id = 0
-        for vm_id, vm_type in vm_types.items():
-            if vm_type in ['SERVICE_VM']:
+        for vm_id,load_order in load_orders.items():
+            if load_order in ['SERVICE_VM']:
                 sos_vm_id = vm_id
         for vm in list(common.get_config_root(scenario_info)):
-            if vm.tag == 'vm' and scenario_cfg_lib.VM_DB[vm_types[int(vm.attrib['id'])]]['load_type'] == 'POST_LAUNCHED_VM':
+            if vm.tag == 'vm' and load_orders[int(vm.attrib['id'])] == 'POST_LAUNCHED_VM':
                 user_vmid = int(vm.attrib['id']) - sos_vm_id
                 pci_vuart_key = 'user_vm:id={},communication_vuarts,communication_vuart'.format(user_vmid)
                 for elem in list(vm):

--- a/misc/config_tools/scenario_config/scenario_cfg_gen.py
+++ b/misc/config_tools/scenario_config/scenario_cfg_gen.py
@@ -45,7 +45,7 @@ def get_scenario_item_values(board_info, scenario_info):
     common.BOARD_INFO_FILE = board_info
     common.SCENARIO_INFO_FILE = scenario_info
     common.get_vm_num(scenario_info)
-    common.get_vm_types()
+    common.get_load_order()
 
     # per scenario
     guest_flags = copy.deepcopy(common.GUEST_FLAG)
@@ -199,7 +199,7 @@ def main(args):
     common.BOARD_INFO_FILE = params['--board']
     common.SCENARIO_INFO_FILE = params['--scenario']
     common.get_vm_num(params['--scenario'])
-    common.get_vm_types()
+    common.get_load_order()
 
     # get board name
     (err_dic, board_name) = common.get_board_name()

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -3,24 +3,37 @@
 	   xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	   xmlns:acrn="https://projectacrn.org">
 
-<xs:simpleType name="VMOptionsType">
+<xs:simpleType name="LoadOrderType">
   <xs:annotation>
     <xs:documentation>Current supported VM types are:
 
-- ``SAFETY_VM`` pre-launched Safety VM
-- ``PRE_STD_VM`` pre-launched Standard VM
-- ``PRE_RT_VM`` pre-launched real-time capable VM
-- ``SERVICE_VM`` pre-launched Service VM
-- ``POST_STD_VM`` post-launched Standard VM
-- ``POST_RT_VM`` post-launched real-time capable VM</xs:documentation>
+- ``PRE_LAUNCHED_VM`` pre-launched VM
+- ``SERVICE_VM`` Service VM
+- ``POST_LAUNCHED_VM`` post-launched VM</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="SERVICE_VM" />
-    <xs:enumeration value="SAFETY_VM" />
-    <xs:enumeration value="PRE_RT_VM" />
-    <xs:enumeration value="PRE_STD_VM" />
-    <xs:enumeration value="POST_STD_VM" />
-    <xs:enumeration value="POST_RT_VM" />
+    <xs:enumeration value="PRE_LAUNCHED_VM" />
+    <xs:enumeration value="POST_LAUNCHED_VM" />
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="VMType">
+  <xs:annotation>
+    <xs:documentation>Current supported VM types are:
+
+- ``RTVM`` Read-time VM
+- ``STANDARD_VM`` Service VM
+- ``TEE_VM`` VM with Trusted Execution Environment, which could provide high level
+  security of code execution
+- ``REE_VM`` VM with Rich Execution Environment, which is a companion VM with TEE_VM,
+  and could provide more features and applications, but is vulnerable to attacks</xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="RTVM" />
+    <xs:enumeration value="STANDARD_VM" />
+    <xs:enumeration value="TEE_VM" />
+    <xs:enumeration value="REE_VM" />
   </xs:restriction>
 </xs:simpleType>
 

--- a/misc/config_tools/schema/checks/pre_launched_vm_support.xsd
+++ b/misc/config_tools/schema/checks/pre_launched_vm_support.xsd
@@ -36,7 +36,7 @@ or little cores are assigned, but not both.</xs:documentation>
     </xs:annotation>
   </xs:assert>
 
-  <xs:assert test="hv//SSRAM_ENABLED = 'n' or empty(vm[vm_type='PRE_RT_VM']) or
+  <xs:assert test="hv//SSRAM_ENABLED = 'n' or empty(vm[load_order ='PRE_LAUNCHED_VM' and vm_type='RTVM']) or
 		   every $cap in caches/cache[@level=3]/capability[@id='Software SRAM'] satisfies
 		   (compare($cap/end, '0x80000000') &lt; 0 or compare($cap/start, '0xf8000000') &gt;= 0)">
     <xs:annotation acrn:severity="warning">
@@ -52,8 +52,8 @@ https://github.com/projectacrn/acrn-hypervisor/issues if you meet this.</xs:docu
     </xs:annotation>
   </xs:assert>
 
-  <xs:assert test="(count(vm[vm_type = 'PRE_RT_VM']) = 1 and count(vm[vm_type='POST_RT_VM']) = 0)
-                   or (count(vm[vm_type='PRE_RT_VM']) = 0 and count(vm[vm_type='POST_RT_VM']) &gt;= 0)">
+  <xs:assert test="(count(vm[load_order ='PRE_LAUNCHED_VM' and vm_type ='RTVM']) = 1 and count(vm[load_order ='POST_LAUNCHED_VM' and vm_type ='RTVM']) = 0)
+                   or (count(vm[load_order ='PRE_LAUNCHED_VM' and vm_type ='RTVM']) = 0 and count(vm[load_order ='POST_LAUNCHED_VM' and vm_type ='RTVM']) &gt;= 0)">
     <xs:annotation acrn:severity="error">
       <xs:documentation>There should not be both pre-launched RTVM and post-launched RTVM.
 And two or more pre-launched RTVM are not allowed.

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -25,7 +25,7 @@ hypervisor shell.</xs:documentation>
       <xs:annotation>
         <xs:documentation>Specify the host serial device used for hypervisor debugging.
 This option is only valid if :option:`hv.DEBUG_OPTIONS.RELEASE` is set to ``n``.
-This option impacts the content of ``vm.(legacy_vuart id="0").base`` when :option:`vm.vm_type` is ``SERVICE_VM``,
+This option impacts the content of ``vm.(legacy_vuart id="0").base`` when :option:`vm.load_order` is ``SERVICE_VM``,
 which specifies the PIO base for Service VM legacy vUART 0 (used for the console).
 The PIO base for the Service VM's legacy vUART 0 is determined using these rules:
 
@@ -303,9 +303,14 @@ If this value is empty, then the default value will be calculated from informati
 
 <xs:complexType name="VMConfigType">
   <xs:all>
-    <xs:element name="vm_type" type="VMOptionsType">
-      <xs:annotation acrn:readonly="y">
+    <xs:element name="vm_type" type="VMType">
+      <xs:annotation>
         <xs:documentation>Specify the VM type.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="load_order" type="LoadOrderType">
+      <xs:annotation>
+        <xs:documentation>Specify the load_order.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="name">
@@ -412,7 +417,7 @@ its ``id`` attribute. When it is enabled, specify which target VM's vUART the cu
   </xs:all>
   <xs:attribute name="id" type="xs:integer" />
 
-  <xs:assert test="vm_type != 'SERVICE_VM' or count(guest_flags[guest_flag = 'GUEST_FLAG_LAPIC_PASSTHROUGH']) = 0 or count(guest_flags[guest_flag = 'GUEST_FLAG_NVMX_ENABLED']) > 0">
+  <xs:assert test="load_order != 'SERVICE_VM' or count(guest_flags[guest_flag = 'GUEST_FLAG_LAPIC_PASSTHROUGH']) = 0 or count(guest_flags[guest_flag = 'GUEST_FLAG_NVMX_ENABLED']) > 0">
     <xs:annotation>
       <xs:documentation>Service VM cannot use LAPIC passthrough unless GUEST_FLAG_NVMX_ENABLED is set.</xs:documentation>
     </xs:annotation>

--- a/misc/config_tools/service_vm_config/serial_config.py
+++ b/misc/config_tools/service_vm_config/serial_config.py
@@ -30,7 +30,7 @@ def main(args):
     allocation_etree = lxml.etree.parse(args.allocation)
     vuart_target_vmid = [0] * VUART_DEV_NAME_NUM
 
-    vm_list = scenario_etree.xpath("//vm[vm_type = 'SERVICE_VM']")
+    vm_list = scenario_etree.xpath("//vm[load_order = 'SERVICE_VM']")
     for vm in vm_list:
         for legacy_vuart in vm.iter(tag = 'legacy_vuart'):
             if legacy_vuart.find('target_vm_id') != None:
@@ -38,7 +38,7 @@ def main(args):
                 legacy_vuartid = int(legacy_vuart.attrib["id"])
                 vuart_target_vmid[legacy_vuartid] = user_vm_id
 
-    vm_list = allocation_etree.xpath("//vm[vm_type = 'SERVICE_VM']")
+    vm_list = allocation_etree.xpath("//vm[load_order = 'SERVICE_VM']")
     for vm in vm_list:
         vuart_list = find_non_standard_uart(vm)
         if len(vuart_list) != 0:

--- a/misc/config_tools/static_allocators/bdf.py
+++ b/misc/config_tools/static_allocators/bdf.py
@@ -95,11 +95,10 @@ def get_devs_bdf_passthrough(scenario_etree):
     return: list of passtrhough devices' bdf.
     """
     dev_list = []
-    for vm_type in lib.lib.PRE_LAUNCHED_VMS_TYPE:
-        pt_devs = scenario_etree.xpath(f"//vm[vm_type = '{vm_type}']/pci_devs/pci_dev/text()")
-        for pt_dev in pt_devs:
-            bdf = lib.lib.BusDevFunc.from_str(pt_dev.split()[0])
-            dev_list.append(bdf)
+    pt_devs = scenario_etree.xpath(f"//vm[load_order = 'PRE_LAUNCHED_VM']/pci_devs/pci_dev/text()")
+    for pt_dev in pt_devs:
+        bdf = lib.lib.BusDevFunc.from_str(pt_dev.split()[0])
+        dev_list.append(bdf)
     return dev_list
 
 def create_device_node(allocation_etree, vm_id, devdict):
@@ -141,11 +140,11 @@ def fn(board_etree, scenario_etree, allocation_etree):
         vm_id = vm_node.get('id')
         devdict = {}
         used = []
-        vm_type = common.get_node("./vm_type/text()", vm_node)
-        if vm_type is not None and lib.lib.is_post_launched_vm(vm_type):
+        load_order = common.get_node("./load_order/text()", vm_node)
+        if load_order is not None and lib.lib.is_post_launched_vm(load_order):
             continue
 
-        if vm_type is not None and lib.lib.is_sos_vm(vm_type):
+        if load_order is not None and lib.lib.is_service_vm(load_order):
             native_used = get_devs_bdf_native(board_etree)
             passthrough_used = get_devs_bdf_passthrough(scenario_etree)
             used = [bdf for bdf in native_used if bdf not in passthrough_used]

--- a/misc/config_tools/static_allocators/cpu_affinity.py
+++ b/misc/config_tools/static_allocators/cpu_affinity.py
@@ -10,14 +10,14 @@ sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '
 import common, board_cfg_lib
 
 def sos_cpu_affinity(etree):
-    if common.get_node("//vm[vm_type = 'SERVICE_VM']", etree) is None:
+    if common.get_node("//vm[load_order = 'SERVICE_VM']", etree) is None:
         return None
 
-    if common.get_node("//vm[vm_type = 'SERVICE_VM' and count(cpu_affinity)]", etree) is not None:
+    if common.get_node("//vm[load_order = 'SERVICE_VM' and count(cpu_affinity)]", etree) is not None:
         return None
 
     sos_extend_all_cpus = board_cfg_lib.get_processor_info()
-    pre_all_cpus = etree.xpath("//vm[vm_type = 'PRE_RT_VM' or vm_type = 'PRE_STD_VM' or vm_type = 'SAFETY_VM']/cpu_affinity/pcpu_id/text()")
+    pre_all_cpus = etree.xpath("//vm[load_order = 'PRE_LAUNCHED_VM']/cpu_affinity/pcpu_id/text()")
 
     cpus_for_sos = list(set(sos_extend_all_cpus) - set(pre_all_cpus))
     return sorted(cpus_for_sos)
@@ -25,12 +25,12 @@ def sos_cpu_affinity(etree):
 def fn(board_etree, scenario_etree, allocation_etree):
     cpus_for_sos = sos_cpu_affinity(scenario_etree)
     if cpus_for_sos:
-        if common.get_node("//vm[vm_type = 'SERVICE_VM']", scenario_etree) is not None:
-            vm_id = common.get_node("//vm[vm_type = 'SERVICE_VM']/@id", scenario_etree)
+        if common.get_node("//vm[load_order = 'SERVICE_VM']", scenario_etree) is not None:
+            vm_id = common.get_node("//vm[load_order = 'SERVICE_VM']/@id", scenario_etree)
             allocation_sos_vm_node = common.get_node(f"/acrn-config/vm[@id='{vm_id}']", allocation_etree)
             if allocation_sos_vm_node is None:
                 allocation_sos_vm_node = common.append_node("/acrn-config/vm", None, allocation_etree, id = vm_id)
-            if common.get_node("./vm_type", allocation_sos_vm_node) is None:
-                common.append_node("./vm_type", "SERVICE_VM", allocation_sos_vm_node)
+            if common.get_node("./load_order", allocation_sos_vm_node) is None:
+                common.append_node("./load_order", "SERVICE_VM", allocation_sos_vm_node)
         for pcpu_id in cpus_for_sos:
             common.append_node("./cpu_affinity/pcpu_id", str(pcpu_id), allocation_sos_vm_node)

--- a/misc/config_tools/static_allocators/lib/lib.py
+++ b/misc/config_tools/static_allocators/lib/lib.py
@@ -119,16 +119,16 @@ def get_ivshmem_enabled_by_tree(etree):
     return shmem_enabled
  
 def is_pre_launched_vm(vm_type):
-    if vm_type in PRE_LAUNCHED_VMS_TYPE:
+    if vm_type is 'PRE_LAUNCHED_VM':
         return True
     return False
 
 def is_post_launched_vm(vm_type):
-    if vm_type in POST_LAUNCHED_VMS_TYPE:
+    if vm_type is 'POST_LAUNCHED_VM':
         return True
     return False
 
-def is_sos_vm(vm_type):
-    if vm_type in SERVICE_VM_TYPE:
+def is_service_vm(vm_type):
+    if vm_type is 'SERVICE_VM':
         return True
     return False

--- a/misc/config_tools/static_allocators/main.py
+++ b/misc/config_tools/static_allocators/main.py
@@ -17,7 +17,7 @@ def main(args):
     common.BOARD_INFO_FILE = args.board
     common.SCENARIO_INFO_FILE = args.scenario
     common.get_vm_num(args.scenario)
-    common.get_vm_types()
+    common.get_load_order()
 
     scripts_path = os.path.dirname(os.path.realpath(__file__))
     current = os.path.basename(__file__)

--- a/misc/config_tools/static_allocators/pio.py
+++ b/misc/config_tools/static_allocators/pio.py
@@ -52,11 +52,11 @@ def fn(board_etree, scenario_etree, allocation_etree):
 
     vm_node_list = scenario_etree.xpath("//vm")
     for vm_node in vm_node_list:
-        vm_type = common.get_node("./vm_type/text()", vm_node)
+        load_order = common.get_node("./load_order/text()", vm_node)
         legacy_vuart_base = ""
         legacy_vuart_id_list = vm_node.xpath("legacy_vuart[base != 'INVALID_COM_BASE']/@id")
         for legacy_vuart_id in legacy_vuart_id_list:
-            if legacy_vuart_id == '0' and  vm_type == "SERVICE_VM":
+            if legacy_vuart_id == '0' and  load_order == "SERVICE_VM":
                 if hv_debug_console in native_ttys.keys():
                     if native_ttys[hv_debug_console]['type'] == "portio":
                         legacy_vuart_base = native_ttys[hv_debug_console]['base']

--- a/misc/config_tools/xforms/lib.xsl
+++ b/misc/config_tools/xforms/lib.xsl
@@ -319,7 +319,7 @@
   <func:function name="acrn:pci-dev-num">
     <xsl:param name="vmid" />
     <xsl:for-each select="//config-data/acrn-config/vm[@id = $vmid]">
-      <xsl:variable name="vmtype" select="./vm_type" />
+      <xsl:variable name="vmtype" select="./load_order" />
       <xsl:variable name="ivshmem">
         <xsl:choose>
           <xsl:when test="count(//hv//IVSHMEM/IVSHMEM_REGION) > 0">
@@ -353,7 +353,7 @@
       <xsl:if test="acrn:is-post-launched-vm($vmtype)">
         <func:result select="$ivshmem + $console_vuart + $communication_vuart + $virtual_root_port" />
       </xsl:if>
-      <xsl:if test="acrn:is-sos-vm($vmtype)">
+      <xsl:if test="acrn:is-service-vm($vmtype)">
         <func:result select="$ivshmem + $console_vuart + $communication_vuart" />
       </xsl:if>
     </xsl:for-each>
@@ -455,49 +455,19 @@
     </xsl:choose>
   </func:function>
 
-  <func:function name="acrn:is-sos-vm">
-    <xsl:param name="vm_type" />
-    <xsl:choose>
-      <xsl:when test="$vm_type = 'SERVICE_VM'">
-        <func:result select="true()" />
-      </xsl:when>
-      <xsl:otherwise>
-        <func:result select="false()" />
-      </xsl:otherwise>
-    </xsl:choose>
+  <func:function name="acrn:is-service-vm">
+    <xsl:param name="load_order" />
+    <func:result select="$load_order = 'SERVICE_VM'" />
   </func:function>
 
   <func:function name="acrn:is-pre-launched-vm">
-    <xsl:param name="vm_type" />
-    <xsl:choose>
-      <xsl:when test="$vm_type = 'PRE_RT_VM'">
-        <func:result select="true()" />
-      </xsl:when>
-      <xsl:when test="$vm_type = 'PRE_STD_VM'">
-        <func:result select="true()" />
-      </xsl:when>
-      <xsl:when test="$vm_type = 'SAFETY_VM'">
-        <func:result select="true()" />
-      </xsl:when>
-      <xsl:otherwise>
-        <func:result select="false()" />
-      </xsl:otherwise>
-    </xsl:choose>
+    <xsl:param name="load_order" />
+    <func:result select="$load_order = 'PRE_LAUNCHED_VM'" />
   </func:function>
 
   <func:function name="acrn:is-post-launched-vm">
-    <xsl:param name="vm_type" />
-    <xsl:choose>
-      <xsl:when test="$vm_type = 'POST_STD_VM'">
-        <func:result select="true()" />
-      </xsl:when>
-      <xsl:when test="$vm_type = 'POST_RT_VM'">
-        <func:result select="true()" />
-      </xsl:when>
-      <xsl:otherwise>
-        <func:result select="false()" />
-      </xsl:otherwise>
-    </xsl:choose>
+    <xsl:param name="load_order" />
+    <func:result select="$load_order = 'POST_LAUNCHED_VM'" />
   </func:function>
 
   <!-- acrn:is-vmsix-supported-device checks the given params are matched with any of the listed devices -->

--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -34,7 +34,7 @@
   </xsl:template>
 
   <xsl:template match="config-data/acrn-config">
-    <xsl:if test="count(vm[acrn:is-sos-vm(vm_type)])">
+    <xsl:if test="count(vm[acrn:is-service-vm(load_order)])">
       <xsl:call-template name="sos_serial_console" />
       <xsl:call-template name="sos_bootargs_diff" />
     </xsl:if>
@@ -84,7 +84,7 @@
 
 <xsl:template name="sos_bootargs_diff">
   <xsl:variable name="sos_rootfs">
-  <xsl:variable name="bootargs" select="str:split(//vm[acrn:is-sos-vm(vm_type)]/os_config/bootargs[text()], ' ')" />
+  <xsl:variable name="bootargs" select="str:split(//vm[acrn:is-service-vm(load_order)]/os_config/bootargs[text()], ' ')" />
   <xsl:for-each select="$bootargs">
     <xsl:variable name="pos" select="position()" />
     <xsl:variable name="bootarg" select="$bootargs[$pos]" />
@@ -93,8 +93,8 @@
       </xsl:if>
   </xsl:for-each>
   </xsl:variable>
-  <xsl:variable name="sos_bootargs" select="normalize-space(str:replace(//vm[acrn:is-sos-vm(vm_type)]/os_config/bootargs[text()], $sos_rootfs, ''))" />
-  <xsl:variable name="maxcpunum" select="count(//vm[acrn:is-sos-vm(vm_type)]/cpu_affinity/pcpu_id)" />
+  <xsl:variable name="sos_bootargs" select="normalize-space(str:replace(//vm[acrn:is-service-vm(load_order)]/os_config/bootargs[text()], $sos_rootfs, ''))" />
+  <xsl:variable name="maxcpunum" select="count(//vm[acrn:is-service-vm(load_order)]/cpu_affinity/pcpu_id)" />
   <xsl:variable name="hugepages" select="round(number(substring-before(//board-data//TOTAL_MEM_INFO, 'kB')) div (1024 * 1024)) - 3" />
   <xsl:variable name="maxcpus">
     <xsl:choose>
@@ -118,8 +118,8 @@
 <xsl:template name="cpu_affinity">
   <xsl:for-each select="vm">
     <xsl:choose>
-      <xsl:when test="acrn:is-sos-vm(vm_type)">
-        <xsl:value-of select="acrn:define('SERVICE_VM_CONFIG_CPU_AFFINITY', concat('(', acrn:string-join(//vm[acrn:is-sos-vm(vm_type)]/cpu_affinity/pcpu_id, '|', 'AFFINITY_CPU(', 'U)'),')'), '')" />
+      <xsl:when test="acrn:is-service-vm(load_order)">
+        <xsl:value-of select="acrn:define('SERVICE_VM_CONFIG_CPU_AFFINITY', concat('(', acrn:string-join(//vm[acrn:is-service-vm(load_order)]/cpu_affinity/pcpu_id, '|', 'AFFINITY_CPU(', 'U)'),')'), '')" />
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="acrn:define(concat('VM', @id, '_CONFIG_CPU_AFFINITY'), concat('(', acrn:string-join(cpu_affinity/pcpu_id, '|', 'AFFINITY_CPU(', 'U)'),')'), '')" />
@@ -177,7 +177,7 @@
 </xsl:template>
 
 <xsl:template name="vm0_passthrough_tpm">
-  <xsl:if test="acrn:is-pre-launched-vm(vm[@id = 0]/vm_type)">
+  <xsl:if test="acrn:is-pre-launched-vm(vm[@id = 0]/load_order)">
     <xsl:if test="//vm/mmio_resources/TPM2/text() = 'y' and //device[@id = 'MSFT0101' or compatible_id = 'MSFT0101']">
       <xsl:value-of select="acrn:define('VM0_PASSTHROUGH_TPM', '', '')" />
       <xsl:value-of select="acrn:define('VM0_TPM_BUFFER_BASE_ADDR', '0xFED40000', 'UL')" />
@@ -203,7 +203,7 @@
 
 <xsl:template name="vm_boot_args">
   <xsl:for-each select="vm">
-    <xsl:if test="acrn:is-pre-launched-vm(vm_type)">
+    <xsl:if test="acrn:is-pre-launched-vm(load_order)">
     <xsl:variable name="bootargs" select="normalize-space(os_config/bootargs)" />
       <xsl:if test="$bootargs">
         <xsl:value-of select="acrn:define(concat('VM', @id, '_BOOT_ARGS'), concat($quot, $bootargs, ' ', $quot), '')" />

--- a/misc/config_tools/xforms/pci_dev.c.xsl
+++ b/misc/config_tools/xforms/pci_dev.c.xsl
@@ -33,7 +33,7 @@
   <xsl:template match="config-data/acrn-config/vm">
     <!-- Initializer of a acrn_vm_pci_dev_config instance -->
     <xsl:choose>
-      <xsl:when test="acrn:is-sos-vm(vm_type)">
+      <xsl:when test="acrn:is-service-vm(load_order)">
         <xsl:value-of select="acrn:array-initializer('struct acrn_vm_pci_dev_config', 'sos_pci_devs', 'CONFIG_MAX_PCI_DEV_NUM')" />
       </xsl:when>
       <xsl:when test="acrn:pci-dev-num(@id)">
@@ -41,18 +41,18 @@
       </xsl:when>
     </xsl:choose>
 
-    <xsl:if test="acrn:is-pre-launched-vm(vm_type) and acrn:pci-dev-num(@id)">
+    <xsl:if test="acrn:is-pre-launched-vm(load_order) and acrn:pci-dev-num(@id)">
       <xsl:call-template name="virtual_pci_hostbridge" />
     </xsl:if>
     <xsl:call-template name="ivshmem_shm_mem" />
     <xsl:apply-templates select="console_vuart" />
     <xsl:apply-templates select="communication_vuart" />
     <xsl:apply-templates select="pci_devs" />
-    <xsl:if test="acrn:is-post-launched-vm(vm_type)">
+    <xsl:if test="acrn:is-post-launched-vm(load_order)">
       <xsl:apply-templates select="PTM" />
     </xsl:if>
 
-    <xsl:if test="acrn:is-sos-vm(vm_type) or acrn:pci-dev-num(@id)">
+    <xsl:if test="acrn:is-service-vm(load_order) or acrn:pci-dev-num(@id)">
       <xsl:value-of select="$end_of_array_initializer" />
     </xsl:if>
   </xsl:template>
@@ -77,7 +77,7 @@
         <xsl:value-of select="acrn:initializer('emu_type', 'PCI_DEV_TYPE_HVEMUL', '')" />
         <xsl:value-of select="acrn:initializer('vdev_ops', '&amp;vmcs9900_ops', '')" />
         <xsl:choose>
-          <xsl:when test="acrn:is-post-launched-vm(../vm_type)">
+          <xsl:when test="acrn:is-post-launched-vm(../load_order)">
             <xsl:value-of select="acrn:initializer('vbar_base[0]', 'INVALID_PCI_BASE', '')" />
             <xsl:value-of select="acrn:initializer('vbdf.value', 'UNASSIGNED_VBDF', '')" />
           </xsl:when>
@@ -103,7 +103,7 @@
       <xsl:value-of select="acrn:initializer('emu_type', 'PCI_DEV_TYPE_HVEMUL', '')" />
       <xsl:value-of select="acrn:initializer('vdev_ops', '&amp;vmcs9900_ops', '')" />
       <xsl:choose>
-        <xsl:when test="acrn:is-post-launched-vm(../vm_type)">
+        <xsl:when test="acrn:is-post-launched-vm(../load_order)">
           <xsl:value-of select="acrn:initializer('vbar_base[0]', 'INVALID_PCI_BASE', '')" />
           <xsl:value-of select="acrn:initializer('vbdf.value', 'UNASSIGNED_VBDF', '')" />
         </xsl:when>
@@ -142,14 +142,14 @@
   <xsl:template name="ivshmem_shm_mem">
     <xsl:variable name="vm_id" select="@id" />
     <xsl:variable name="vm_name" select="name" />
-    <xsl:variable name="vm_type" select="vm_type" />
+    <xsl:variable name="load_order" select="load_order" />
     <xsl:for-each select="//hv//IVSHMEM/IVSHMEM_REGION/IVSHMEM_VMS/IVSHMEM_VM[VM_NAME = $vm_name]">
       <xsl:text>{</xsl:text>
       <xsl:value-of select="$newline" />
       <xsl:value-of select="acrn:initializer('emu_type', 'PCI_DEV_TYPE_HVEMUL', '')" />
       <xsl:value-of select="acrn:initializer('vdev_ops', '&amp;vpci_ivshmem_ops', '')" />
       <xsl:choose>
-        <xsl:when test="acrn:is-post-launched-vm($vm_type)">
+        <xsl:when test="acrn:is-post-launched-vm($load_order)">
           <xsl:value-of select="acrn:initializer('vbdf.value', 'UNASSIGNED_VBDF', '')" />
         </xsl:when>
         <xsl:otherwise>

--- a/misc/config_tools/xforms/pt_intx.c.xsl
+++ b/misc/config_tools/xforms/pt_intx.c.xsl
@@ -42,7 +42,7 @@
   </xsl:template>
 
   <xsl:template match="config-data/acrn-config/vm">
-    <xsl:if test="acrn:is-pre-launched-vm(vm_type)">
+    <xsl:if test="acrn:is-pre-launched-vm(load_order)">
       <xsl:variable name="vm_id" select="@id" />
       <xsl:variable name="pt_intx" select="acrn:get-intx-mapping(//vm[@id=$vm_id]//pt_intx)" />
       <xsl:variable name="length" select="count($pt_intx)" />

--- a/misc/config_tools/xforms/vm_configurations.h.xsl
+++ b/misc/config_tools/xforms/vm_configurations.h.xsl
@@ -38,15 +38,15 @@
   <xsl:template name ="vm_count">
     <xsl:value-of select="acrn:comment('SERVICE_VM_NUM can only be 0 or 1; When SERVICE_VM_NUM is 1, MAX_POST_VM_NUM must be 0 too.')" />
     <xsl:value-of select="$newline" />
-    <xsl:value-of select="acrn:define('PRE_VM_NUM', count(vm[acrn:is-pre-launched-vm(vm_type)]), 'U')" />
-    <xsl:value-of select="acrn:define('SERVICE_VM_NUM', count(vm[acrn:is-sos-vm(vm_type)]), 'U')" />
-    <xsl:value-of select="acrn:define('MAX_POST_VM_NUM', hv/CAPACITIES/MAX_VM_NUM - count(vm[acrn:is-pre-launched-vm(vm_type)]) - count(vm[acrn:is-sos-vm(vm_type)]) , 'U')" />
+    <xsl:value-of select="acrn:define('PRE_VM_NUM', count(vm[acrn:is-pre-launched-vm(load_order)]), 'U')" />
+    <xsl:value-of select="acrn:define('SERVICE_VM_NUM', count(vm[acrn:is-service-vm(load_order)]), 'U')" />
+    <xsl:value-of select="acrn:define('MAX_POST_VM_NUM', hv/CAPACITIES/MAX_VM_NUM - count(vm[acrn:is-pre-launched-vm(load_order)]) - count(vm[acrn:is-service-vm(load_order)]) , 'U')" />
     <xsl:value-of select="acrn:define('CONFIG_MAX_VM_NUM', hv/CAPACITIES/MAX_VM_NUM , 'U')" />
   </xsl:template>
 
   <xsl:template name ="sos_vm_bootarges">
-    <xsl:if test="count(vm[vm_type='SERVICE_VM'])">
-      <xsl:value-of select="acrn:comment(concat('SERVICE_VM == VM', vm[vm_type='SERVICE_VM']/@id))" />
+    <xsl:if test="count(vm[load_order='SERVICE_VM'])">
+      <xsl:value-of select="acrn:comment(concat('SERVICE_VM == VM', vm[load_order='SERVICE_VM']/@id))" />
       <xsl:value-of select="$newline" />
       <xsl:value-of select="acrn:define('SERVICE_VM_OS_BOOTARGS', 'SERVICE_VM_ROOTFS SERVICE_VM_OS_CONSOLE SERVICE_VM_IDLE SERVICE_VM_BOOTARGS_DIFF', '')" />
     </xsl:if>
@@ -54,7 +54,7 @@
 
   <xsl:template name ="pre_launched_vm_hpa">
     <xsl:for-each select="vm">
-      <xsl:if test="acrn:is-pre-launched-vm(vm_type)">
+      <xsl:if test="acrn:is-pre-launched-vm(load_order)">
         <xsl:value-of select="acrn:define(concat('VM', @id, '_CONFIG_MEM_START_HPA'), memory/start_hpa, 'UL')" />
         <xsl:value-of select="acrn:define(concat('VM', @id, '_CONFIG_MEM_SIZE'), memory/size, 'UL')" />
         <xsl:value-of select="acrn:define(concat('VM', @id, '_CONFIG_MEM_START_HPA2'), memory/start_hpa2, 'UL')" />


### PR DESCRIPTION
    Patches includes:
    1.Add load_order(PRE_LAUNCHED_VM/SERVICE_VM/POST_LAUNCHED_VM) parameter
    2.Change vm_type parameter to values as RTVM, STANDARD_VM, TEE, REE
      TEE and REE are hidden in UI.
    3.Deduce vm severity in vm_configuration from vm_type and load_order
    4. Change the corresponding scenario.xml in repo
   
    Tracked-On: #6690
    Signed-off-by: hangliu1 <hang1.liu@linux.intel.com>
    Reviewed-by: Junjie Mao <junjie.mao@intel.com>