### PR TITLE
config-tools: remove SERIAL_CONSOLE extracion for bootargs of SOS

### DIFF
--- a/misc/config_tools/data/cfl-k700-i7/hybrid.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid.xml
@@ -137,7 +137,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 console=ttyS0 consoleblank=0 no_timer_check
         quiet loglevel=3 i915.nuclear_pageflip=1 swiotlb=131072
         </bootargs>
     </os_config>

--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -90,7 +90,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>RT_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>rw rootwait root=/dev/nvme0n1p3 earlyprintk=serial,ttyS0,115200 rootfstype=ext4 console=ttyS0,115200 console=tty0 rw nohpet console=hvc0 no_timer_check ignore_loglevel
+      <bootargs>rw rootwait root=/dev/nvme0n1p3 earlyprintk=serial,ttyS0,115200 rootfstype=ext4 console=ttyS0,115200 console=tty0 console=ttyS0 rw nohpet console=hvc0 no_timer_check ignore_loglevel
 	log_buf_len=16M consoleblank=0 tsc=reliable clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup
 	idle=poll irqaffinity=0 no_ipi_broadcast=1  reboot=acpi
 	</bootargs>

--- a/misc/config_tools/data/cfl-k700-i7/shared.xml
+++ b/misc/config_tools/data/cfl-k700-i7/shared.xml
@@ -65,7 +65,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1</bootargs>
     </os_config>
     <legacy_vuart id="0">

--- a/misc/config_tools/data/generic_board/hybrid.xml
+++ b/misc/config_tools/data/generic_board/hybrid.xml
@@ -137,7 +137,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 swiotlb=131072</bootargs>
     </os_config>
     <legacy_vuart id="0">

--- a/misc/config_tools/data/generic_board/shared.xml
+++ b/misc/config_tools/data/generic_board/shared.xml
@@ -72,7 +72,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 swiotlb=131072</bootargs>
     </os_config>
     <legacy_vuart id="0">

--- a/misc/config_tools/data/nuc11tnbi5/hybrid.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid.xml
@@ -137,7 +137,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 swiotlb=131072</bootargs>
     </os_config>
     <legacy_vuart id="0">

--- a/misc/config_tools/data/nuc11tnbi5/shared.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared.xml
@@ -72,7 +72,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>rw rootwait root=/dev/nvme0n1p3 console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+      <bootargs>rw rootwait root=/dev/nvme0n1p3 console=tty0 console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 swiotlb=131072</bootargs>
     </os_config>
     <legacy_vuart id="0">

--- a/misc/config_tools/data/qemu/shared.xml
+++ b/misc/config_tools/data/qemu/shared.xml
@@ -64,7 +64,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>root=/dev/vda1 earlyprintk=serial,ttyS0,115200n8 rw rootwait console=tty0 consoleblank=0 no_timer_check ignore_loglevel
+      <bootargs>root=/dev/vda1 earlyprintk=serial,ttyS0,115200n8 rw rootwait console=tty0 console=ttyS0 consoleblank=0 no_timer_check ignore_loglevel
         ignore_loglevel no_timer_check intel_iommu=off tsc=reliable</bootargs>
     </os_config>
     <legacy_vuart id="0">

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
@@ -137,7 +137,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>        root=/dev/sda3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+      <bootargs>        root=/dev/sda3 rw rootwait console=tty0 console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 swiotlb=131072
       </bootargs>
     </os_config>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared.xml
@@ -72,7 +72,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>  rw rootwait root=/dev/sda3 console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+      <bootargs>  rw rootwait root=/dev/sda3 console=tty0 console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 swiotlb=131072
       </bootargs>
     </os_config>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -127,7 +127,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>root=/dev/sda3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+      <bootargs>root=/dev/sda3 rw rootwait console=tty0 console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1</bootargs>
     </os_config>
     <legacy_vuart id="0">

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
@@ -89,7 +89,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>RT_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>rw rootwait root=/dev/sda3 rootfstype=ext4 console=ttyS0,115200 console=tty0 rw nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+      <bootargs>rw rootwait root=/dev/sda3 rootfstype=ext4 console=ttyS0,115200 console=tty0 console=ttyS0 rw nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
 	clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 no_ipi_broadcast=1
 	reboot=acpi
         </bootargs>

--- a/misc/config_tools/data/whl-ipc-i5/sdc.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc.xml
@@ -63,7 +63,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>root=/dev/sda3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+      <bootargs>root=/dev/sda3 rw rootwait console=tty0 console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1</bootargs>
     </os_config>
     <legacy_vuart id="0">

--- a/misc/config_tools/data/whl-ipc-i5/shared.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared.xml
@@ -64,7 +64,7 @@
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
       <ramdisk_mod/>
-      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+      <bootargs>root=/dev/nvme0n1p3 rw rootwait console=tty0 console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1</bootargs>
     </os_config>
     <legacy_vuart id="0">

--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -35,7 +35,6 @@
 
   <xsl:template match="config-data/acrn-config">
     <xsl:if test="count(vm[acrn:is-service-vm(load_order)])">
-      <xsl:call-template name="sos_serial_console" />
       <xsl:call-template name="sos_bootargs_diff" />
     </xsl:if>
     <xsl:call-template name="cpu_affinity" />
@@ -63,24 +62,6 @@
       </xsl:if>
     </xsl:for-each>
   </xsl:template>
-
-<xsl:template name="sos_serial_console">
-  <xsl:variable name="consoleport" select="hv/DEBUG_OPTIONS/SERIAL_CONSOLE" />
-  <xsl:variable name="sos_console">
-    <xsl:if test="$consoleport = ''">
-      <xsl:text>" "</xsl:text>
-    </xsl:if>
-    <xsl:if test="$consoleport != ''">
-      <xsl:if test="contains($consoleport, '/')">
-        <xsl:value-of select="concat($quot, 'console=', substring-after(substring-after($consoleport,'/'), '/'), ' ', $quot)" />
-      </xsl:if>
-      <xsl:if test="not(contains($consoleport, '/'))">
-        <xsl:value-of select="concat($quot, 'console=', $consoleport, ' ', $quot)" />
-      </xsl:if>
-    </xsl:if>
-  </xsl:variable>
-  <xsl:value-of select="acrn:define('SERVICE_VM_OS_CONSOLE', $sos_console, '')" />
-</xsl:template>
 
 <xsl:template name="sos_bootargs_diff">
   <xsl:variable name="sos_rootfs">

--- a/misc/config_tools/xforms/vm_configurations.h.xsl
+++ b/misc/config_tools/xforms/vm_configurations.h.xsl
@@ -48,7 +48,7 @@
     <xsl:if test="count(vm[load_order='SERVICE_VM'])">
       <xsl:value-of select="acrn:comment(concat('SERVICE_VM == VM', vm[load_order='SERVICE_VM']/@id))" />
       <xsl:value-of select="$newline" />
-      <xsl:value-of select="acrn:define('SERVICE_VM_OS_BOOTARGS', 'SERVICE_VM_ROOTFS SERVICE_VM_OS_CONSOLE SERVICE_VM_IDLE SERVICE_VM_BOOTARGS_DIFF', '')" />
+      <xsl:value-of select="acrn:define('SERVICE_VM_OS_BOOTARGS', 'SERVICE_VM_ROOTFS SERVICE_VM_IDLE SERVICE_VM_BOOTARGS_DIFF', '')" />
     </xsl:if>
   </xsl:template>
 


### PR DESCRIPTION
Remove the logic to parse SERIAL_CONSOLE and append to bootargs. Specify the console in bootargs directly.

Tracked-On: #7127
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>