### PR TITLE
ACRN:DM: Set the desired state to inject PCI legacy intx

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -2031,6 +2031,8 @@ pci_lintr_route(struct pci_vdev *dev)
 	dev->lintr.ioapic_irq = ii->ii_ioapic_irq;
 	dev->lintr.pirq_pin = ii->ii_pirq_pin;
 	pci_set_cfgdata8(dev, PCIR_INTLINE, pirq_irq(ii->ii_pirq_pin));
+	/* Initialize it to High */
+	vm_set_gsi_irq(dev->vmctx, ii->ii_ioapic_irq, GSI_SET_HIGH);
 }
 
 /**

--- a/devicemodel/hw/pci/irq.c
+++ b/devicemodel/hw/pci/irq.c
@@ -147,13 +147,13 @@ void pci_irq_deinit(struct vmctx *ctx)
 void
 pci_irq_assert(struct pci_vdev *dev)
 {
-	vm_set_gsi_irq(dev->vmctx, dev->lintr.ioapic_irq, GSI_SET_HIGH);
+	vm_set_gsi_irq(dev->vmctx, dev->lintr.ioapic_irq, GSI_SET_LOW);
 }
 
 void
 pci_irq_deassert(struct pci_vdev *dev)
 {
-	vm_set_gsi_irq(dev->vmctx, dev->lintr.ioapic_irq, GSI_SET_LOW);
+	vm_set_gsi_irq(dev->vmctx, dev->lintr.ioapic_irq, GSI_SET_HIGH);
 }
 
 int


### PR DESCRIPTION
When the virtio-XXX pci devices fall back to legacy PCI intx,
the pci_irq_assert is called to inject the interrupt and then
the pci_irq_deassert is used to mark the completion of PCI interrupt.
Currently the HV vIOAPIC uses the pin_state for the interrupt injection
of legacy PCI intx. In such case it will fail to inject the PCI legacy
intx and the guest system fails to be booted when adding the boot option
of "pci=nomsi".

PCI legacy INTx usually use active low level trigger mode as it is Open-Drain
state and allows multitple interrupt signals to share a single line.
https://wiki.osdev.org/PCI_Local_Bus_Signals
In such case DM needs to set the correct state for the PCI device so that the
HV vIOAPIC can help to inject the PCI legacy intx.

BTW: When the MSI/MSIX is used for PCI device, it uses another mechanism
to inject the interrupt. It is harmless to configure the initial state.

Tracked-On: #7124
Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>