### PR TITLE
hv: remove assert statement in run_vcpu()

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -764,8 +764,6 @@ int32_t run_vcpu(struct acrn_vcpu *vcpu)
 		} else {
 			pr_fatal("vmexit fail err_inst=%x", exec_vmread32(VMX_INSTR_ERROR));
 		}
-
-		ASSERT(status == 0, "vm fail");
 	}
 
 	return status;


### PR DESCRIPTION
 Remove this assert to avoid hypervisor crash when
 current VM entry fails, pr_fatal() message is enough
 for debug purpose.

Tracked-On: #7141
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>