### PR TITLE
config_tools: fix the board inspector exit issue

### DIFF
--- a/misc/config_tools/board_inspector/board_inspector.py
+++ b/misc/config_tools/board_inspector/board_inspector.py
@@ -51,7 +51,6 @@ def check_deps():
         res = subprocess.Popen(["update-pciids", "-q"])
         if res.wait() != 0:
             logging.warning(f"Failed to invoke update-pciids. No functional impact is foreseen, but descriptions of PCI devices may be inaccurate.")
-            sys.exit(1)
     except Exception as e:
         logging.warning(f"Failed to invoke update-pciids: {e}. No functional impact is foreseen, but descriptions of PCI devices may be unavailable.")
 


### PR DESCRIPTION
Fix the issue that board inspector exit after showing warning message.

Tracked-On: #6689
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>