### PR TITLE
misc: refine vuart connection

### DIFF
--- a/misc/config_tools/data/cfl-k700-i7/hybrid.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid.xml
@@ -52,6 +52,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>SAFETY_VM0</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -89,24 +103,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
-    <pci_devs>
-      <pci_dev/>
-    </pci_devs>
     <mmio_resources>
       <TPM2>n</TPM2>
       <p2sb>n</p2sb>
@@ -146,21 +145,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -187,21 +174,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="3">
@@ -226,21 +201,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -58,6 +58,20 @@
       <GPU_SBDF>0x00000010</GPU_SBDF>
       <UEFI_OS_LOADER_NAME/>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>PRE_RT_VM0</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>RTVM</vm_type>
@@ -100,21 +114,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev>00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (7) I219-LM (rev 10)</pci_dev>
       <pci_dev>01:00.0 Non-Volatile memory controller: Silicon Motion, Inc. SM2263EN/SM2263XT SSD Controller (rev 03)</pci_dev>
@@ -161,21 +163,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -206,21 +196,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="3">
@@ -247,21 +225,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/cfl-k700-i7/partitioned.xml
+++ b/misc/config_tools/data/cfl-k700-i7/partitioned.xml
@@ -52,6 +52,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>PRE_STD_VM0</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>PRE_STD_VM1</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -91,21 +105,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev>00:17.0 SATA controller: Intel Corporation Cannon Lake PCH SATA AHCI Controller (rev 10)</pci_dev>
       <pci_dev>00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (7) I219-LM (rev 10)</pci_dev>
@@ -154,21 +156,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev>00:14.0 USB controller: Intel Corporation Cannon Lake PCH USB 3.1 xHCI Host Controller (rev 10)</pci_dev>
       <pci_dev/>

--- a/misc/config_tools/data/cfl-k700-i7/shared.xml
+++ b/misc/config_tools/data/cfl-k700-i7/shared.xml
@@ -45,6 +45,20 @@
       <GPU_SBDF>0x00000010</GPU_SBDF>
       <UEFI_OS_LOADER_NAME>\\EFI\\BOOT\\bootx64.efi</UEFI_OS_LOADER_NAME>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>POST_RT_VM1</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -73,21 +87,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>2</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -116,21 +118,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
   </vm>
   <vm id="2">
     <vm_type>RTVM</vm_type>
@@ -156,21 +146,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="3">
@@ -197,21 +175,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="4">
@@ -238,21 +204,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="5">
@@ -279,21 +233,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="6">
@@ -320,21 +262,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/generic_board/hybrid.xml
+++ b/misc/config_tools/data/generic_board/hybrid.xml
@@ -52,6 +52,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>SAFETY_VM0</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -89,21 +103,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -145,21 +147,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -186,21 +176,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="3">
@@ -225,21 +203,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/generic_board/hybrid_rt.xml
+++ b/misc/config_tools/data/generic_board/hybrid_rt.xml
@@ -71,6 +71,20 @@
       <GPU_SBDF>0x00000010</GPU_SBDF>
       <UEFI_OS_LOADER_NAME/>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>PRE_RT_VM0</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>RTVM</vm_type>
@@ -110,21 +124,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev>00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</pci_dev>
       <pci_dev>58:00.0 Ethernet controller: Intel Corporation Device 15f2 (rev 03)</pci_dev>
@@ -164,21 +166,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -207,21 +197,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="3">
@@ -246,21 +224,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/generic_board/partitioned.xml
+++ b/misc/config_tools/data/generic_board/partitioned.xml
@@ -52,6 +52,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>PRE_STD_VM0</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>PRE_STD_VM1</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -91,21 +105,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev>00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</pci_dev>
       <pci_dev>58:00.0 Ethernet controller: Intel Corporation Device 15f2 (rev 03)</pci_dev>
@@ -154,21 +156,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev>00:14.0 USB controller: Intel Corporation Device a0ed (rev 20)</pci_dev>
       <pci_dev/>

--- a/misc/config_tools/data/generic_board/shared.xml
+++ b/misc/config_tools/data/generic_board/shared.xml
@@ -52,6 +52,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>POST_RT_VM1</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -80,21 +94,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>2</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -123,21 +125,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="2">
@@ -165,21 +155,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="3">
@@ -206,21 +184,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="4">
@@ -247,21 +213,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="5">
@@ -288,21 +242,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="6">
@@ -329,21 +271,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid.xml
@@ -52,6 +52,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>SAFETY_VM0</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -89,21 +103,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -145,21 +147,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -186,21 +176,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="3">
@@ -225,21 +203,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc11tnbi5/partitioned.xml
+++ b/misc/config_tools/data/nuc11tnbi5/partitioned.xml
@@ -52,6 +52,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>PRE_STD_VM0</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>PRE_STD_VM1</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -91,21 +105,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev>00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</pci_dev>
       <pci_dev>58:00.0 Ethernet controller: Intel Corporation Device 15f2 (rev 03)</pci_dev>
@@ -154,21 +156,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev>00:14.0 USB controller: Intel Corporation Device a0ed (rev 20)</pci_dev>
       <pci_dev/>

--- a/misc/config_tools/data/nuc11tnbi5/shared.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared.xml
@@ -52,6 +52,32 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>Connection_1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x3F</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>POST_STD_VM1</vm_name>
+          <io_port>0x3F</io_port>
+        </endpoint>
+      </vuart_connection>
+      <vuart_connection>
+        <name>Connection_2</name>
+        <type>pci</type>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <vbdf>00:10.0</vbdf>
+        </endpoint>
+        <endpoint>
+          <vm_name>POST_RT_VM1</vm_name>
+          <vbdf>00:10.0</vbdf>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -80,21 +106,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>2</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -123,21 +137,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="2">
@@ -165,21 +167,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="3">
@@ -206,21 +196,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="4">
@@ -247,21 +225,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="5">
@@ -288,21 +254,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="6">
@@ -329,21 +283,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/qemu/shared.xml
+++ b/misc/config_tools/data/qemu/shared.xml
@@ -45,6 +45,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>POST_STD_VM1</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -72,21 +86,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -113,20 +115,8 @@
       <base>INVALID_COM_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
@@ -52,6 +52,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>SAFETY_VM0</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -89,21 +103,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -146,21 +148,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -187,21 +177,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="3">
@@ -226,21 +204,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/partitioned.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/partitioned.xml
@@ -52,6 +52,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>PRE_STD_VM0</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>PRE_STD_VM1</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -91,21 +105,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev>00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</pci_dev>
       <pci_dev>00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (13) I219-LM (rev 20)</pci_dev>
@@ -154,21 +156,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev>00:14.0 USB controller: Intel Corporation Tiger Lake-LP USB 3.2 Gen 2x1 xHCI Host Controller (rev 20)</pci_dev>
       <pci_dev/>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared.xml
@@ -52,6 +52,32 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>POST_STD_VM1</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+      <vuart_connection>
+        <name>vUART connection 2</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x3E8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>POST_RT_VM1</vm_name>
+          <io_port>0x3E8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -81,28 +107,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM3_BASE</base>
-      <irq>SERVICE_VM_COM3_IRQ</irq>
-      <target_vm_id>2</target_vm_id>
-      <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -131,28 +138,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
     <priority>PRIO_LOW</priority>
   </vm>
@@ -181,28 +169,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM3_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
-    <legacy_vuart id="2">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM3_BASE</base>
-      <irq>COM3_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>2</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
     <priority>PRIO_LOW</priority>
   </vm>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -44,6 +44,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>SAFETY_VM0</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -80,21 +94,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -135,21 +137,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -176,21 +166,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
@@ -57,6 +57,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>PRE_RT_VM0</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>RTVM</vm_type>
@@ -99,21 +113,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev>00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
       <pci_dev>03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
@@ -153,21 +155,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -196,21 +186,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="3">
@@ -235,21 +213,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>0</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i5/partitioned.xml
+++ b/misc/config_tools/data/whl-ipc-i5/partitioned.xml
@@ -44,6 +44,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>PRE_STD_VM0</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>PRE_STD_VM1</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -85,21 +99,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev>00:17.0 SATA controller: Intel Corporation Cannon Point-LP SATA Controller [AHCI Mode] (rev 30)</pci_dev>
       <pci_dev>04:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
@@ -148,21 +150,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev>00:14.0 USB controller: Intel Corporation Cannon Point-LP USB 3.1 xHCI Controller (rev 30)</pci_dev>
       <pci_dev>03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>

--- a/misc/config_tools/data/whl-ipc-i5/sdc.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc.xml
@@ -71,21 +71,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -114,21 +102,9 @@
       <base>INVALID_COM_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i5/shared.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared.xml
@@ -44,6 +44,20 @@
     <MISC_CFG>
       <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
+    <vuart_connections>
+      <vuart_connection>
+        <name>vUART connection 1</name>
+        <type>legacy</type>
+        <endpoint>
+          <vm_name>ACRN_Service_VM</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+        <endpoint>
+          <vm_name>POST_RT_VM1</vm_name>
+          <io_port>0x2F8</io_port>
+        </endpoint>
+      </vuart_connection>
+    </vuart_connections>
   </hv>
   <vm id="0">
     <vm_type>STANDARD_VM</vm_type>
@@ -72,21 +86,9 @@
       <base>SERVICE_VM_COM1_BASE</base>
       <irq>SERVICE_VM_COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>SERVICE_VM_COM2_BASE</base>
-      <irq>SERVICE_VM_COM2_IRQ</irq>
-      <target_vm_id>2</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <pci_devs>
       <pci_dev/>
     </pci_devs>
@@ -115,21 +117,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
   </vm>
   <vm id="2">
     <vm_type>RTVM</vm_type>
@@ -155,21 +145,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>COM2_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="3">
@@ -196,21 +174,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="4">
@@ -237,21 +203,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="5">
@@ -278,21 +232,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
   <vm id="6">
@@ -319,21 +261,9 @@
       <base>COM1_BASE</base>
       <irq>COM1_IRQ</irq>
     </legacy_vuart>
-    <legacy_vuart id="1">
-      <type>VUART_LEGACY_PIO</type>
-      <base>INVALID_COM_BASE</base>
-      <irq>COM2_IRQ</irq>
-      <target_vm_id>0</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </legacy_vuart>
     <console_vuart id="0">
       <base>INVALID_PCI_BASE</base>
     </console_vuart>
-    <communication_vuart id="1">
-      <base>INVALID_PCI_BASE</base>
-      <target_vm_id>1</target_vm_id>
-      <target_uart_id>1</target_uart_id>
-    </communication_vuart>
     <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -225,6 +225,38 @@ must exactly match the module tag in the GRUB multiboot cmdline.</xs:documentati
   </xs:restriction>
 </xs:simpleType>
 
+<xs:simpleType name="VuartType">
+  <xs:annotation>
+    <xs:documentation>vCOM type</xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="legacy" />
+    <xs:enumeration value="pci" />
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="VuartEndpointType">
+  <xs:sequence>
+    <xs:element name="vm_name" type="xs:string"/>
+    <xs:element name="io_port" type="HexFormat" default="0x3F" />
+    <xs:element name="vbdf" type="VBDFType" minOccurs="0" maxOccurs="1"  />
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="VuartConnectionType">
+  <xs:sequence>
+    <xs:element name="name" type="xs:string" />
+    <xs:element name="type" type="VuartType" default="legacy" />
+    <xs:element name="endpoint" type="VuartEndpointType" minOccurs="2" maxOccurs="2" />
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="VuartConnectionsType">
+  <xs:sequence>
+    <xs:element name="vuart_connection" type="VuartConnectionType"  minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:complexType>
+
 <xs:simpleType name="LegacyVuartType">
   <xs:annotation acrn:configurable="n">
     <xs:documentation>vCOM type</xs:documentation>

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -298,6 +298,12 @@ If this value is empty, then the default value will be calculated from informati
     <xs:element name="MEMORY" type="MemoryOptionsType" />
     <xs:element name="CAPACITIES" type="CapacitiesOptionsType" />
     <xs:element name="MISC_CFG" type="MiscCfgOptionsType" />
+    <xs:element name="vuart_connections" type="VuartConnectionsType" minOccurs="0" maxOccurs="8">
+      <xs:annotation>
+        <xs:documentation>Specify the vUART connection setting.
+Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:all>
 </xs:complexType>
 
@@ -371,7 +377,7 @@ Refer SDM 17.19.2 for details, and use with caution.</xs:documentation>
 argument and memory.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="legacy_vuart" type="LegacyVuartConfiguration" minOccurs="2" maxOccurs="8">
+    <xs:element name="legacy_vuart" type="LegacyVuartConfiguration" minOccurs="1" maxOccurs="8">
       <xs:annotation>
         <xs:documentation>Specify the vUART (aka COM) with the vUART ID by its ``id`` attribute.
 Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
@@ -381,12 +387,6 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
       <xs:annotation>
         <xs:documentation>Specify the console vUART (aka PCI based vUART) with the vUART ID by
 its ``id`` attribute.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
-    <xs:element name="communication_vuart" type="CommunicationVuartConfiguration" maxOccurs="unbounded">
-      <xs:annotation>
-        <xs:documentation>Specify the communication vUART (aka PCI based vUART) with the vUART ID by
-its ``id`` attribute. When it is enabled, specify which target VM's vUART the current VM connects to.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="mmio_resources" type="MMIOResourcesConfiguration" minOccurs="0">

--- a/misc/config_tools/service_vm_config/serial_config.py
+++ b/misc/config_tools/service_vm_config/serial_config.py
@@ -37,20 +37,6 @@ def main(args):
                 user_vm_id = legacy_vuart.find('target_vm_id').text
                 legacy_vuartid = int(legacy_vuart.attrib["id"])
                 vuart_target_vmid[legacy_vuartid] = user_vm_id
-
-    vm_list = allocation_etree.xpath("//vm[load_order = 'SERVICE_VM']")
-    for vm in vm_list:
-        vuart_list = find_non_standard_uart(vm)
-        if len(vuart_list) != 0:
-            with open(args.out, "w+") as config_f:
-                for uart_start_num, vuart in enumerate(vuart_list, start=START_VUART_DEV_NAME_NO):
-                    base = " port " + vuart.find('base').text
-                    vuart_id = int(vuart.attrib["id"])
-                    vm_id_note = "# User_VM_id: " + str(vuart_target_vmid[vuart_id]) + '\n'
-                    config_f.write(vm_id_note)
-                    conf = "/dev/ttyS" + str(uart_start_num) + base + UART_IRQ_BAUD + '\n'
-                    config_f.write(conf)
-
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--allocation", help="the XML file summarizing resource allocated by config tool")

--- a/misc/config_tools/static_allocators/bdf.py
+++ b/misc/config_tools/static_allocators/bdf.py
@@ -27,12 +27,7 @@ def find_unused_bdf(used_bdf):
 
 def insert_vuart_to_dev_dict(scenario_etree, devdict, used):
     console_vuart =  scenario_etree.xpath(f"./console_vuart[base != 'INVALID_PCI_BASE']/@id")
-    communication_vuarts = scenario_etree.xpath(f".//communication_vuart[base != 'INVALID_PCI_BASE']/@id")
     for vuart_id in console_vuart:
-        free_bdf = find_unused_bdf(used)
-        devdict[f"{VUART}_{vuart_id}"] = free_bdf
-        used.append(free_bdf)
-    for vuart_id in communication_vuarts:
         free_bdf = find_unused_bdf(used)
         devdict[f"{VUART}_{vuart_id}"] = free_bdf
         used.append(free_bdf)

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -103,6 +103,7 @@
     <xsl:apply-templates select="os_config" />
     <xsl:call-template name="acpi_config" />
     <xsl:call-template name="legacy_vuart" />
+    <xsl:call-template name="vuart_connection" />
     <xsl:call-template name="pci_dev_num" />
     <xsl:call-template name="pci_devs" />
     <xsl:if test="acrn:is-pre-launched-vm(load_order)">
@@ -267,6 +268,55 @@
           <xsl:value-of select="acrn:initializer('t_vuart.vuart_id', concat(target_uart_id, 'U'))" />
         </xsl:if>
       </xsl:if>
+      <xsl:text>},</xsl:text>
+      <xsl:value-of select="$newline" />
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template name="vuart_connection">
+    <xsl:variable name="vm_id" select="@id" />
+    <xsl:variable name="vmname" select="name/text()" />
+    <xsl:for-each select="//vuart_connection[endpoint/vm_name = $vmname]">
+      <xsl:variable name="connection_name" select="name/text()" />
+      <xsl:variable name="type" select="type/text()" />
+      <xsl:variable name="vuart_id" select="position()"/>
+      <xsl:value-of select="acrn:initializer(concat('vuart[', $vuart_id, ']'), '{', true())" />
+      <xsl:choose>
+        <xsl:when test="$type = 'legacy'">
+          <xsl:value-of select="acrn:initializer('type', 'VUART_LEGACY_PIO')" />
+        </xsl:when>
+        <xsl:when test="$type = 'pci'">
+          <xsl:value-of select="acrn:initializer('type', 'VUART_PCI')" />
+        </xsl:when>
+      </xsl:choose>
+      <xsl:value-of select="acrn:initializer('irq', concat(//allocation-data/acrn-config/vm[@id=$vm_id]/legacy_vuart[@id=$vuart_id]/irq, 'U'))" />
+      <xsl:for-each select="endpoint">
+        <xsl:choose>
+          <xsl:when test="vm_name = $vmname">
+            <xsl:choose>
+              <xsl:when test="$type = 'legacy'">
+                <xsl:value-of select="acrn:initializer('addr.port_base', concat(io_port, 'U'))" />
+              </xsl:when>
+              <xsl:when test="$type = 'pci'">
+                <xsl:variable name="b" select="substring-before(vbdf/text(), ':')" />
+                <xsl:variable name="d" select="substring-before(substring-after(vbdf/text(), ':'), '.')" />
+                <xsl:variable name="f" select="substring-after(vbdf/text(), '.')" />
+                <xsl:value-of select="acrn:initializer('addr.bdf', concat('{', $b, ', ', $d, ', ', $f, '}'))" />
+              </xsl:when>
+            </xsl:choose>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:variable name="target_name" select="vm_name" />
+            <xsl:value-of select="acrn:initializer('t_vuart.vm_id', concat(//vm[name = $target_name]/@id, 'U'))" />
+            <xsl:for-each select="//vuart_connection[endpoint/vm_name = $target_name]">
+              <xsl:variable name="uart_num" select="position()"/>
+              <xsl:if test="name = $connection_name">
+	        <xsl:value-of select="acrn:initializer('t_vuart.vuart_id', concat($uart_num, 'U'))" />
+              </xsl:if>
+          </xsl:for-each>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:for-each>
       <xsl:text>},</xsl:text>
       <xsl:value-of select="$newline" />
     </xsl:for-each>


### PR DESCRIPTION
We have redesign the vuart and the UI for user, so the config tool
should change the schema and xform for the new xml, then change the
static_allocators to alloc irq and io_port for new connection.

This patch add a new vuart connection type and change the xforms and xmls
to adapter the new design.

This patch dependent on the change of one source patch.

Tracked-On: #6690
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>
