### PR TITLE
doc: add header notice on latest documentation from master

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,4 +1,15 @@
 {% extends "!layout.html" %}
+{% block document %}
+  {% if not is_release %}
+    <div class="admonition important">
+        <p class="admonition-title">Important</p>
+        <p>This is the latest documentation for the unstable development branch of
+        Project ACRN (master).<br/>Use the drop-down menu on the left to select
+        documentation for a stable release such as <a href="/2.7/">v2.7</a>.</p>
+    </div>
+  {% endif %}
+  {{ super() }}
+{% endblock %}
 {% block menu %}
   {% include "aversions.html" %}
   {{ super() }}


### PR DESCRIPTION
The master branch is considered unstable and under development. We need
to remind developers of this and refer them to the available stable release
documentation.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>