### PR TITLE
doc: remove build problem in release notes

### DIFF
--- a/doc/release_notes/release_notes_2.5.rst
+++ b/doc/release_notes/release_notes_2.5.rst
@@ -109,7 +109,7 @@ Add New Configuration Options
 
 In v2.5, the following elements are added to scenario XML files:
 
-- :option:`hv.FEATURES.NVMX_ENABLED`
+- ``hv.FEATURES.NVMX_ENABLED``
 - :option:`vm.PTM`
 
 The following element is renamed:
@@ -118,7 +118,7 @@ The following element is renamed:
 
 Constraints on values of the following element have changed:
 
-- :option:`vm.guest_flags.guest_flag` no longer accepts an empty text. For VMs
+- ``vm.guest_flags.guest_flag`` no longer accepts an empty text. For VMs
   with no guest flag set, set the value to ``0``.
 
 Document Updates


### PR DESCRIPTION
when an XML option was removed, it will break documentation links to
that option information.  We'll remove the link in the old release notes
to fix this problem.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>