### PR TITLE
hv: refine the vept module

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -286,10 +286,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 		 */
 		reserve_buffer_for_ept_pages();
 
-		/*
-		 * Reserve memory from platform E820 for shadow EPT 4K pages
-		 */
-		allocate_buffer_for_sept_pages();
+		init_vept();
 
 		pcpu_sync = ALL_CPUS_MASK;
 		/* Start all secondary cores */

--- a/hypervisor/arch/x86/guest/nested.c
+++ b/hypervisor/arch/x86/guest/nested.c
@@ -960,8 +960,8 @@ int32_t vmwrite_vmexit_handler(struct acrn_vcpu *vcpu)
 
 					if (vmcs_field == VMX_EPT_POINTER_FULL) {
 						if (cur_vvmcs->vmcs12.ept_pointer != vmcs_value) {
-							put_nept_desc(cur_vvmcs->vmcs12.ept_pointer);
-							get_nept_desc(vmcs_value);
+							put_vept_desc(cur_vvmcs->vmcs12.ept_pointer);
+							get_vept_desc(vmcs_value);
 						}
 					}
 				}
@@ -1136,7 +1136,7 @@ static void clear_vvmcs(struct acrn_vcpu *vcpu, struct acrn_vvmcs *vvmcs)
 	clear_va_vmcs(vvmcs->vmcs02);
 
 	/* This VMCS can no longer refer to any shadow EPT */
-	put_nept_desc(vvmcs->vmcs12.ept_pointer);
+	put_vept_desc(vvmcs->vmcs12.ept_pointer);
 
 	/* This vvmcs[] entry doesn't cache a VMCS12 any more */
 	vvmcs->vmcs12_gpa = INVALID_GPA;
@@ -1189,7 +1189,7 @@ int32_t vmptrld_vmexit_handler(struct acrn_vcpu *vcpu)
 					sizeof(struct acrn_vmcs12));
 
 				/* if needed, create nept_desc and allocate shadow root for the EPTP */
-				get_nept_desc(vvmcs->vmcs12.ept_pointer);
+				get_vept_desc(vvmcs->vmcs12.ept_pointer);
 
 				/* Need to load shadow fields from this new VMCS12 to VMCS02 */
 				sync_vmcs12_to_vmcs02(vcpu, &vvmcs->vmcs12);
@@ -1624,7 +1624,5 @@ void init_nested_vmx(__unused struct acrn_vm *vm)
 		/* Cache the value of physical MSR_IA32_VMX_BASIC */
 		vmx_basic = (uint32_t)msr_read(MSR_IA32_VMX_BASIC);
 		setup_vmcs_shadowing_bitmap();
-
-		init_vept();
 	}
 }

--- a/hypervisor/include/arch/x86/asm/guest/vept.h
+++ b/hypervisor/include/arch/x86/asm/guest/vept.h
@@ -22,30 +22,29 @@
 /*
  * A descriptor to store info of nested EPT
  */
-struct nept_desc {
-	/*
-	 * A shadow EPTP.
-	 * The format is same with 'EPT pointer' in VMCS.
-	 * Its PML4 address field is a HVA of the hypervisor.
-	 */
-	uint64_t shadow_eptp;
+struct vept_desc {
 	/*
 	 * An guest EPTP configured by L1 VM.
 	 * The format is same with 'EPT pointer' in VMCS.
 	 * Its PML4 address field is a GPA of the L1 VM.
 	 */
 	uint64_t guest_eptp;
+	/*
+	 * A shadow EPTP.
+	 * The format is same with 'EPT pointer' in VMCS.
+	 * Its PML4 address field is a HVA of the hypervisor.
+	 */
+	uint64_t shadow_eptp;
 	uint32_t ref_count;
 };
 
-void allocate_buffer_for_sept_pages(void);
 void init_vept(void);
 uint64_t get_shadow_eptp(uint64_t guest_eptp);
-struct nept_desc *get_nept_desc(uint64_t guest_eptp);
-void put_nept_desc(uint64_t guest_eptp);
+struct vept_desc *get_vept_desc(uint64_t guest_eptp);
+void put_vept_desc(uint64_t guest_eptp);
 bool handle_l2_ept_violation(struct acrn_vcpu *vcpu);
 int32_t invept_vmexit_handler(struct acrn_vcpu *vcpu);
 #else
-static inline void allocate_buffer_for_sept_pages(void) {};
+static inline void init_vept(void) {};
 #endif /* CONFIG_NVMX_ENABLED */
 #endif /* VEPT_H */


### PR DESCRIPTION
Now the vept module uses a mixture of nept and vept, it's better to
refine it.

So this patch rename nept to vept and simplify the interface of vept
init module.

Tracked-On: #6690
Acked-by: Anthony Xu <anthony.xu@intel.com>
Signed-off-by: Chenli Wei <chenli.wei@intel.com>