### PR TITLE
doc: fix doc build error for removed options

### DIFF
--- a/doc/release_notes/release_notes_2.7.rst
+++ b/doc/release_notes/release_notes_2.7.rst
@@ -144,9 +144,9 @@ As part of using consistent names for UOS and SOS, we also change configuration
 option names or values using these obsolete terms:
 
 - The :option:`vm.vm_type` option value ``SOS_VM`` is now ``SERVICE_VM``
-- The :option:`vm.legacy_vuart.base` option value ``SOS_VM_COM1_BASE`` is now
+- The ``vm.legacy_vuart.base`` option value ``SOS_VM_COM1_BASE`` is now
   ``SERVICE_VM_COM1_BASE``, with the same change for COM2, COM3, and COM4 base
-  and for the :option:`vm.legacy_vuart.irq` option values.
+  and for the ``vm.legacy_vuart.irq`` option values.
 
 In v2.7, the ``acrn-dm`` command line parameter ``--cpu_affinity`` is now mandatory
 when launching a User VM. If the launch XML settings, used to generate the launch

--- a/doc/tutorials/nvmx_virtualization.rst
+++ b/doc/tutorials/nvmx_virtualization.rst
@@ -182,7 +182,7 @@ with these settings:
      the PCI-vUART for the Service VM. Refer to :ref:`Enable vUART Configurations <vuart_config>`
      for more details about VUART configuration.
 
-   - Edit :option:`vm.legacy_vuart.base` in ``legacy_vuart 0`` and set it to ``INVALID_LEGACY_PIO``
+   - Edit ``vm.legacy_vuart.base`` in ``legacy_vuart 0`` and set it to ``INVALID_LEGACY_PIO``
 
    - Edit :option:`vm.console_vuart.base` in ``console_vuart 0`` and set it to ``PCI_VUART``
 


### PR DESCRIPTION
PR #7167 removed configuration options that were referenced by
documentation.  Remove those references.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>