### PR TITLE
Remove the assume of virtio-net device name

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_net.c
+++ b/devicemodel/hw/pci/virtio/virtio_net.c
@@ -820,7 +820,6 @@ virtio_net_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	char nstr[80];
 	char tname[MAXCOMLEN + 1];
 	struct virtio_net *net;
-	char fname[IFNAMSIZ];
 	char *devopts = NULL;
 	char *name = NULL;
 	char *type = NULL;
@@ -911,23 +910,20 @@ virtio_net_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	}
 
 	vtopts = tmp = strdup(opts);
-	if ((strstr(tmp, "tap") != NULL)
-			|| (strncmp(tmp, "vmnet",5) == 0)) {
+	if (strncmp(tmp, "tap", 3) == 0) {
 		type = strsep(&tmp, "=");
 		name = strsep(&tmp, ",");
 	}
 
-	if ((tmp != NULL) && (strncmp(tmp, "mac_seed",8) == 0)) {
+	if ((tmp != NULL) && (strncmp(tmp, "mac_seed", 8) == 0)) {
 		strsep(&tmp, "=");
 		mac_seed = tmp;
 	}
 
 	if ((type != NULL) && (name != NULL)) {
-		snprintf(fname, IFNAMSIZ, "%s_%s", type, name);
 
-		if ((strstr(type, "tap") != NULL) ||
-				(strncmp(type, "vmnet", 5) == 0)){
-			virtio_net_tap_setup(net, fname);
+		if (strcmp(type, "tap") == 0) {
+			virtio_net_tap_setup(net, name);
 		}
 	}
 

--- a/misc/config_tools/launch_config/launch_script_template.sh
+++ b/misc/config_tools/launch_config/launch_script_template.sh
@@ -136,7 +136,7 @@ function add_virtual_device() {
     if [ "${kind}" = "virtio-net" ]; then
         # Create the tap device
         tap_conf=${options%,*}
-        create_tap "tap_${tap_conf#tap=}" >> /dev/stderr
+        create_tap "${tap_conf#tap=}" >> /dev/stderr
     fi
 
     echo -n "-s ${slot},${kind}"

--- a/misc/config_tools/launch_config/launch_script_template.sh
+++ b/misc/config_tools/launch_config/launch_script_template.sh
@@ -135,8 +135,10 @@ function add_virtual_device() {
 
     if [ "${kind}" = "virtio-net" ]; then
         # Create the tap device
-        tap_conf=${options%,*}
-        create_tap "${tap_conf#tap=}" >> /dev/stderr
+        if [[ ${options} =~ tap=([^,]+) ]]; then
+            tap_conf="${BASH_REMATCH[1]}"
+            create_tap "${tap_conf}" >> /dev/stderr
+        fi
     fi
 
     echo -n "-s ${slot},${kind}"


### PR DESCRIPTION
Now, the DM assumes the device name entered by user is dependent on
the type.

For example, the device of tap type is named tap_TAAG, this patch
remove the above assumption.

User could set any name, no matter the code of DM or actually created,
it is represented by user input.

Commit 1. DM remove the assume logic of device name.

Commit 2. Config tool also change the generation logic of  launch script .

Commit 3. Fix the issue that got wrong device name after specifying mac address