### PR TITLE
Update LICENSE information file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2017-2021, Project ACRN
-All rights reserved.
+Copyright (c) 2017-2022, Project ACRN
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Update the top-level LICENSE file that provides the full text of the BSD-3
Clause license that this project uses. Two updates were made to it:
* Update the year to include 2022
* Removed an extra line: "All rights reserved"

The text matches exactly the reference found here: https://opensource.org/licenses/BSD-3-Clause

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>