### PR TITLE
config_tools: remove the assume of virtio-net device name

### DIFF
--- a/misc/config_tools/launch_config/launch_script_template.sh
+++ b/misc/config_tools/launch_config/launch_script_template.sh
@@ -136,7 +136,7 @@ function add_virtual_device() {
     if [ "${kind}" = "virtio-net" ]; then
         # Create the tap device
         tap_conf=${options%,*}
-        create_tap "tap_${tap_conf#tap=}" >> /dev/stderr
+        create_tap "${tap_conf#tap=}" >> /dev/stderr
     fi
 
     echo -n "-s ${slot},${kind}"


### PR DESCRIPTION
Since PR #7185 has removed the assume of virtio-net device name,
we also remove it in the launch script generation logic.

Tracked-On: #6690
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>