### PR TITLE
Revert "dm: set PMU_PT flag for CPU core partition VM"

### DIFF
--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -186,7 +186,6 @@ vm_create(const char *name, uint64_t req_buf, int *vcpu_num)
 		create_vm.vm_flag |= GUEST_FLAG_LAPIC_PASSTHROUGH;
 		create_vm.vm_flag |= GUEST_FLAG_RT;
 		create_vm.vm_flag |= GUEST_FLAG_IO_COMPLETION_POLLING;
-		create_vm.vm_flag |= GUEST_FLAG_PMU_PASSTHROUGH;
 	} else {
 		create_vm.vm_flag &= (~GUEST_FLAG_LAPIC_PASSTHROUGH);
 		create_vm.vm_flag &= (~GUEST_FLAG_IO_COMPLETION_POLLING);


### PR DESCRIPTION
This reverts commit 811992ee2beb4ba0acf04f72aff675a82d617e3d.

There could be some conflict with current configure tool. will fix it
later.