### PR TITLE
misc: refine the non-stand vUART config

### DIFF
--- a/misc/config_tools/service_vm_config/serial_config.py
+++ b/misc/config_tools/service_vm_config/serial_config.py
@@ -4,8 +4,12 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'library'))
+
 import argparse
 import lxml.etree
+import common
 
 #vuart devices name is configured to start from /dev/ttyS8
 START_VUART_DEV_NAME_NO = 8
@@ -13,12 +17,21 @@ VUART_DEV_NAME_NUM = 8
 stadard_uart_port = {'0x3F8', '0x2F8', '0x3E8', '0x2E8'}
 UART_IRQ_BAUD = " irq 0 uart 16550A baud_base 115200"
 
-def find_non_standard_uart(vm):
+def find_non_standard_uart(vm, scenario_etree):
     uart_list = []
-    for vuart in vm.iter(tag = 'legacy_vuart'):
-        base = vuart.find('base').text
-        if base not in stadard_uart_port:
-            uart_list.append(vuart)
+    vmname = common.get_node("./name/text()", vm)
+
+    connection_list = scenario_etree.xpath(f"//vuart_connection[endpoint/vm_name = '{vmname}']")
+    for connection in connection_list:
+        type = common.get_node(f"./type/text()", connection)
+
+        if (type != "legacy") :
+            continue
+
+        port = common.get_node(f".//endpoint[vm_name = '{vmname}']/io_port/text()", connection)
+        if port not in stadard_uart_port:
+           uart_list.append(connection)
+
     return uart_list
 
 def main(args):
@@ -28,15 +41,31 @@ def main(args):
     """
     scenario_etree = lxml.etree.parse(args.scenario)
     allocation_etree = lxml.etree.parse(args.allocation)
-    vuart_target_vmid = [0] * VUART_DEV_NAME_NUM
+    vuart_target_vmid = {}
 
     vm_list = scenario_etree.xpath("//vm[load_order = 'SERVICE_VM']")
     for vm in vm_list:
-        for legacy_vuart in vm.iter(tag = 'legacy_vuart'):
-            if legacy_vuart.find('target_vm_id') != None:
-                user_vm_id = legacy_vuart.find('target_vm_id').text
-                legacy_vuartid = int(legacy_vuart.attrib["id"])
-                vuart_target_vmid[legacy_vuartid] = user_vm_id
+        vmname = common.get_node("./name/text()", vm)
+        for connection in scenario_etree.xpath(f"//vuart_connection[endpoint/vm_name = '{vmname}']"):
+            vm_name = common.get_node(f".//endpoint[vm_name != '{vmname}']/vm_name/text()", connection)
+            for target_vm in scenario_etree.xpath(f"//vm[name = '{vm_name}']"):
+                vuart_target_vmid[connection.find('name').text] = target_vm.attrib["id"]
+
+    vm_list = scenario_etree.xpath("//vm[load_order = 'SERVICE_VM']")
+    for vm in vm_list:
+        vuart_list = find_non_standard_uart(vm, scenario_etree)
+        vmname = common.get_node("./name/text()", vm)
+        if len(vuart_list) != 0:
+            with open(args.out, "w+") as config_f:
+                for uart_start_num, vuart in enumerate(vuart_list, start=START_VUART_DEV_NAME_NO):
+                    port = common.get_node(f".//endpoint[vm_name = '{vmname}']/io_port/text()", vuart)
+                    base = " port " + str(port)
+                    connection_name = vuart.find('name').text
+                    vm_id_note = "# User_VM_id: " + str(vuart_target_vmid[connection_name]) + '\n'
+                    config_f.write(vm_id_note)
+                    conf = "/dev/ttyS" + str(uart_start_num) + base + UART_IRQ_BAUD + '\n'
+                    config_f.write(conf)
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--allocation", help="the XML file summarizing resource allocated by config tool")


### PR DESCRIPTION
The Service VM needs a 'serial.conf' file to recognize and use
non-standard vUART with the 'setserial' package.

The logic of create serial.conf should update after we move vUART
connection to global and use endpoint to replace the target VM id.

This patch select the new vUART connection and check whether one of the
endpoint is Service VM, if yes, then check the io_port and record it
when the vUART is non-standard.

All these non-standard vUART will be written to the serial.conf.

Tracked-On: #6690
Reviewed-by: Junjie Mao junjie.mao@intel.com
Signed-off-by: Chenli Wei <chenli.wei@intel.com>