### PR TITLE
doc: Remove outdated tutorials

### DIFF
--- a/doc/develop.rst
+++ b/doc/develop.rst
@@ -14,17 +14,6 @@ Advanced Scenario Tutorials
    tutorials/using_hybrid_mode_on_nuc
    tutorials/using_partition_mode_on_nuc
 
-Service VM Tutorials
-********************
-
-.. rst-class:: rst-columns2
-
-.. toctree::
-   :maxdepth: 1
-
-   tutorials/running_deb_as_serv_vm
-   tutorials/using_yp
-
 .. _develop_acrn_user_vm:
 
 User VM Tutorials
@@ -36,8 +25,6 @@ User VM Tutorials
    :maxdepth: 1
 
    tutorials/using_windows_as_user_vm
-   tutorials/running_ubun_as_user_vm
-   tutorials/running_deb_as_user_vm
    tutorials/using_xenomai_as_user_vm
    tutorials/using_vxworks_as_user_vm
    tutorials/using_zephyr_as_user_vm

--- a/doc/release_notes/release_notes_1.3.rst
+++ b/doc/release_notes/release_notes_1.3.rst
@@ -46,9 +46,9 @@ We have many new `reference documents available <https://projectacrn.github.io>`
 * :ref:`ACRN Configuration Tool Manual <acrn_configuration_tool>`
 * :ref:`Trace and Data Collection for ACRN real-time (RT) Performance Tuning <rt_performance_tuning>`
 * Building ACRN in Docker
-* :ref:`Running Ubuntu as the User VM <running_ubun_as_user_vm>`
-* :ref:`Running Debian as the User VM <running_deb_as_user_vm>`
-* :ref:`Running Debian as the Service VM <running_deb_as_serv_vm>`
+* Running Ubuntu as the User VM
+* Running Debian as the User VM
+* Running Debian as the Service VM
 * :ref:`vUART configuration <vuart_config>`
 * :ref:`Enable virtio-i2c <virtio-i2c>`
 

--- a/doc/release_notes/release_notes_2.0.rst
+++ b/doc/release_notes/release_notes_2.0.rst
@@ -241,14 +241,14 @@ Many new and updated `reference documents <https://projectacrn.github.io>`_ are 
 
 * Service VM Tutorials
 
-  * :ref:`running_deb_as_serv_vm`
+  * Run Debian as the Service VM
 
 * User VM Tutorials
 
   .. rst-class:: rst-columns2
 
   * :ref:`using_zephyr_as_uos`
-  * :ref:`running_deb_as_user_vm`
+  * Run Debian as the User VM
   * Run Celadon as the User VM
   * :ref:`using_windows_as_uos`
   * :ref:`using_vxworks_as_uos`

--- a/doc/release_notes/release_notes_2.2.rst
+++ b/doc/release_notes/release_notes_2.2.rst
@@ -100,7 +100,7 @@ New and updated reference documents are available, including:
 * :ref:`using_grub`
 * :ref:`using_partition_mode_on_nuc`
 * :ref:`connect_serial_port`
-* :ref:`using_yp`
+* Using Yocto Project With ACRN
 * :ref:`acrn-dm_parameters`
 * :ref:`hv-parameters`
 * :ref:`acrnctl`

--- a/doc/release_notes/release_notes_2.3.rst
+++ b/doc/release_notes/release_notes_2.3.rst
@@ -104,9 +104,9 @@ New and updated reference documents are available, including:
 * :ref:`rt_performance_tuning`
 * :ref:`rt_perf_tips_rtvm`
 * :ref:`run-kata-containers`
-* :ref:`running_deb_as_serv_vm`
-* :ref:`running_deb_as_user_vm`
-* :ref:`running_ubun_as_user_vm`
+* Run Debian as the Service VM
+* Run Debian as the User VM
+* Run Ubuntu as the User VM
 * :ref:`setup_openstack_libvirt`
 * :ref:`sgx_virt`
 * :ref:`sriov_virtualization`

--- a/doc/release_notes/release_notes_2.5.rst
+++ b/doc/release_notes/release_notes_2.5.rst
@@ -159,7 +159,7 @@ formatting, and presentation throughout the ACRN documentation:
 * :ref:`acrn_on_qemu`
 * :ref:`acrn_doc`
 * :ref:`enable_ivshmem`
-* :ref:`running_deb_as_serv_vm`
+* Run Debian as the Service VM
 * :ref:`trusty-security-services`
 * :ref:`using_hybrid_mode_on_nuc`
 * :ref:`connect_serial_port`
@@ -194,7 +194,7 @@ Fixed Issues Details
 - :acrn-issue:`6147` - ASAN reports UAF + SEGV when fuzzing exposed PIO with Hypercube guest VM.
 - :acrn-issue:`6157` - coding style fix on v2.5 branch
 - :acrn-issue:`6162` - [REG][EHL][SBL] Fail to boot sos
-- :acrn-issue:`6168` - SOS failed to boot with nest enabled 
+- :acrn-issue:`6168` - SOS failed to boot with nest enabled
 - :acrn-issue:`6172` - member access within null pointer of type 'struct xhci_trb'
 - :acrn-issue:`6178` - config-tools: adding an empty node <pt_intx> for a pre-launched VM causing check_pt_intx throw out an error
 - :acrn-issue:`6185` - [TGL][Industry]yaag can't get ip after SRIVO VF passthru

--- a/doc/tutorials/running_deb_as_serv_vm.rst
+++ b/doc/tutorials/running_deb_as_serv_vm.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _running_deb_as_serv_vm:
 
 Run Debian as the Service VM

--- a/doc/tutorials/running_deb_as_user_vm.rst
+++ b/doc/tutorials/running_deb_as_user_vm.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _running_deb_as_user_vm:
 
 Run Debian as the User VM
@@ -18,7 +20,7 @@ We are using a Kaby Lake Intel NUC (NUC7i7DNHE) and Debian 10 as the User VM in 
 
 Before you start this tutorial, make sure the KVM tools are installed on the
 development machine and set **IGD Aperture Size to 512** in the BIOS
-settings (refer to :numref:`intel-bios-deb`). Connect two monitors to your
+settings. Connect two monitors to your
 Intel NUC:
 
 .. code-block:: none
@@ -84,7 +86,7 @@ steps will detail how to use the Debian CD-ROM (ISO) image to install Debian
 
       $ sudo virt-manager
 
-#. Verify that you can see the main menu as shown in :numref:`vmmanager-debian` below.
+#. Verify that you can see the main menu as shown in the figure below.
 
    .. figure:: images/debian-uservm-1.png
       :align: center
@@ -96,7 +98,7 @@ steps will detail how to use the Debian CD-ROM (ISO) image to install Debian
 
    a. Choose **Local install media (ISO image or CD-ROM)** and then click
       **Forward**. A **Create a new virtual machine** box displays, as shown
-      in :numref:`newVM-debian` below.
+      in the figure below.
 
       .. figure:: images/debian-uservm-2.png
          :align: center
@@ -117,7 +119,8 @@ steps will detail how to use the Debian CD-ROM (ISO) image to install Debian
    #. Rename the image if you desire. You must check the **customize
       configuration before install** option before you finish all stages.
 
-#. Verify that you can see the Overview screen has been set up, shown in :numref:`debian10-setup` below:
+#. Verify that you can see the Overview screen has been set up, shown in the
+   figure below:
 
     .. figure:: images/debian-uservm-3.png
        :align: center
@@ -126,7 +129,7 @@ steps will detail how to use the Debian CD-ROM (ISO) image to install Debian
        Debian Setup Overview
 
 #. Complete the Debian installation. Verify that you have set up a
-   Virtual Disk (VDA) partition, as shown in :numref:`partition-vda` below:
+   Virtual Disk (VDA) partition, as shown in the figure below:
 
     .. figure:: images/debian-uservm-4.png
        :align: center
@@ -199,7 +202,8 @@ Re-use and modify the `launch_win.sh` script in order to launch the new Debian 1
 
       $ sudo ./launch_debian.sh
 
-#. View the Debian desktop on the secondary monitor, as shown in :numref:`debian-display2` below:
+#. View the Debian desktop on the secondary monitor, as shown in the figure
+   below:
 
     .. figure:: images/debian-uservm-5.png
        :align: center
@@ -247,7 +251,7 @@ console so you can make command-line entries directly from it.
       -s 9,virtio-console,@stdio:stdio_port \
 
 #. Launch Debian using the modified script. Verify that you see the
-   console output shown in :numref:`console output-debian` below:
+   console output shown in the figure below:
 
     .. figure:: images/debian-uservm-7.png
        :align: center

--- a/doc/tutorials/running_ubun_as_user_vm.rst
+++ b/doc/tutorials/running_ubun_as_user_vm.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _running_ubun_as_user_vm:
 
 Run Ubuntu as the User VM
@@ -17,7 +19,7 @@ Intel NUC Kit. If you have not, refer to the following instructions:
 
 Before you start this tutorial, make sure the KVM tools are installed on the
 development machine and set **IGD Aperture Size to 512** in the BIOS
-settings (refer to :numref:`intel-bios-ubun`). Connect two monitors to your
+settings. Connect two monitors to your
 Intel NUC:
 
 .. code-block:: none
@@ -80,7 +82,7 @@ This tutorial uses the Ubuntu 18.04 desktop ISO as the base image.
 
       $ sudo virt-manager
 
-#. Verify that you can see the main menu as shown in :numref:`vmmanager-ubun` below.
+#. Verify that you can see the main menu as shown in the figure below.
 
    .. figure:: images/ubuntu-uservm-1.png
       :align: center
@@ -92,7 +94,7 @@ This tutorial uses the Ubuntu 18.04 desktop ISO as the base image.
 
    a. Choose **Local install media (ISO image or CD-ROM)** and then click
       **Forward**. A **Create a new virtual machine** box displays, as shown
-      in :numref:`newVM-ubun` below.
+      in the figure below.
 
       .. figure:: images/ubuntu-uservm-2.png
          :align: center
@@ -113,7 +115,8 @@ This tutorial uses the Ubuntu 18.04 desktop ISO as the base image.
    #. Rename the image if you desire. You must check the
       **customize configuration before install** option before you finish all stages.
 
-#. Verify that you can see the Overview screen as set up, as shown in :numref:`ubun-setup` below:
+#. Verify that you can see the Overview screen as set up, as shown in the figure
+   below:
 
     .. figure:: images/ubuntu-uservm-3.png
        :align: center
@@ -182,7 +185,8 @@ Modify the ``launch_win.sh`` script in order to launch Ubuntu as the User VM.
 
       $ sudo sh launch_ubuntu.sh
 
-#. View the Ubuntu desktop on the secondary monitor, as shown in :numref:`ubun-display1` below:
+#. View the Ubuntu desktop on the secondary monitor, as shown in the figure
+   below:
 
     .. figure:: images/ubuntu-uservm-4.png
        :align: center
@@ -217,7 +221,7 @@ VM console so you can make command-line entries directly from it.
       -s 9,virtio-console,@stdio:stdio_port \
 
 #. Log in to the Service VM and launch Ubuntu. Verify that you see the
-   console output shown in :numref:`console output-ubun` below:
+   console output shown in the figure below:
 
     .. figure:: images/ubuntu-uservm-5.png
        :align: center

--- a/doc/tutorials/using_yp.rst
+++ b/doc/tutorials/using_yp.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _using_yp:
 
 Using Yocto Project With ACRN


### PR DESCRIPTION
- Remove Ubuntu and Debian tutorials, as GSG is sufficient
- Remove Yocto tutorial, as it is just a reference to a repo that supports ACRN v2.4

Signed-off-by: Reyes, Amy <amy.reyes@intel.com>