### PR TITLE
dm: update virtio-i2c bus counter when device is deinit

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_i2c.c
+++ b/devicemodel/hw/pci/virtio/virtio_i2c.c
@@ -827,6 +827,8 @@ virtio_i2c_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		pthread_mutex_destroy(&vi2c->req_mtx);
 		pthread_mutex_destroy(&vi2c->mtx);
 		virtio_i2c_reset(vi2c);
+		acpi_i2c_adapter_num--;
+		assert(acpi_i2c_adapter_num >= 0);
 		free(vi2c);
 		dev->arg = NULL;
 	}


### PR DESCRIPTION
 i2c bus counter 'acpi_i2c_adapter_num' shall be updated
 when virtio-i2c device is de-initialized, else in user VM
 reboot case, this global counter will not be reset and
 keep the value last user VM boot, which is not expected
 and cause iasl(building ACPI data) program crash finally
 because the i2c device name space overflow.

Tracked-On: #7028
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>