### PR TITLE
fix a bug about host/guest msr store/load and revert PMU_PT flag in ACRN-DM

### DIFF
--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -186,6 +186,7 @@ vm_create(const char *name, uint64_t req_buf, int *vcpu_num)
 		create_vm.vm_flag |= GUEST_FLAG_LAPIC_PASSTHROUGH;
 		create_vm.vm_flag |= GUEST_FLAG_RT;
 		create_vm.vm_flag |= GUEST_FLAG_IO_COMPLETION_POLLING;
+		create_vm.vm_flag |= GUEST_FLAG_PMU_PASSTHROUGH;
 	} else {
 		create_vm.vm_flag &= (~GUEST_FLAG_LAPIC_PASSTHROUGH);
 		create_vm.vm_flag &= (~GUEST_FLAG_IO_COMPLETION_POLLING);

--- a/hypervisor/arch/x86/guest/vcat.c
+++ b/hypervisor/arch/x86/guest/vcat.c
@@ -409,10 +409,10 @@ int32_t write_vclosid(struct acrn_vcpu *vcpu, uint64_t val)
 			 * Write the new pCLOSID value to the guest msr area
 			 *
 			 * The prepare_auto_msr_area() function has already initialized the vcpu->arch.msr_area.
-			 * Here we only need to update the vcpu->arch.msr_area.guest[MSR_AREA_IA32_PQR_ASSOC].value field,
+			 * Here we only need to update the vcpu->arch.msr_area.guest[].value field for IA32_PQR_ASSOC,
 			 * all other vcpu->arch.msr_area fields remains unchanged at runtime.
 			 */
-			vcpu->arch.msr_area.guest[MSR_AREA_IA32_PQR_ASSOC].value = clos2pqr_msr(pclosid);
+			vcpu->arch.msr_area.guest[vcpu->arch.msr_area.index_of_pqr_assoc].value = clos2pqr_msr(pclosid);
 
 			ret = 0;
 		}

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -212,15 +212,12 @@ struct msr_store_entry {
 	uint64_t value;
 } __aligned(16);
 
-enum {
-	MSR_AREA_IA32_PQR_ASSOC = 0,
-	MSR_AREA_PERF_CTRL,
-	MSR_AREA_COUNT,
-};
+#define MSR_AREA_COUNT 2 /* the max MSRs in auto load/store area */
 
 struct msr_store_area {
 	struct msr_store_entry guest[MSR_AREA_COUNT];
 	struct msr_store_entry host[MSR_AREA_COUNT];
+	uint32_t index_of_pqr_assoc;
 	uint32_t count;	/* actual count of entries to be loaded/restored during VMEntry/VMExit */
 };
 


### PR DESCRIPTION
Revert "Revert "dm: set PMU_PT flag for CPU ...""

    This reverts commit 6750d5a2770ad183bf748e718e57934be03a5705.

    the bug is root caused and fixed for host/guest MSR store/load,
    so recovery the original patch.

Tracked-On: #6966
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
