### PR TITLE
config_tools: add CPU capability and BIOS invalid setting checks

### DIFF
--- a/misc/config_tools/board_inspector/board_inspector.py
+++ b/misc/config_tools/board_inspector/board_inspector.py
@@ -16,6 +16,8 @@ from cpuparser import parse_cpuid, get_online_cpu_ids, get_offline_cpu_ids
 script_dir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(script_dir))
 
+from inspectorlib import validator
+
 def check_deps():
     # Check that the required tools are installed on the system
     BIN_LIST = ['cpuid', 'rdmsr', 'lspci', ' dmidecode', 'blkid', 'stty']
@@ -111,6 +113,11 @@ def main(board_name, board_xml, args):
             if args.basic and getattr(module, "advanced", False):
                 continue
             module.extract(args, board_etree)
+
+        # Validate the XML against XSD assertions
+        count = validator.validate_board("schema/boardchecks.xsd", board_etree)
+        if count == 0:
+            logging.info("All board checks passed.")
 
         # Finally overwrite the output with the updated XML
         board_etree.write(board_xml, pretty_print=True)

--- a/misc/config_tools/board_inspector/cpuparser/cpuids.py
+++ b/misc/config_tools/board_inspector/cpuparser/cpuids.py
@@ -20,9 +20,17 @@ class LEAF_0(CPUID):
     max_leaf = cpuidfield(EAX, 31, 0, doc="Highest value the CPUID recognizes for returning basic processor information")
 
     @property
+    def cpuid_level(self):
+        return hex(self.regs.eax)
+
+    @property
     def vendor(self):
         """Vendor identification string"""
         return struct.pack('III', self.regs.ebx, self.regs.edx, self.regs.ecx)
+
+    attribute_bits = [
+        "cpuid_level",
+    ]
 
 class LEAF_1(CPUID):
     """Basic CPUID Information

--- a/misc/config_tools/board_inspector/cpuparser/msr.py
+++ b/misc/config_tools/board_inspector/cpuparser/msr.py
@@ -1,0 +1,206 @@
+# Copyright (C) 2022 Intel Corporation.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+from cpuparser.platformbase import MSR, msrfield
+
+class MSR_IA32_MISC_ENABLE(MSR):
+    addr = 0x1a0
+    fast_string = msrfield(1, 0, doc=None)
+
+    capability_bits = [
+        "fast_string",
+    ]
+
+class MSR_IA32_VMX_PROCBASED_CTLS2(MSR):
+    addr = 0x0000048B
+
+    @property
+    def vmx_procbased_ctls2_vapic(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 0)
+
+    @property
+    def vmx_procbased_ctls2_ept(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 1)
+
+    @property
+    def vmx_procbased_ctls2_vpid(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 5)
+
+    @property
+    def vmx_procbased_ctls2_rdtscp(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 3)
+
+    @property
+    def vmx_procbased_ctls2_unrestrict(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 7)
+
+    capability_bits = [
+        "vmx_procbased_ctls2_vapic",
+        "vmx_procbased_ctls2_ept",
+        "vmx_procbased_ctls2_vpid",
+        "vmx_procbased_ctls2_rdtscp",
+        "vmx_procbased_ctls2_unrestrict",
+    ]
+
+class MSR_IA32_VMX_PINBASED_CTLS(MSR):
+    addr = 0x00000481
+
+    @property
+    def vmx_pinbased_ctls_irq_exit(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 0)
+
+    capability_bits = [
+        "vmx_pinbased_ctls_irq_exit",
+    ]
+
+class MSR_IA32_VMX_PROCBASED_CTLS(MSR):
+    addr = 0x00000482
+
+    @property
+    def vmx_procbased_ctls_tsc_off(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 3)
+
+    @property
+    def vmx_procbased_ctls_tpr_shadow(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 21)
+
+    @property
+    def vmx_procbased_ctls_io_bitmap(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 25)
+
+    @property
+    def vmx_procbased_ctls_msr_bitmap(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 28)
+
+    @property
+    def vmx_procbased_ctls_hlt(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 7)
+
+    @property
+    def vmx_procbased_ctls_secondary(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 31)
+
+    @property
+    def ept(self):
+        is_ept_supported = False
+        if ((self.value >> 32) & (1 << 31)) != 0:
+            msr_val = MSR_IA32_VMX_PROCBASED_CTLS2.rdmsr(self.cpu_id)
+            if msrfield.is_ctrl_setting_allowed(msr_val.value, 1 << 1):
+                is_ept_supported = True
+        return is_ept_supported
+
+    @property
+    def apicv(self):
+        features = 0
+        vapic_feature_tpr_shadow = 1 << 3
+        vapic_feature_virt_access = 1 << 0
+        vapic_feature_vx2apic_mode = 1 << 5
+        vapic_feature_virt_reg = 1 << 1
+        vapic_feature_intr_delivery = 1 << 2
+        vapic_feature_post_intr = 1 << 4
+
+        if msrfield.is_ctrl_setting_allowed(self.value, 1 << 21):
+            features |= vapic_feature_tpr_shadow
+
+        msr_val = MSR_IA32_VMX_PROCBASED_CTLS2.rdmsr(self.cpu_id)
+        if msrfield.is_ctrl_setting_allowed(msr_val.value, 1 << 0):
+            features |= vapic_feature_virt_access
+        if msrfield.is_ctrl_setting_allowed(msr_val.value, 1 << 4):
+            features |= vapic_feature_vx2apic_mode
+        if msrfield.is_ctrl_setting_allowed(msr_val.value, 1 << 8):
+            features |= vapic_feature_virt_reg
+        if msrfield.is_ctrl_setting_allowed(msr_val.value, 1 << 9):
+            features |= vapic_feature_intr_delivery
+
+        msr_val = MSR_IA32_VMX_PINBASED_CTLS.rdmsr(self.cpu_id)
+        if msrfield.is_ctrl_setting_allowed(msr_val.value, 1 << 7):
+            features |= vapic_feature_post_intr
+
+        apicv_basic_feature = (vapic_feature_tpr_shadow | vapic_feature_virt_access | vapic_feature_vx2apic_mode)
+        return (features & apicv_basic_feature) == apicv_basic_feature
+
+    capability_bits = [
+        "ept",
+        "apicv",
+        "vmx_procbased_ctls_tsc_off",
+        "vmx_procbased_ctls_tpr_shadow",
+        "vmx_procbased_ctls_io_bitmap",
+        "vmx_procbased_ctls_msr_bitmap",
+        "vmx_procbased_ctls_hlt",
+        "vmx_procbased_ctls_secondary",
+    ]
+
+class MSR_IA32_VMX_EPT_VPID_CAP(MSR):
+    addr = 0x0000048C
+
+    invept = msrfield(1, 20)
+    ept_2mb_page = msrfield(1, 16)
+    vmx_ept_1gb_page = msrfield(1, 17)
+    invvpid = msrfield(1, 32) and msrfield(1, 41) and msrfield(1, 42)
+
+    capability_bits = [
+        "invept",
+        "invvpid",
+        "ept_2mb_page",
+        "vmx_ept_1gb_page",
+    ]
+
+class MSR_IA32_VMX_MISC(MSR):
+    addr = 0x00000485
+    unrestricted_guest = msrfield(1, 5)
+
+    capability_bits = [
+        "unrestricted_guest",
+    ]
+
+class MSR_IA32_VMX_BASIC(MSR):
+    addr = 0x00000480
+    set_32bit_addr_width = msrfield(1, 48)
+
+    capability_bits = [
+        "set_32bit_addr_width",
+    ]
+
+class MSR_IA32_VMX_EXIT_CTLS(MSR):
+    addr = 0x00000483
+
+    @property
+    def vmx_exit_ctls_ack_irq(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 15)
+
+    @property
+    def vmx_exit_ctls_save_pat(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 18)
+
+    @property
+    def vmx_exit_ctls_load_pat(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 19)
+
+    @property
+    def vmx_exit_ctls_host_addr64(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 9)
+
+    capability_bits = [
+        "vmx_exit_ctls_ack_irq",
+        "vmx_exit_ctls_save_pat",
+        "vmx_exit_ctls_load_pat",
+        "vmx_exit_ctls_host_addr64",
+    ]
+
+class MSR_IA32_VMX_ENTRY_CTLS(MSR):
+    addr = 0x00000484
+
+    @property
+    def vmx_entry_ctls_load_pat(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 14)
+
+    @property
+    def vmx_entry_ctls_ia32e_mode(self):
+        return msrfield.is_vmx_cap_supported(self, 1 << 9)
+
+    capability_bits = [
+        "vmx_entry_ctls_load_pat",
+        "vmx_entry_ctls_ia32e_mode",
+    ]

--- a/misc/config_tools/board_inspector/cpuparser/msr.py
+++ b/misc/config_tools/board_inspector/cpuparser/msr.py
@@ -13,6 +13,19 @@ class MSR_IA32_MISC_ENABLE(MSR):
         "fast_string",
     ]
 
+class MSR_IA32_FEATURE_CONTROL(MSR):
+    addr = 0x03a
+    msr_ia32_feature_control_lock = msrfield(1, 0, doc=None)
+    msr_ia32_feature_control_vmx_no_smx = msrfield(1, 2, doc=None)
+
+    @property
+    def disable_vmx(self):
+        return self.msr_ia32_feature_control_lock and not self.msr_ia32_feature_control_vmx_no_smx
+
+    capability_bits = [
+        "disable_vmx",
+    ]
+
 class MSR_IA32_VMX_PROCBASED_CTLS2(MSR):
     addr = 0x0000048B
 

--- a/misc/config_tools/board_inspector/extractors/10-processors.py
+++ b/misc/config_tools/board_inspector/extractors/10-processors.py
@@ -53,9 +53,10 @@ def extract_model(processors_node, cpu_id, family_id, model_id, core_type, nativ
                 if getattr(leaf_data, cap) == 1:
                     add_child(n, "capability", id=cap)
 
-        msr_regs = [MSR_IA32_MISC_ENABLE, MSR_IA32_VMX_BASIC, MSR_IA32_VMX_PINBASED_CTLS,
-                    MSR_IA32_VMX_PROCBASED_CTLS, MSR_IA32_VMX_EXIT_CTLS, MSR_IA32_VMX_ENTRY_CTLS,
-                    MSR_IA32_VMX_MISC, MSR_IA32_VMX_PROCBASED_CTLS2, MSR_IA32_VMX_EPT_VPID_CAP]
+        msr_regs = [MSR_IA32_MISC_ENABLE, MSR_IA32_FEATURE_CONTROL, MSR_IA32_VMX_BASIC,
+                    MSR_IA32_VMX_PINBASED_CTLS, MSR_IA32_VMX_PROCBASED_CTLS, MSR_IA32_VMX_EXIT_CTLS,
+                    MSR_IA32_VMX_ENTRY_CTLS, MSR_IA32_VMX_MISC, MSR_IA32_VMX_PROCBASED_CTLS2,
+                    MSR_IA32_VMX_EPT_VPID_CAP]
         for msr_reg in msr_regs:
             msr_data = msr_reg.rdmsr(cpu_id)
             for cap in msr_data.capability_bits:

--- a/misc/config_tools/board_inspector/inspectorlib/validator.py
+++ b/misc/config_tools/board_inspector/inspectorlib/validator.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 Intel Corporation.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import sys, os
+import argparse
+import lxml.etree as etree
+import logging
+import xmlschema
+
+logging_fn = {
+    "error": logging.error,
+    "warning": logging.warning,
+    "info": logging.info,
+}
+
+def validate_board(xsd_path, board_etree):
+    schema_etree = etree.parse(xsd_path)
+    schema_etree.xinclude()
+    schema = xmlschema.XMLSchema11(schema_etree)
+
+    it = schema.iter_errors(board_etree)
+    count = 0
+    for error in it:
+        anno = error.validator.annotation
+        severity = anno.elem.get("{https://projectacrn.org}severity")
+        description = anno.elem.find("{http://www.w3.org/2001/XMLSchema}documentation").text
+        logging_fn[severity](description)
+        if severity in ["error", "warning"]:
+            count += 1
+
+    return count

--- a/misc/config_tools/board_inspector/schema/boardchecks.xsd
+++ b/misc/config_tools/board_inspector/schema/boardchecks.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<xs:schema
+    xmlns:xi="http://www.w3.org/2003/XInclude"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:element name="acrn-config">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:any processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:anyAttribute processContents="skip"/>
+
+      <xi:include href="checks/platform_capabilities.xsd" xpointer="xpointer(id('root')/*)" />
+
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/misc/config_tools/board_inspector/schema/checks/platform_capabilities.xsd
+++ b/misc/config_tools/board_inspector/schema/checks/platform_capabilities.xsd
@@ -3,6 +3,27 @@
 	   xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	   xmlns:acrn="https://projectacrn.org">
 
+  <xs:assert test="contains(//DRHD_INFO[text()], 'DRHD0')">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>Intel Virtualization Technology for Directed I/O (VT-d) feature is not enabled.
+ACRN requires this feature to function properly. Please enable it in your BIOS settings.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="//processors//core[count(thread) = 1]">
+    <xs:annotation acrn:severity="warning">
+      <xs:documentation>Hyper-Threading (HT) is enabled. While this feature can provide more overall processing power,
+hyperthreading can adversely impact predictable real-time performance behavior.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies not($model/capability[@id='disable_vmx'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>Virtual Machine Extensions (VMX) feature is not enabled.
+ACRN requires this feature to function properly. Please enable it in BIOS.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
   <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx'])">
     <xs:annotation acrn:severity="error">
       <xs:documentation>Virtual Machine Extensions (VMX) feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>

--- a/misc/config_tools/board_inspector/schema/checks/platform_capabilities.xsd
+++ b/misc/config_tools/board_inspector/schema/checks/platform_capabilities.xsd
@@ -5,7 +5,262 @@
 
   <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx'])">
     <xs:annotation acrn:severity="error">
-      <xs:documentation>Intel(R) Virtualization Technology Extension shall be enabled in BIOS.</xs:documentation>
+      <xs:documentation>Virtual Machine Extensions (VMX) feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='intel_64'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>Long mode (x86-64, 64-bit) feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies not($model/capability[@id='set_32bit_addr_width'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>The width of the physical addresses used for the VMXON region is limited to 32bit. "Intel 64 architecture" feature is not enabled. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies compare($model/attribute[@id='cpuid_level'], '0x15') &gt;= 0">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>Instruction CPUID time stamp counter, nominal core crystal clock information leaf and processor frequency information leaf are not supported. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model
+	  satisfies (($model/attribute[@id='physical_address_bits']) != 0 and ($model/attribute[@id='linear_address_bits']) != 0)">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>"Zero linear/physical address size" feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model
+	  satisfies not(($model/attribute[@id='physical_address_bits']) > 39 and (not($model/capability[@id='gbyte_pages'])
+	  or not($model/capability[@id='vmx_ept_1gb_page'])))">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>"1GB large page(Physical-address width > 39)" feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='fast_string'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>"Fast string" feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='erms'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>Enhanced rep movsb/stosb feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='invariant_tsc'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>Invariant TSC feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='tsc_deadline'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>TSC deadline feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='execute_disable'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>NX feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='smep'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>SMEP feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='smap'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>SMAP feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='mtrr'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>MTRR feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='clflushopt'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>CLFLUSHOPT feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='x2apic'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>x2APIC feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='popcnt'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>POPCNT feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='sse'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>SSE feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='rdrand'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>RDRAND feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='invept'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>INVEPT is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='unrestricted_guest'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>Unrestricted guest is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='ept'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>EPT feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='ept_2mb_page'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>EPT does not support 2MB large pages on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='invvpid'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>INVVPID feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='apicv'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>APICV feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_pinbased_ctls_irq_exit'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability External-interrupt exiting for VM execution controls feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_procbased_ctls_tsc_off'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability Use TSC offsetting for VM execution controls feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_procbased_ctls_tpr_shadow'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability Use TPR shadow for VM execution controls feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_procbased_ctls_io_bitmap'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability Use I/O bitmaps for VM execution controls feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_procbased_ctls_msr_bitmap'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability Use MSR bitmaps for VM execution controls feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_procbased_ctls_hlt'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability HLT exiting for VM execution controls feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_procbased_ctls_secondary'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability Activate secondary controls for VM execution controls feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_exit_ctls_ack_irq'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability acknowledge interrupt on exit feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_exit_ctls_save_pat'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability save IA32_PAT on VM exit feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_exit_ctls_load_pat'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability load IA32_PAT on VM exit feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_exit_ctls_host_addr64'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability Host address-space size on VM exit feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_entry_ctls_load_pat'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability IA32_PAT MSR load on VM entry feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_entry_ctls_ia32e_mode'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability IA-32e mode guest support after VM entry feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_procbased_ctls2_vapic'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability Virtualize APIC accesses for VM execution controls feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_procbased_ctls2_ept'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability Enable EPT for VM execution controls feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_procbased_ctls2_vpid'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability Enable VPID for VM execution controls feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_procbased_ctls2_rdtscp'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability Enable RDTSCP for VM execution controls feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx_procbased_ctls2_unrestrict'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>VMX capability Unrestricted guest for VM execution controls feature is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
     </xs:annotation>
   </xs:assert>
 

--- a/misc/config_tools/board_inspector/schema/checks/platform_capabilities.xsd
+++ b/misc/config_tools/board_inspector/schema/checks/platform_capabilities.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<xs:schema xml:id="root"
+	   xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	   xmlns:acrn="https://projectacrn.org">
+
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='vmx'])">
+    <xs:annotation acrn:severity="error">
+      <xs:documentation>Intel(R) Virtualization Technology Extension shall be enabled in BIOS.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+</xs:schema>


### PR DESCRIPTION
1. Add BIOS invalid setting check
I) check if VMX feature is enabled in the BIOS setting. If disabled, the board inspector will show an error message.
II)  check if Hyper-Threading is enabled in the BIOS setting. If enabled, the board inspector will show the warning message.
III) check if VT-d is enabled in the BIOS setting. If disabled, the board inspector will show an error message.

2. Add CPU capability checks.
If a feature is not supported on this processor, the board inspector will show an error message because it would impact ACRN’s ability to function properly.