### PR TITLE
hv: mmio: replace hi_mmio with mmio64

### DIFF
--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -294,12 +294,12 @@ void init_paging(void)
 		pgtable_add_map((uint64_t *)ppt_mmu_pml4_addr, high64_min_ram, high64_min_ram,
 				high64_max_ram - high64_min_ram, PAGE_ATTR_USER | PAGE_CACHE_WB, &ppt_pgtable);
 	}
-	/* Map [low32_max_ram, 4G) and [HI_MMIO_START, HI_MMIO_END) MMIO regions as UC attribute */
+	/* Map [low32_max_ram, 4G) and [MMIO64_START, MMIO64_END) MMIO regions as UC attribute */
 	pgtable_add_map((uint64_t *)ppt_mmu_pml4_addr, low32_max_ram, low32_max_ram,
 		MEM_4G - low32_max_ram, PAGE_ATTR_USER | PAGE_CACHE_UC, &ppt_pgtable);
-	if ((HI_MMIO_START != ~0UL) && (HI_MMIO_END != 0UL)) {
-		pgtable_add_map((uint64_t *)ppt_mmu_pml4_addr, HI_MMIO_START, HI_MMIO_START,
-			(HI_MMIO_END - HI_MMIO_START), PAGE_ATTR_USER | PAGE_CACHE_UC, &ppt_pgtable);
+	if ((MMIO64_START != ~0UL) && (MMIO64_END != 0UL)) {
+		pgtable_add_map((uint64_t *)ppt_mmu_pml4_addr, MMIO64_START, MMIO64_START,
+			(MMIO64_END - MMIO64_START), PAGE_ATTR_USER | PAGE_CACHE_UC, &ppt_pgtable);
 	}
 
 	/*


### PR DESCRIPTION
Now HI_MMIO_xxx is duplicate with MMIO64_xxx. This patch replace HI_MMIO_xxx
with MMIO64_xxx.

Tracked-On: #6011
Signed-off-by: Fei Li <fei1.li@intel.com>