### PR TITLE
Extract available PCI devices and serials from board XML

### DIFF
--- a/misc/config_tools/board_inspector/board_inspector.py
+++ b/misc/config_tools/board_inspector/board_inspector.py
@@ -102,6 +102,7 @@ def main(board_name, board_xml, args):
         root_node.append(lxml.etree.Element("memory"))
         root_node.append(lxml.etree.Element("ioapics"))
         root_node.append(lxml.etree.Element("devices"))
+        root_node.append(lxml.etree.Element("device-classes"))
 
         extractors_path = os.path.join(script_dir, "extractors")
         extractors = [f for f in os.listdir(extractors_path) if f[:2].isdigit()]

--- a/misc/config_tools/board_inspector/extractors/70-device-classes.py
+++ b/misc/config_tools/board_inspector/extractors/70-device-classes.py
@@ -7,35 +7,50 @@ import re, os
 import logging
 from extractors.helpers import add_child, get_node
 
-SYS_DEVICES_CLASS_PATH = "/sys/class/input/"
+SYS_INPUT_DEVICES_CLASS_PATH = "/sys/class/input/"
+SYS_TTY_DEVICES_CLASS_PATH = "/sys/class/tty/"
+
+def add_child_with_file_contents(parent_node, tag, filepath, translations = {}):
+    try:
+        with open(filepath, "r") as f:
+            res = f.read().strip()
+            if res in translations.keys():
+                add_child(parent_node, tag, translations[res])
+            else:
+                add_child(parent_node, tag, res)
+    except Exception as e:
+        logging.warning(f"Failed to read the data from {filepath}: {e}")
 
 def get_input_ids():
     input_ids = list()
     root_regex = re.compile("input([0-9]+)")
-    for root in filter(lambda x: x.startswith("input"), os.listdir(SYS_DEVICES_CLASS_PATH)):
+    for root in filter(lambda x: x.startswith("input"), os.listdir(SYS_INPUT_DEVICES_CLASS_PATH)):
         m = root_regex.match(root)
         if m:
             input_ids.append(int(m.group(1)))
     return sorted(input_ids)
 
-def extract_topology(device_classes_node):
+def extract_inputs(device_classes_node):
     inputs_node = add_child(device_classes_node, "inputs", None)
     input_ids = get_input_ids()
     for id in input_ids:
         input_node = add_child(inputs_node, "input", None)
-        try:
-            with open("/sys/class/input/input{}/name".format(id), "r") as f:
-                res = f.read().strip()
-                add_child(input_node, "name", res)
-        except Exception as e:
-            logging.warning(f"Failed to read the data of /sys/class/input/input{id}/name: {e}")
+        add_child_with_file_contents(input_node, "name", f"/sys/class/input/input{id}/name")
+        add_child_with_file_contents(input_node, "phys", f"/sys/class/input/input{id}/phys")
 
-        try:
-            with open("/sys/class/input/input{}/phys".format(id), "r") as f:
-                res = f.read().strip()
-                add_child(input_node, "phys", res)
-        except Exception as e:
-            logging.warning(f"Failed to read the data of /sys/class/input/input{id}/phys: {e}")
+def get_serial_devs():
+    return sorted(filter(lambda x: x.startswith("ttyS"), os.listdir(SYS_TTY_DEVICES_CLASS_PATH)), key=lambda x:int(x[4:]))
+
+def extract_ttys(device_classes_node):
+    ttys_node = add_child(device_classes_node, "ttys", None)
+    for serial_dev in get_serial_devs():
+        serial_node = add_child(ttys_node, "serial")
+        add_child(serial_node, "dev_path", f"/dev/{serial_dev}")
+        add_child_with_file_contents(serial_node, "type", f"{SYS_TTY_DEVICES_CLASS_PATH}{serial_dev}/type")
+
+def extract_topology(device_classes_node):
+    extract_inputs(device_classes_node)
+    extract_ttys(device_classes_node)
 
 def extract(args, board_etree):
     device_classes_node = get_node(board_etree, "//device-classes")

--- a/misc/config_tools/board_inspector/extractors/70-device-classes.py
+++ b/misc/config_tools/board_inspector/extractors/70-device-classes.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2022 Intel Corporation.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import re, os
+import logging
+from extractors.helpers import add_child, get_node
+
+SYS_DEVICES_CLASS_PATH = "/sys/class/input/"
+
+def get_input_ids():
+    input_ids = list()
+    root_regex = re.compile("input([0-9]+)")
+    for root in filter(lambda x: x.startswith("input"), os.listdir(SYS_DEVICES_CLASS_PATH)):
+        m = root_regex.match(root)
+        if m:
+            input_ids.append(int(m.group(1)))
+    return sorted(input_ids)
+
+def extract_topology(device_classes_node):
+    inputs_node = add_child(device_classes_node, "inputs", None)
+    input_ids = get_input_ids()
+    for id in input_ids:
+        input_node = add_child(inputs_node, "input", None)
+        try:
+            with open("/sys/class/input/input{}/name".format(id), "r") as f:
+                res = f.read().strip()
+                add_child(input_node, "name", res)
+        except Exception as e:
+            logging.warning(f"Failed to read the data of /sys/class/input/input{id}/name: {e}")
+
+        try:
+            with open("/sys/class/input/input{}/phys".format(id), "r") as f:
+                res = f.read().strip()
+                add_child(input_node, "phys", res)
+        except Exception as e:
+            logging.warning(f"Failed to read the data of /sys/class/input/input{id}/phys: {e}")
+
+def extract(args, board_etree):
+    device_classes_node = get_node(board_etree, "//device-classes")
+    extract_topology(device_classes_node)

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -222,7 +222,8 @@ CLOSID 0 and the second is mapped to virtual CLOSID 1, etc.</xs:documentation>
 <xs:complexType name="PCIDevsConfiguration">
   <xs:sequence>
     <xs:element name="pci_dev" type="xs:string" minOccurs="0" maxOccurs="unbounded">
-      <xs:annotation acrn:title="PCI device assignment">
+      <xs:annotation acrn:title="PCI device assignment"
+		     acrn:options="//device[class]/@description" acrn:options-sorted-by="lambda s: (s.split(' ', maxsplit=1)[-1].split(':')[0], s.split(' ')[0])">
         <xs:documentation>Select the PCI devices you want to assign to this virtual machine.</xs:documentation>
       </xs:annotation>
     </xs:element>

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -19,7 +19,8 @@
       </xs:annotation>
     </xs:element>
     <xs:element name="SERIAL_CONSOLE" type="SerialConsoleOptions">
-      <xs:annotation acrn:title="Serial console port" acrn:views="basic">
+      <xs:annotation acrn:title="Serial console port" acrn:views="basic"
+		     acrn:options="//ttys/serial[type != '0']/dev_path/text()">
         <xs:documentation>Select the host serial device used for hypervisor debugging.</xs:documentation>
       </xs:annotation>
     </xs:element>


### PR DESCRIPTION
This patch adds data into board XML that enables the extraction of available PCI devices or serial ports using XPATH which are encoded in the XML schema as well. This helps the next-generation configurator to automatically pick to options from board XMLs.