### PR TITLE
misc: set PMU_PT flag for pre-launched RTVM

### DIFF
--- a/misc/config_tools/static_allocators/guest_flags.py
+++ b/misc/config_tools/static_allocators/guest_flags.py
@@ -22,6 +22,7 @@ policies = [
     GuestFlagPolicy(".//nested_virtualization_support = 'y'", "GUEST_FLAG_NVMX_ENABLED"),
     GuestFlagPolicy(".//security_vm = 'y'", "GUEST_FLAG_SECURITY_VM"),
     GuestFlagPolicy(".//vm_type = 'RTVM'", "GUEST_FLAG_RT"),
+    GuestFlagPolicy(".//vm_type = 'RTVM' and .//load_order = 'PRE_LAUNCHED_VM'", "GUEST_FLAG_PMU_PASSTHROUGH"),
     GuestFlagPolicy(".//vm_type = 'TEE_VM'", "GUEST_FLAG_TEE"),
     GuestFlagPolicy(".//vm_type = 'REE_VM'", "GUEST_FLAG_REE"),
 ]


### PR DESCRIPTION
For post-launched RTVM, the acrn-dm can own PMU_PASSTHROUGH flag; for
pre-launched RTVM, need set it in configuration file by default.

Tracked-On: #6966
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Signed-off-by: Minggui Cao <minggui.cao@intel.com>