### PR TITLE
config_tools: remove board and scenario attribute

### DIFF
--- a/hypervisor/scripts/makefile/config.mk
+++ b/hypervisor/scripts/makefile/config.mk
@@ -204,6 +204,9 @@ $(HV_SCENARIO_XML):
 	    echo "Scenario XML is being fetched from $(realpath $(SCENARIO_FILE))"; \
 	    mkdir -p $(dir $(HV_SCENARIO_XML)); \
 	    python3 $(HV_CONFIG_TOOL_DIR)/scenario_config/default_populator.py $(SCENARIO_FILE) $(HV_SCENARIO_XML); \
+	    if [ -z $$(xmllint --xpath 'string(//@scenario)' $(HV_SCENARIO_XML)) ]; then \
+	      sed "s#<acrn-config#<acrn-config scenario=\"$(subst .xml,,$(notdir $(SCENARIO_FILE)))\"#g" -i $(HV_SCENARIO_XML); \
+	    fi; \
 	  else \
 	    echo "No pre-defined scenario available at $(SCENARIO_FILE)"; \
 	    echo "Try setting another predefined BOARD or SCENARIO or specifying a scenario XML file"; \

--- a/misc/config_tools/board_config/board_cfg_gen.py
+++ b/misc/config_tools/board_config/board_cfg_gen.py
@@ -59,12 +59,6 @@ def main(args):
         return err_dic
     board_cfg_lib.BOARD_NAME = board
 
-    # check if this is the scenario config which matched board info
-    (err_dic, status) = common.is_config_file_match()
-    if not status:
-        err_dic['board config'] = "The board xml file does not match scenario xml file!"
-        return err_dic
-
     output = ''
     if params['--out']:
         if os.path.isabs(params['--out']):

--- a/misc/config_tools/library/common.py
+++ b/misc/config_tools/library/common.py
@@ -248,17 +248,6 @@ def get_scenario_name():
     return (err_dic, scenario)
 
 
-def is_config_file_match():
-
-    (err_dic, scenario_for_board) = get_xml_attrib(SCENARIO_INFO_FILE, "board")
-    (err_dic, board_name) = get_xml_attrib(BOARD_INFO_FILE, "board")
-
-    if scenario_for_board == board_name:
-        return (err_dic, True)
-    else:
-        return (err_dic, False)
-
-
 def find_tmp_flag(flag):
     """
     Find the index in GUEST_FLAG by flag

--- a/misc/config_tools/library/launch_cfg_lib.py
+++ b/misc/config_tools/library/launch_cfg_lib.py
@@ -180,25 +180,6 @@ def get_post_vm_cnt():
     return (launch_vm_count, post_vm_count)
 
 
-def is_config_file_match():
-
-    match = True
-    # check if the board config match scenario config
-    (err_dic, scenario_for_board) = common.get_xml_attrib(common.SCENARIO_INFO_FILE, "board")
-    (err_dic, board_name) = common.get_xml_attrib(common.BOARD_INFO_FILE, "board")
-    if scenario_for_board != board_name:
-        err_dic['scenario config'] = "The board xml file does not match scenario xml file!"
-        match = False
-
-    # check if the board config match launch config
-    (err_dic, launch_for_board) = common.get_xml_attrib(common.LAUNCH_INFO_FILE, "board")
-    if launch_for_board != board_name:
-        err_dic['launch config'] = "The board xml file does not match scenario xml file!"
-        match = False
-
-    return (err_dic, match)
-
-
 def get_sos_vmid():
 
     sos_id = ''

--- a/misc/config_tools/scenario_config/scenario_cfg_gen.py
+++ b/misc/config_tools/scenario_config/scenario_cfg_gen.py
@@ -214,12 +214,6 @@ def main(args):
                               "Now this value is {}.".format(common.MAX_VM_NUM)
         return err_dic
 
-    # check if this is the scenario config which matches board info
-    (err_dic, status) = common.is_config_file_match()
-    if not status:
-        err_dic['scenario config'] = "The board xml file does not match scenario xml file!"
-        return err_dic
-
     if params['--out']:
         if os.path.isabs(params['--out']):
             scen_output = params['--out'] + "/scenarios/" + scenario + "/"

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -489,8 +489,8 @@ to launch post-launched User VMs.</xs:documentation>
       <xs:alternative test=".//load_order = 'POST_LAUNCHED_VM'" type="VMConfigType" />
     </xs:element>
   </xs:all>
-  <xs:attribute name="board" type="xs:string" use="required" />
-  <xs:attribute name="scenario" type="xs:string" use="required" />
+  <xs:attribute name="board" type="xs:string" />
+  <xs:attribute name="scenario" type="xs:string" />
 </xs:complexType>
 
 <xs:element name="acrn-config" type="ACRNConfigType">


### PR DESCRIPTION
remove BOARD/SCENARIO attribute dependency for the new configuration.

To do:
will remove all BOARD/SCENARIO attributes in all scenario XML files
and update the upgrader.py after the new configuration works.

Tracked-On: #6690
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>
Reviewed-by: Junjie Mao <[junjie.mao@intel.com](mailto:junjie.mao@intel.com)>