### PR TITLE
config-tools: fix the generation of DM-land ivshmem regions

### DIFF
--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -237,7 +237,7 @@ def generate_for_one_vm(board_etree, hv_scenario_etree, vm_scenario_etree, vm_id
     # Emulated PCI devices
     script.add_virtual_device("hostbridge", vbdf="0:0")
 
-    for ivshmem in eval_xpath_all(vm_scenario_etree, "//IVSHMEM_REGION[PROVIDED_BY = 'Device model' and .//VM_NAME = 'vm_name']"):
+    for ivshmem in eval_xpath_all(vm_scenario_etree, f"//IVSHMEM_REGION[PROVIDED_BY = 'Device Model' and .//VM_NAME = '{vm_name}']"):
         script.add_virtual_device("ivshmem", options=f"dm:/{ivshmem.find('NAME').text},{ivshmem.find('IVSHMEM_SIZE').text}")
 
     if eval_xpath(vm_scenario_etree, ".//console_vuart/text()") == "PCI":


### PR DESCRIPTION
The device-model land ivshmem regions are not properly generated into the launch
scripts today because:

  1. Those regions are provided by "Device Model", not "Device model".

  2. VM names are not properly encoded in the XPATH that search for the
     ivshmem regions accessible to a VM.

This patch fixes both issues.

Fixes: 0d84ecc4a ("config_tools: merge data in launch XMLs into scenario XMLs")
Tracked-On: #6690
Signed-off-by: Junjie Mao <junjie.mao@intel.com>