### PR TITLE
Vgpu dmabuf

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -43,6 +43,7 @@ CFLAGS += -I$(SYSROOT)/usr/include/pixman-1
 CFLAGS += -I$(SYSROOT)/usr/include/glib-2.0
 CFLAGS += -I$(SYSROOT)/usr/include/SDL2
 CFLAGS += -I$(SYSROOT)/usr/include/EGL
+CFLAGS += -I$(SYSROOT)/usr/include/GLES2
 
 ifneq (, $(DM_ASL_COMPILER))
 CFLAGS += -DASL_COMPILER=\"$(DM_ASL_COMPILER)\"
@@ -89,6 +90,8 @@ LIBS += -lcjson
 LIBS += -lpixman-1
 LIBS += -lSDL2
 LIBS += -lEGL
+LIBS += -lGLESv2
+
 
 # lib
 SRCS += lib/dm_string.c

--- a/devicemodel/core/hugetlb.c
+++ b/devicemodel/core/hugetlb.c
@@ -42,6 +42,8 @@
 
 extern char *vmname;
 
+#define ALIGN_CHECK(x, align)	(((x) & ((align)-1)) ? 1 : 0)
+
 #define HUGETLB_LV1		0
 #define HUGETLB_LV2		1
 #define HUGETLB_LV_MAX		2
@@ -718,6 +720,13 @@ int hugetlb_setup_memory(struct vmctx *ctx)
 		}
 	}
 
+	if (ALIGN_CHECK(ctx->lowmem, hugetlb_priv[HUGETLB_LV1].pg_size) ||
+		ALIGN_CHECK(ctx->highmem, hugetlb_priv[HUGETLB_LV1].pg_size) ||
+		ALIGN_CHECK(ctx->biosmem, hugetlb_priv[HUGETLB_LV1].pg_size) ||
+		ALIGN_CHECK(ctx->fbmem, hugetlb_priv[HUGETLB_LV1].pg_size)) {
+		pr_err("Memory size is not aligned to 2M.\n");
+		goto err;
+	}
 	/* all memory should be at least aligned with
 	 * hugetlb_priv[HUGETLB_LV1].pg_size */
 	ctx->lowmem =

--- a/devicemodel/core/hugetlb.c
+++ b/devicemodel/core/hugetlb.c
@@ -881,3 +881,35 @@ vm_find_memfd_region(struct vmctx *ctx, vm_paddr_t gpa,
 
 	return ret;
 }
+
+bool vm_allow_dmabuf(struct vmctx *ctx)
+{
+	uint32_t mem_flags;
+
+	mem_flags = 0;
+	if (ctx->highmem) {
+		/* Check the highmem is used by HUGETLB_LV1/HUGETLB_LV2 */
+		if ((hugetlb_priv[HUGETLB_LV1].fd > 0) &&
+			(hugetlb_priv[HUGETLB_LV1].highmem))
+			mem_flags |= 1;
+		if ((hugetlb_priv[HUGETLB_LV2].fd > 0) &&
+			(hugetlb_priv[HUGETLB_LV2].highmem))
+			mem_flags |= 0x02;
+		if (mem_flags == 0x03)
+			return false;
+	}
+
+	if (ctx->lowmem) {
+		/* Check the lowhmem is used by HUGETLB_LV1/HUGETLB_LV2 */
+		mem_flags = 0;
+		if ((hugetlb_priv[HUGETLB_LV1].fd > 0) &&
+			(hugetlb_priv[HUGETLB_LV1].lowmem))
+			mem_flags |= 1;
+		if ((hugetlb_priv[HUGETLB_LV2].fd > 0) &&
+			(hugetlb_priv[HUGETLB_LV2].lowmem))
+			mem_flags |= 0x02;
+		if (mem_flags == 0x03)
+			return false;
+	}
+	return true;
+}

--- a/devicemodel/include/vdisplay.h
+++ b/devicemodel/include/vdisplay.h
@@ -64,6 +64,10 @@ struct surface {
 	uint32_t bpp;
 	uint32_t stride;
 	void *pixel;
+	struct  {
+		int dmabuf_fd;
+		uint32_t surf_fourcc;
+	} dma_info;
 };
 
 struct cursor {

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -95,6 +95,7 @@ struct vm_mem_region {
 };
 bool	vm_find_memfd_region(struct vmctx *ctx, vm_paddr_t gpa,
 			     struct vm_mem_region *ret_region);
+bool    vm_allow_dmabuf(struct vmctx *ctx);
 /*
  * Create a device memory segment identified by 'segid'.
  *

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -89,6 +89,12 @@ struct vm_isa_irq {
 	int		ioapic_irq;
 };
 
+struct vm_mem_region {
+	uint64_t fd_offset;
+	int fd;
+};
+bool	vm_find_memfd_region(struct vmctx *ctx, vm_paddr_t gpa,
+			     struct vm_mem_region *ret_region);
 /*
  * Create a device memory segment identified by 'segid'.
  *


### PR DESCRIPTION
Now Virtio-gpu FE is using the below cmds to submit the framebuffer that
needs to be displayed.
   VIRTIO_GPU_CMD_TRANSFER_TO_HOST_2D
   VIRTIO_GPU_CMD_SET_SCANOUT
   VIRTIO_GPU_CMD_FLUSH

This will introduce twice copy. It will affect the CPU usage, memory resource.

In order to optimize the twice copy, this patch set tries to add the support
of zero-copy based on dmabuf-sharing.
The key of zero-copy depends on the DMABuf and eglCreateImageKHR from dmabuf.
In order to create dmabuf based on the GPA addr of virtio-gpu framebuf, the memory
allocation for guest_vm should be based on memfd. This requires that the memory
for guest_vm should be allocated from memfd instead of explicit hugetlb file.
