### PR TITLE
doc: fix exception error in last_modified processing

### DIFF
--- a/doc/extensions/last_updated.py
+++ b/doc/extensions/last_updated.py
@@ -65,13 +65,13 @@ def _not_git_repo(dir):
 def _get_last_updated_from_git(file_path, git_repo, doc_root):
 
     rel_path = os.path.relpath(file_path, doc_root)
+    time_format = "%Y-%m-%d"
 
     for git_repo_path in git_repo:
 
         new_path = os.path.join(git_repo_path, rel_path)
         if os.path.isfile(new_path):
             try:
-                    time_format = "%Y-%m-%d"
                     output=subprocess.check_output(
                         f'git --no-pager log -1 --date=format:"{time_format}" --pretty="format:%cd" {new_path}',
                         shell=True, cwd=git_repo_path)
@@ -80,8 +80,11 @@ def _get_last_updated_from_git(file_path, git_repo, doc_root):
                     # folder on the list
                     continue
             else:
+                try:
                     last_updated = datetime.strptime(output.decode('utf-8'), time_format).date()
                     return last_updated
+                except:
+                    continue
         else:
             continue
 


### PR DESCRIPTION
When I added a new document that wasn't checked into GitHub yet, the doc
build failed with an unhanded exception:

    Extension error (last_updated):
    (exception: time data '' does not match format '%Y-%m-%d')

Problem is the git query looking up the last commit date for a file
returns an empty string for the date if the file exists but it's not in
the git repo (yet). The subsequent call to strptime raises an exception if passed
an empty string.  This patch handles the exception.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>