### PR TITLE
doc: fix Makefile to report errors if exception raised

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -60,16 +60,16 @@ content:
 html: content doxy
 	@echo making HTML content
 	$(Q)./scripts/show-versions.py
-	$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html -d $(BUILDDIR)/doctrees $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(OPTS) >> $(BUILDDIR)/doc.log 2>&1
+	-$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html -d $(BUILDDIR)/doctrees $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(OPTS) >> $(BUILDDIR)/doc.log 2>&1
 	$(Q)./scripts/filter-doc-log.sh $(BUILDDIR)/doc.log
 
 singlehtml: content doxy
-	$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b singlehtml -d $(BUILDDIR)/doctrees $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(OPTS) >> $(BUILDDIR)/doc.log 2>&1
+	-$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b singlehtml -d $(BUILDDIR)/doctrees $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(OPTS) >> $(BUILDDIR)/doc.log 2>&1
 	$(Q)./scripts/filter-doc-log.sh $(BUILDDIR)/doc.log
 
 pdf: html
 	@echo now making $(BUILDDIR)/latex/acrn.pdf
-	$(Q)make -silent latexpdf LATEXMKOPTS=$(LATEXMKOPTS) >> $(BUILDDIR)/doc.log 2>&1
+	-$(Q)make -silent latexpdf LATEXMKOPTS=$(LATEXMKOPTS) >> $(BUILDDIR)/doc.log 2>&1
 	$(Q)./scripts/filter-doc-log.sh $(BUILDDIR)/doc.log
 
 


### PR DESCRIPTION
We use a post-processor to scan the output log from Sphinx to remove
known errors and warnings before deciding if the Sphinx build was
successful.  If an exception happened during the Sphinx build, (see
about the error would appear.  Update the Makefile to not stop on errors
for the Sphinx build. The post-processor will stop the make by returning
an error code if it finds unexpected errors in the log.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>