### PR TITLE
config_tools: fix the issue that fail to read XSD file

### DIFF
--- a/misc/config_tools/board_inspector/board_inspector.py
+++ b/misc/config_tools/board_inspector/board_inspector.py
@@ -116,7 +116,7 @@ def main(board_name, board_xml, args):
             module.extract(args, board_etree)
 
         # Validate the XML against XSD assertions
-        count = validator.validate_board("schema/boardchecks.xsd", board_etree)
+        count = validator.validate_board(os.path.join(script_dir, 'schema', 'boardchecks.xsd'), board_etree)
         if count == 0:
             logging.info("All board checks passed.")
 


### PR DESCRIPTION
fix the path issue that fail to read XSD file.

Tracked-On: #6689
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>