### PR TITLE
doc: handle last updated footer for new document

### DIFF
--- a/doc/extensions/last_updated.py
+++ b/doc/extensions/last_updated.py
@@ -134,9 +134,10 @@ def on_html_page_context(app, pagename, templatename, context, doctree):
                                                         git_repo=app.config.last_updated_git_path,
                                                         doc_root=app.srcdir)
         if last_updated_value is None:
-            app.logger.warning(f'Could not get the last updated value from git for the following file:\
-                    \n {rst_file_path}\n Ensure that you specified the correct folder in last_updated_git_path.')
-            context['last_updated'] = None
+            #app.logger.warning(f'Could not get the last updated value from git for the following file:\
+            #        \n {rst_file_path}\n Ensure that you specified the correct folder in last_updated_git_path.')
+            #context['last_updated'] = None
+            context['last_updated'] = context['last_published']
         else:
             context['last_updated'] = last_updated_value.strftime(date_fmt)
 


### PR DESCRIPTION
If a new document is added, the CI system fails because the new document
hasn't been checked into the branch yet so the last_updated.py script
complains with an error.  Change to use the last_published date in this
situation.

Tracked-On: #7249

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>