### PR TITLE
Remove "All rights reserved" string headers

### DIFF
--- a/devicemodel/arch/x86/power_button.c
+++ b/devicemodel/arch/x86/power_button.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/core/hugetlb.c
+++ b/devicemodel/core/hugetlb.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/core/monitor.c
+++ b/devicemodel/core/monitor.c
@@ -2,7 +2,7 @@
  * Project Acrn
  * Acrn-dm-monitor
  *
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/core/pm_vuart.c
+++ b/devicemodel/core/pm_vuart.c
@@ -2,7 +2,7 @@
  * Project Acrn
  * Acrn-dm: pm-vuart
  *
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/core/sw_load_bzimage.c
+++ b/devicemodel/core/sw_load_bzimage.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/core/sw_load_elf.c
+++ b/devicemodel/core/sw_load_elf.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/core/sw_load_ovmf.c
+++ b/devicemodel/core/sw_load_ovmf.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/core/sw_load_vsbl.c
+++ b/devicemodel/core/sw_load_vsbl.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/core/vrpmb.c
+++ b/devicemodel/core/vrpmb.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/mmio/core.c
+++ b/devicemodel/hw/mmio/core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/pci/gsi_sharing.c
+++ b/devicemodel/hw/pci/gsi_sharing.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/pci/gvt.c
+++ b/devicemodel/hw/pci/gvt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/ivshmem.c
+++ b/devicemodel/hw/pci/ivshmem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/pci/platform_gsi_info.c
+++ b/devicemodel/hw/pci/platform_gsi_info.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/pci/virtio/vhost.c
+++ b/devicemodel/hw/pci/virtio/vhost.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_audio.c
+++ b/devicemodel/hw/pci/virtio/virtio_audio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_coreu.c
+++ b/devicemodel/hw/pci/virtio/virtio_coreu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_gpio.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_hdcp.c
+++ b/devicemodel/hw/pci/virtio/virtio_hdcp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_hyper_dmabuf.c
+++ b/devicemodel/hw/pci/virtio/virtio_hyper_dmabuf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_i2c.c
+++ b/devicemodel/hw/pci/virtio/virtio_i2c.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_input.c
+++ b/devicemodel/hw/pci/virtio/virtio_input.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_ipu.c
+++ b/devicemodel/hw/pci/virtio/virtio_ipu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_kernel.c
+++ b/devicemodel/hw/pci/virtio/virtio_kernel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_mei.c
+++ b/devicemodel/hw/pci/virtio/virtio_mei.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_rpmb.c
+++ b/devicemodel/hw/pci/virtio/virtio_rpmb.c
@@ -2,7 +2,6 @@
  * Virtio Rpmb backend.
  *
  * Copyright (C) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/pci/wdt_i6300esb.c
+++ b/devicemodel/hw/pci/wdt_i6300esb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/platform/acpi/acpi_parser.c
+++ b/devicemodel/hw/platform/acpi/acpi_parser.c
@@ -3,7 +3,6 @@
  *
  * Copyright (c) 2003 John Baldwin <jhb@FreeBSD.org>
  * Copyright (c) 2022 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/platform/acpi/acpi_pm.c
+++ b/devicemodel/hw/platform/acpi/acpi_pm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/platform/cmos_io.c
+++ b/devicemodel/hw/platform/cmos_io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/platform/debugexit.c
+++ b/devicemodel/hw/platform/debugexit.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2018 Intel
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/platform/ioc.c
+++ b/devicemodel/hw/platform/ioc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/platform/ioc_cbc.c
+++ b/devicemodel/hw/platform/ioc_cbc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/platform/pty_vuart.c
+++ b/devicemodel/hw/platform/pty_vuart.c
@@ -2,7 +2,7 @@
  * Project Acrn
  * Acrn-dm-pty
  *
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/platform/rpmb/att_keybox.c
+++ b/devicemodel/hw/platform/rpmb/att_keybox.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2019 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/platform/rpmb/rpmb_backend.c
+++ b/devicemodel/hw/platform/rpmb/rpmb_backend.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/platform/rpmb/rpmb_sim.c
+++ b/devicemodel/hw/platform/rpmb/rpmb_sim.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/platform/tpm/tpm.c
+++ b/devicemodel/hw/platform/tpm/tpm.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2018 Intel Corporation
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/platform/tpm/tpm_crb.c
+++ b/devicemodel/hw/platform/tpm/tpm_crb.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2018 Intel Corporation
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/platform/tpm/tpm_emulator.c
+++ b/devicemodel/hw/platform/tpm/tpm_emulator.c
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2018 Intel Corporation
  * Copyright (C) 2014, 2015 IBM Corporation.
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/platform/tpm/tpm_internal.h
+++ b/devicemodel/hw/platform/tpm/tpm_internal.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2018 Intel Corporation
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/platform/vssram/tcc_buffer.h
+++ b/devicemodel/hw/platform/vssram/tcc_buffer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Intel Corporation. All rights reserved.
+ * Copyright (C) 2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/platform/vssram/vssram.c
+++ b/devicemodel/hw/platform/vssram/vssram.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/vga.c
+++ b/devicemodel/hw/vga.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Intel Corporation. All rights reserved.
+ * Copyright (C) 2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
  */

--- a/devicemodel/include/atomic.h
+++ b/devicemodel/include/atomic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/include/att_keybox.h
+++ b/devicemodel/include/att_keybox.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2019, Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/dm_string.h
+++ b/devicemodel/include/dm_string.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/gpio_dm.h
+++ b/devicemodel/include/gpio_dm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/ioc.h
+++ b/devicemodel/include/ioc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/log.h
+++ b/devicemodel/include/log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/include/macros.h
+++ b/devicemodel/include/macros.h
@@ -1,7 +1,7 @@
 /*-
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2018 Intel Corporation.
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/devicemodel/include/mei.h
+++ b/devicemodel/include/mei.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/mmio_dev.h
+++ b/devicemodel/include/mmio_dev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/include/monitor.h
+++ b/devicemodel/include/monitor.h
@@ -2,7 +2,7 @@
  * Project Acrn
  * Acrn-dm-monitor
  *
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/pm_vuart.h
+++ b/devicemodel/include/pm_vuart.h
@@ -2,7 +2,7 @@
  * Project Acrn
  * Acrn-dm: pm-vuart
  *
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/pty_vuart.h
+++ b/devicemodel/include/pty_vuart.h
@@ -2,7 +2,7 @@
  * Project Acrn
  * Acrn-dm-pty
  *
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/public/hsm_ioctl_defs.h
+++ b/devicemodel/include/public/hsm_ioctl_defs.h
@@ -4,7 +4,7 @@
  *
  * GPL LICENSE SUMMARY
  *
- * Copyright (c) 2017 Intel Corporation. All rights reserved.
+ * Copyright (c) 2017 Intel Corporation.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of version 2 of the GNU General Public License as
@@ -17,7 +17,7 @@
  *
  * BSD LICENSE
  *
- * Copyright (C) 2017 Intel Corporation. All rights reserved.
+ * Copyright (C) 2017 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/rpmb.h
+++ b/devicemodel/include/rpmb.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/rpmb_backend.h
+++ b/devicemodel/include/rpmb_backend.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/rpmb_sim.h
+++ b/devicemodel/include/rpmb_sim.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/tpm.h
+++ b/devicemodel/include/tpm.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2018 Intel Corporation
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/vbs_common_if.h
+++ b/devicemodel/include/vbs_common_if.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/vga.h
+++ b/devicemodel/include/vga.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Intel Corporation. All rights reserved.
+ * Copyright (C) 2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
  */

--- a/devicemodel/include/vhost.h
+++ b/devicemodel/include/vhost.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/virtio_kernel.h
+++ b/devicemodel/include/virtio_kernel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/vrpmb.h
+++ b/devicemodel/include/vrpmb.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/vssram.h
+++ b/devicemodel/include/vssram.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/lib/dm_string.c
+++ b/devicemodel/lib/dm_string.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/log/disk_logger.c
+++ b/devicemodel/log/disk_logger.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/log/kmsg_logger.c
+++ b/devicemodel/log/kmsg_logger.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/log/log.c
+++ b/devicemodel/log/log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/doc/static/downloads/Integrate-IntelGopDriver-into-OVMF.patch
+++ b/doc/static/downloads/Integrate-IntelGopDriver-into-OVMF.patch
@@ -22,7 +22,7 @@ Index: acrn-edk2/OvmfPkg/IntelGop/IntelGopDriver.inf
 +## @file
 +#  IntelGopDriver Binary
 +#
-+#  Copyright (c) 2006 - 2011, Intel Corporation. All rights reserved.<BR>
++#  Copyright (c) 2006 - 2011, Intel Corporation.<BR>
 +#  SPDX-License-Identifier: BSD-2-Clause-Patent
 +#
 +##

--- a/doc/static/downloads/Use-the-default-vbt-released-with-GOP-driver.patch
+++ b/doc/static/downloads/Use-the-default-vbt-released-with-GOP-driver.patch
@@ -48,7 +48,7 @@ Index: acrn-edk2/OvmfPkg/Vbt/Vbt.inf
 +## @file
 +#  Vbt Binary
 +#
-+#  Copyright (c) 2006 - 2011, Intel Corporation. All rights reserved.<BR>
++#  Copyright (c) 2006 - 2011, Intel Corporation.<BR>
 +#  SPDX-License-Identifier: BSD-2-Clause-Patent
 +#
 +##

--- a/hypervisor/acpi_parser/acpi_ext.c
+++ b/hypervisor/acpi_parser/acpi_ext.c
@@ -3,7 +3,6 @@
  *
  * Copyright (c) 2003 John Baldwin <jhb@FreeBSD.org>
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/boot/trampoline.S
+++ b/hypervisor/arch/x86/boot/trampoline.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/configs/vacpi.c
+++ b/hypervisor/arch/x86/configs/vacpi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/cpu_state_tbl.c
+++ b/hypervisor/arch/x86/cpu_state_tbl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/e820.c
+++ b/hypervisor/arch/x86/e820.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/exception.c
+++ b/hypervisor/arch/x86/exception.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/gdt.c
+++ b/hypervisor/arch/x86/gdt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/guest_memory.c
+++ b/hypervisor/arch/x86/guest/guest_memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/hyperv.c
+++ b/hypervisor/arch/x86/guest/hyperv.c
@@ -2,7 +2,7 @@
  * Microsoft Hyper-V emulation. See Microsoft's
  * Hypervisor Top Level Functional Specification for more information.
  *
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -2,7 +2,6 @@
  * Copyright (c) 2012 Sandvine, Inc.
  * Copyright (c) 2012 NetApp, Inc.
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/arch/x86/guest/lock_instr_emul.c
+++ b/hypervisor/arch/x86/guest/lock_instr_emul.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/optee.c
+++ b/hypervisor/arch/x86/guest/optee.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/trusty.c
+++ b/hypervisor/arch/x86/guest/trusty.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/ucode.c
+++ b/hypervisor/arch/x86/guest/ucode.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vcat.c
+++ b/hypervisor/arch/x86/guest/vcat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/ve820.c
+++ b/hypervisor/arch/x86/guest/ve820.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vept.c
+++ b/hypervisor/arch/x86/guest/vept.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 2011 NetApp, Inc.
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vm_reset.c
+++ b/hypervisor/arch/x86/guest/vm_reset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmx_asm.S
+++ b/hypervisor/arch/x86/guest/vmx_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmx_io.c
+++ b/hypervisor/arch/x86/guest/vmx_io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/idt.S
+++ b/hypervisor/arch/x86/idt.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/lib/retpoline-thunk.S
+++ b/hypervisor/arch/x86/lib/retpoline-thunk.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 2011 NetApp, Inc.
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/arch/x86/nmi.c
+++ b/hypervisor/arch/x86/nmi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/platform_caps.c
+++ b/hypervisor/arch/x86/platform_caps.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/rdt.c
+++ b/hypervisor/arch/x86/rdt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/rtcm.c
+++ b/hypervisor/arch/x86/rtcm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/sched.S
+++ b/hypervisor/arch/x86/sched.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/security.c
+++ b/hypervisor/arch/x86/security.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed.c
+++ b/hypervisor/arch/x86/seed/seed.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed_abl.c
+++ b/hypervisor/arch/x86/seed/seed_abl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed_abl.h
+++ b/hypervisor/arch/x86/seed/seed_abl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed_sbl.c
+++ b/hypervisor/arch/x86/seed/seed_sbl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed_sbl.h
+++ b/hypervisor/arch/x86/seed/seed_sbl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/sgx.c
+++ b/hypervisor/arch/x86/sgx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/trampoline.c
+++ b/hypervisor/arch/x86/trampoline.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/acpi_base.c
+++ b/hypervisor/boot/acpi_base.c
@@ -3,7 +3,6 @@
  *
  * Copyright (c) 2003 John Baldwin <jhb@FreeBSD.org>
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/boot/guest/bzimage_loader.c
+++ b/hypervisor/boot/guest/bzimage_loader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/guest/elf_loader.c
+++ b/hypervisor/boot/guest/elf_loader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/guest/rawimage_loader.c
+++ b/hypervisor/boot/guest/rawimage_loader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/include/boot.h
+++ b/hypervisor/boot/include/boot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/include/guest/vboot.h
+++ b/hypervisor/boot/include/guest/vboot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/include/multiboot_std.h
+++ b/hypervisor/boot/include/multiboot_std.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/multiboot/multiboot.c
+++ b/hypervisor/boot/multiboot/multiboot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/multiboot/multiboot2.c
+++ b/hypervisor/boot/multiboot/multiboot2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/multiboot/multiboot_priv.h
+++ b/hypervisor/boot/multiboot/multiboot_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/event.c
+++ b/hypervisor/common/event.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/irq.c
+++ b/hypervisor/common/irq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/sched_bvt.c
+++ b/hypervisor/common/sched_bvt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/sched_iorr.c
+++ b/hypervisor/common/sched_iorr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/sched_noop.c
+++ b/hypervisor/common/sched_noop.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/softirq.c
+++ b/hypervisor/common/softirq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/timer.c
+++ b/hypervisor/common/timer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/trusty_hypercall.c
+++ b/hypervisor/common/trusty_hypercall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/dbg_cmd.c
+++ b/hypervisor/debug/dbg_cmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/hypercall.c
+++ b/hypervisor/debug/hypercall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/printf.c
+++ b/hypervisor/debug/printf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -1,7 +1,7 @@
 /*
  * SHARED BUFFER
  *
- * Copyright (C) 2017 Intel Corporation. All rights reserved.
+ * Copyright (C) 2017 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/string.c
+++ b/hypervisor/debug/string.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/trace.c
+++ b/hypervisor/debug/trace.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/mmio_dev.c
+++ b/hypervisor/dm/mmio_dev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/vgpio.c
+++ b/hypervisor/dm/vgpio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -2,7 +2,6 @@
  * Copyright (c) 2013 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/ivshmem.c
+++ b/hypervisor/dm/vpci/ivshmem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -1,7 +1,6 @@
 /*-
 * Copyright (c) 2011 NetApp, Inc.
 * Copyright (c) 2018 Intel Corporation
-* All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vdev.c
+++ b/hypervisor/dm/vpci/vdev.c
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -1,7 +1,6 @@
 /*-
 * Copyright (c) 2011 NetApp, Inc.
 * Copyright (c) 2018 Intel Corporation
-* All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vmcs9900.c
+++ b/hypervisor/dm/vpci/vmcs9900.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vmsix_on_msi.c
+++ b/hypervisor/dm/vpci/vmsix_on_msi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -1,7 +1,6 @@
 /*-
 * Copyright (c) 2011 NetApp, Inc.
 * Copyright (c) 2018 Intel Corporation
-* All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vpci_bridge.c
+++ b/hypervisor/dm/vpci/vpci_bridge.c
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
  * Copyright (c) 2019 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -1,7 +1,6 @@
 /*-
 * Copyright (c) 2011 NetApp, Inc.
 * Copyright (c) 2018 Intel Corporation
-* All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vsriov.c
+++ b/hypervisor/dm/vpci/vsriov.c
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vrtc.c
+++ b/hypervisor/dm/vrtc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -2,7 +2,6 @@
  * Copyright (c) 2012 NetApp, Inc.
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -3,7 +3,6 @@
  * Copyright (c) 2000, Michael Smith <msmith@freebsd.org>
  * Copyright (c) 2011 NetApp, Inc.
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/apicreg.h
+++ b/hypervisor/include/arch/x86/asm/apicreg.h
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 1996, by Peter Wemm and Steve Passe
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/board.h
+++ b/hypervisor/include/arch/x86/asm/board.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/boot/ld_sym.h
+++ b/hypervisor/include/arch/x86/asm/boot/ld_sym.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/cpu.h
+++ b/hypervisor/include/arch/x86/asm/cpu.h
@@ -2,7 +2,6 @@
  * Copyright (c) 1989, 1990 William F. Jolitz
  * Copyright (c) 1990 The Regents of the University of California.
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * This code is derived from software contributed to Berkeley by
  * William Jolitz.

--- a/hypervisor/include/arch/x86/asm/cpu_caps.h
+++ b/hypervisor/include/arch/x86/asm/cpu_caps.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/cpufeatures.h
+++ b/hypervisor/include/arch/x86/asm/cpufeatures.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/cpuid.h
+++ b/hypervisor/include/arch/x86/asm/cpuid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/default_acpi_info.h
+++ b/hypervisor/include/arch/x86/asm/default_acpi_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/e820.h
+++ b/hypervisor/include/arch/x86/asm/e820.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/gdt.h
+++ b/hypervisor/include/arch/x86/asm/gdt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/assign.h
+++ b/hypervisor/include/arch/x86/asm/guest/assign.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/ept.h
+++ b/hypervisor/include/arch/x86/asm/guest/ept.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/guest_memory.h
+++ b/hypervisor/include/arch/x86/asm/guest/guest_memory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/guest_pm.h
+++ b/hypervisor/include/arch/x86/asm/guest/guest_pm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/hyperv.h
+++ b/hypervisor/include/arch/x86/asm/guest/hyperv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/instr_emul.h
+++ b/hypervisor/include/arch/x86/asm/guest/instr_emul.h
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 2012 NetApp, Inc.
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/guest/lock_instr_emul.h
+++ b/hypervisor/include/arch/x86/asm/guest/lock_instr_emul.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/optee.h
+++ b/hypervisor/include/arch/x86/asm/guest/optee.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/trusty.h
+++ b/hypervisor/include/arch/x86/asm/guest/trusty.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/ucode.h
+++ b/hypervisor/include/arch/x86/asm/guest/ucode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vcat.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vcpuid.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpuid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vept.h
+++ b/hypervisor/include/arch/x86/asm/guest/vept.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/virq.h
+++ b/hypervisor/include/arch/x86/asm/guest/virq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/virtual_cr.h
+++ b/hypervisor/include/arch/x86/asm/guest/virtual_cr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/asm/guest/vlapic.h
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 2011 NetApp, Inc.
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/guest/vm.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vm_reset.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm_reset.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vmcs.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmcs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vmexit.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmexit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vmx_io.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmx_io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/idt.h
+++ b/hypervisor/include/arch/x86/asm/idt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/io.h
+++ b/hypervisor/include/arch/x86/asm/io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/ioapic.h
+++ b/hypervisor/include/arch/x86/asm/ioapic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/irq.h
+++ b/hypervisor/include/arch/x86/asm/irq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/lapic.h
+++ b/hypervisor/include/arch/x86/asm/lapic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/lib/atomic.h
+++ b/hypervisor/include/arch/x86/asm/lib/atomic.h
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 1998 Doug Rabson
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/lib/bits.h
+++ b/hypervisor/include/arch/x86/asm/lib/bits.h
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 1998 Doug Rabson
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/lib/spinlock.h
+++ b/hypervisor/include/arch/x86/asm/lib/spinlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/mmu.h
+++ b/hypervisor/include/arch/x86/asm/mmu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/msr.h
+++ b/hypervisor/include/arch/x86/asm/msr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/notify.h
+++ b/hypervisor/include/arch/x86/asm/notify.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/page.h
+++ b/hypervisor/include/arch/x86/asm/page.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/pci_dev.h
+++ b/hypervisor/include/arch/x86/asm/pci_dev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/per_cpu.h
+++ b/hypervisor/include/arch/x86/asm/per_cpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/pgtable.h
+++ b/hypervisor/include/arch/x86/asm/pgtable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/platform_caps.h
+++ b/hypervisor/include/arch/x86/asm/platform_caps.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/rdt.h
+++ b/hypervisor/include/arch/x86/asm/rdt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/rtcm.h
+++ b/hypervisor/include/arch/x86/asm/rtcm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/rtct.h
+++ b/hypervisor/include/arch/x86/asm/rtct.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/security.h
+++ b/hypervisor/include/arch/x86/asm/security.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/seed.h
+++ b/hypervisor/include/arch/x86/asm/seed.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/sgx.h
+++ b/hypervisor/include/arch/x86/asm/sgx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/vm_config.h
+++ b/hypervisor/include/arch/x86/asm/vm_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/vmx.h
+++ b/hypervisor/include/arch/x86/asm/vmx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/vtd.h
+++ b/hypervisor/include/arch/x86/asm/vtd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/zeropage.h
+++ b/hypervisor/include/arch/x86/asm/zeropage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/softirq.h
+++ b/hypervisor/include/common/softirq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/timer.h
+++ b/hypervisor/include/common/timer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/dbg_cmd.h
+++ b/hypervisor/include/debug/dbg_cmd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/dump.h
+++ b/hypervisor/include/debug/dump.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/sbuf.h
+++ b/hypervisor/include/debug/sbuf.h
@@ -1,7 +1,7 @@
 /*
  * SHARED BUFFER
  *
- * Copyright (C) 2017 Intel Corporation. All rights reserved.
+ * Copyright (C) 2017 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/include/debug/shell.h
+++ b/hypervisor/include/debug/shell.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/trace.h
+++ b/hypervisor/include/debug/trace.h
@@ -1,7 +1,7 @@
 /*
  * ACRN TRACE
  *
- * Copyright (C) 2017 Intel Corporation. All rights reserved.
+ * Copyright (C) 2017 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/include/debug/uart16550.h
+++ b/hypervisor/include/debug/uart16550.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/io_req.h
+++ b/hypervisor/include/dm/io_req.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/ivshmem.h
+++ b/hypervisor/include/dm/ivshmem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/mmio_dev.h
+++ b/hypervisor/include/dm/mmio_dev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/vacpi.h
+++ b/hypervisor/include/dm/vacpi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/vgpio.h
+++ b/hypervisor/include/dm/vgpio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/vioapic.h
+++ b/hypervisor/include/dm/vioapic.h
@@ -2,7 +2,6 @@
  * Copyright (c) 2013 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/dm/vmcs9900.h
+++ b/hypervisor/include/dm/vmcs9900.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -1,7 +1,6 @@
 /*-
 * Copyright (c) 2011 NetApp, Inc.
 * Copyright (c) 2018 Intel Corporation
-* All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions

--- a/hypervisor/include/dm/vpic.h
+++ b/hypervisor/include/dm/vpic.h
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/dm/vuart.h
+++ b/hypervisor/include/dm/vuart.h
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
  * Copyright (c) 2018 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -2,7 +2,6 @@
 * Copyright (c) 1997, Stefan Esser <se@freebsd.org>
 * Copyright (c) 2011 NetApp, Inc.
 * Copyright (c) 2018 Intel Corporation
-* All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions

--- a/hypervisor/include/lib/crypto/crypto_api.h
+++ b/hypervisor/include/lib/crypto/crypto_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/efi.h
+++ b/hypervisor/include/lib/efi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/errno.h
+++ b/hypervisor/include/lib/errno.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/hash.h
+++ b/hypervisor/include/lib/hash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/list.h
+++ b/hypervisor/include/lib/list.h
@@ -1,7 +1,6 @@
 /*-
  * Copyright (C) 2005-2011 HighPoint Technologies, Inc.
  * Copyright (c) 2017 Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/sprintf.h
+++ b/hypervisor/include/lib/sprintf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/types.h
+++ b/hypervisor/include/lib/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/util.h
+++ b/hypervisor/include/lib/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -1,7 +1,7 @@
 /*
  * common definition
  *
- * Copyright (C) 2017 Intel Corporation. All rights reserved.
+ * Copyright (C) 2017 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -1,7 +1,7 @@
 /*
  * hypercall definition
  *
- * Copyright (C) 2017 Intel Corporation. All rights reserved.
+ * Copyright (C) 2017 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/lib/crypto/crypto_api.c
+++ b/hypervisor/lib/crypto/crypto_api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/lib/crypto/mbedtls/md.c
+++ b/hypervisor/lib/crypto/mbedtls/md.c
@@ -6,7 +6,7 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2018, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/md.h
+++ b/hypervisor/lib/crypto/mbedtls/md.h
@@ -7,7 +7,7 @@
  */
 /*
  *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2018, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/md_internal.h
+++ b/hypervisor/lib/crypto/mbedtls/md_internal.h
@@ -9,7 +9,7 @@
  */
 /*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2018, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/md_wrap.c
+++ b/hypervisor/lib/crypto/mbedtls/md_wrap.c
@@ -6,7 +6,7 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2018, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/sha256.c
+++ b/hypervisor/lib/crypto/mbedtls/sha256.c
@@ -2,7 +2,7 @@
  *  FIPS-180-2 compliant SHA-256 implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2018, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/sha256.h
+++ b/hypervisor/lib/crypto/mbedtls/sha256.h
@@ -8,7 +8,7 @@
  */
 /*
  *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2018, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/lib/stack_protector.c
+++ b/hypervisor/lib/stack_protector.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/quirks/security_vm_fixup.c
+++ b/hypervisor/quirks/security_vm_fixup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/quirks/security_vm_fixup.h
+++ b/hypervisor/quirks/security_vm_fixup.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/quirks/smbios.h
+++ b/hypervisor/quirks/smbios.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/console.c
+++ b/hypervisor/release/console.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/dump.c
+++ b/hypervisor/release/dump.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/hypercall.c
+++ b/hypervisor/release/hypercall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/logmsg.c
+++ b/hypervisor/release/logmsg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/npk_log.c
+++ b/hypervisor/release/npk_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/profiling.c
+++ b/hypervisor/release/profiling.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/sbuf.c
+++ b/hypervisor/release/sbuf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/trace.c
+++ b/hypervisor/release/trace.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/uart16550.c
+++ b/hypervisor/release/uart16550.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * Copyright (C) 2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/scripts/makefile/config.mk
+++ b/hypervisor/scripts/makefile/config.mk
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # usage: check_coexistence <symbol 1> <symbol 2>

--- a/hypervisor/scripts/makefile/unified.xml.in
+++ b/hypervisor/scripts/makefile/unified.xml.in
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 
-<!-- Copyright (C) 2021 Intel Corporation. All rights reserved. -->
+<!-- Copyright (C) 2021 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <acrn-offline-data

--- a/misc/config_tools/board_config/acpi_platform_h.py
+++ b/misc/config_tools/board_config/acpi_platform_h.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_config/board_c.py
+++ b/misc/config_tools/board_config/board_c.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_config/board_cfg_gen.py
+++ b/misc/config_tools/board_config/board_cfg_gen.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_config/board_info_h.py
+++ b/misc/config_tools/board_config/board_info_h.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation. All rights reserved.
+# Copyright (C) 2020 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_config/pci_devices_h.py
+++ b/misc/config_tools/board_config/pci_devices_h.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_config/vbar_base_h.py
+++ b/misc/config_tools/board_config/vbar_base_h.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation. All rights reserved.
+# Copyright (C) 2020 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/__init__.py
+++ b/misc/config_tools/board_inspector/acpiparser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/_utils.py
+++ b/misc/config_tools/board_inspector/acpiparser/_utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/builder.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/builder.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/context.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/context.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/datatypes.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/datatypes.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/exception.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/exception.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/grammar.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/grammar.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/interpreter.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/interpreter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/parser.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/parser.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/stream.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/stream.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/tree.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/tree.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/visitors.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/visitors.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/apic.py
+++ b/misc/config_tools/board_inspector/acpiparser/apic.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/asf.py
+++ b/misc/config_tools/board_inspector/acpiparser/asf.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/dmar.py
+++ b/misc/config_tools/board_inspector/acpiparser/dmar.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/dsdt.py
+++ b/misc/config_tools/board_inspector/acpiparser/dsdt.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/facp.py
+++ b/misc/config_tools/board_inspector/acpiparser/facp.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/prt.py
+++ b/misc/config_tools/board_inspector/acpiparser/prt.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/rdt.py
+++ b/misc/config_tools/board_inspector/acpiparser/rdt.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/rtct.py
+++ b/misc/config_tools/board_inspector/acpiparser/rtct.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/tpm2.py
+++ b/misc/config_tools/board_inspector/acpiparser/tpm2.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/board_inspector.py
+++ b/misc/config_tools/board_inspector/board_inspector.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/cpuparser/__init__.py
+++ b/misc/config_tools/board_inspector/cpuparser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/cpuparser/cpuids.py
+++ b/misc/config_tools/board_inspector/cpuparser/cpuids.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/cpuparser/platformbase.py
+++ b/misc/config_tools/board_inspector/cpuparser/platformbase.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/10-processors.py
+++ b/misc/config_tools/board_inspector/extractors/10-processors.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/20-cache.py
+++ b/misc/config_tools/board_inspector/extractors/20-cache.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/30-memory.py
+++ b/misc/config_tools/board_inspector/extractors/30-memory.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/60-pci.py
+++ b/misc/config_tools/board_inspector/extractors/60-pci.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/80-lookup.py
+++ b/misc/config_tools/board_inspector/extractors/80-lookup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/90-sorting.py
+++ b/misc/config_tools/board_inspector/extractors/90-sorting.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/helpers.py
+++ b/misc/config_tools/board_inspector/extractors/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/inspectorlib/bitfields.py
+++ b/misc/config_tools/board_inspector/inspectorlib/bitfields.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2015, Intel Corporation
-# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/misc/config_tools/board_inspector/inspectorlib/cdata.py
+++ b/misc/config_tools/board_inspector/inspectorlib/cdata.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2015, Intel Corporation
-# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/misc/config_tools/board_inspector/inspectorlib/unpack.py
+++ b/misc/config_tools/board_inspector/inspectorlib/unpack.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2013, Intel Corporation
-# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/misc/config_tools/board_inspector/legacy/acpi.py
+++ b/misc/config_tools/board_inspector/legacy/acpi.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/board_parser.py
+++ b/misc/config_tools/board_inspector/legacy/board_parser.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/clos.py
+++ b/misc/config_tools/board_inspector/legacy/clos.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/dmar.py
+++ b/misc/config_tools/board_inspector/legacy/dmar.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/dmi.py
+++ b/misc/config_tools/board_inspector/legacy/dmi.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/misc.py
+++ b/misc/config_tools/board_inspector/legacy/misc.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/parser_lib.py
+++ b/misc/config_tools/board_inspector/legacy/parser_lib.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/pci_dev.py
+++ b/misc/config_tools/board_inspector/legacy/pci_dev.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/memmapparser/__init__.py
+++ b/misc/config_tools/board_inspector/memmapparser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/memmapparser/e820.py
+++ b/misc/config_tools/board_inspector/memmapparser/e820.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/pcieparser/__init__.py
+++ b/misc/config_tools/board_inspector/pcieparser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/pcieparser/caps.py
+++ b/misc/config_tools/board_inspector/pcieparser/caps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/pcieparser/extcaps.py
+++ b/misc/config_tools/board_inspector/pcieparser/extcaps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/pcieparser/header.py
+++ b/misc/config_tools/board_inspector/pcieparser/header.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/smbiosparser/__init__.py
+++ b/misc/config_tools/board_inspector/smbiosparser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/smbiosparser/smbios.py
+++ b/misc/config_tools/board_inspector/smbiosparser/smbios.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/data/generic_board/generic_code/boards/board.c
+++ b/misc/config_tools/data/generic_board/generic_code/boards/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/data/generic_board/generic_code/boards/board_info.h
+++ b/misc/config_tools/data/generic_board/generic_code/boards/board_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/data/generic_board/generic_code/boards/pci_devices.h
+++ b/misc/config_tools/data/generic_board/generic_code/boards/pci_devices.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/data/generic_board/generic_code/boards/platform_acpi_info.h
+++ b/misc/config_tools/data/generic_board/generic_code/boards/platform_acpi_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/data/generic_board/generic_code/hybrid/vbar_base.h
+++ b/misc/config_tools/data/generic_board/generic_code/hybrid/vbar_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/data/generic_board/generic_code/partitioned/vbar_base.h
+++ b/misc/config_tools/data/generic_board/generic_code/partitioned/vbar_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/data/generic_board/generic_code/shared/vbar_base.h
+++ b/misc/config_tools/data/generic_board/generic_code/shared/vbar_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/hv_config/board_defconfig.py
+++ b/misc/config_tools/hv_config/board_defconfig.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/hv_config/hv_item.py
+++ b/misc/config_tools/hv_config/hv_item.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation. All rights reserved.
+# Copyright (C) 2020 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/library/board_cfg_lib.py
+++ b/misc/config_tools/library/board_cfg_lib.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/library/common.py
+++ b/misc/config_tools/library/common.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/library/hv_cfg_lib.py
+++ b/misc/config_tools/library/hv_cfg_lib.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation. All rights reserved.
+# Copyright (C) 2020 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/library/hypervisor_license
+++ b/misc/config_tools/library/hypervisor_license
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/library/launch_cfg_lib.py
+++ b/misc/config_tools/library/launch_cfg_lib.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/library/scenario_cfg_lib.py
+++ b/misc/config_tools/library/scenario_cfg_lib.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/scenario_config/scenario_cfg_gen.py
+++ b/misc/config_tools/scenario_config/scenario_cfg_gen.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/scenario_config/scenario_item.py
+++ b/misc/config_tools/scenario_config/scenario_item.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# Copyright (C) 2019 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/cpu_affinity.py
+++ b/misc/config_tools/static_allocators/cpu_affinity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/intx.py
+++ b/misc/config_tools/static_allocators/intx.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/lib/__init__.py
+++ b/misc/config_tools/static_allocators/lib/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/lib/error.py
+++ b/misc/config_tools/static_allocators/lib/error.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/main.py
+++ b/misc/config_tools/static_allocators/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/pio.py
+++ b/misc/config_tools/static_allocators/pio.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/xforms/config.h.xsl
+++ b/misc/config_tools/xforms/config.h.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. All rights reserved. -->
+<!-- Copyright (C) 2021 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/config.mk.xsl
+++ b/misc/config_tools/xforms/config.mk.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. All rights reserved. -->
+<!-- Copyright (C) 2021 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. All rights reserved. -->
+<!-- Copyright (C) 2021 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/ivshmem_cfg.h.xsl
+++ b/misc/config_tools/xforms/ivshmem_cfg.h.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. All rights reserved. -->
+<!-- Copyright (C) 2021 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. All rights reserved. -->
+<!-- Copyright (C) 2021 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/pt_intx.c.xsl
+++ b/misc/config_tools/xforms/pt_intx.c.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. All rights reserved. -->
+<!-- Copyright (C) 2021 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/vm_configurations.h.xsl
+++ b/misc/config_tools/xforms/vm_configurations.h.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. All rights reserved. -->
+<!-- Copyright (C) 2021 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/debug_tools/acrn_log/acrnlog.c
+++ b/misc/debug_tools/acrn_log/acrnlog.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/debug_tools/acrn_trace/acrntrace.c
+++ b/misc/debug_tools/acrn_trace/acrntrace.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/debug_tools/acrn_trace/acrntrace.h
+++ b/misc/debug_tools/acrn_trace/acrntrace.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/debug_tools/acrn_trace/sbuf.c
+++ b/misc/debug_tools/acrn_trace/sbuf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/debug_tools/acrn_trace/sbuf.h
+++ b/misc/debug_tools/acrn_trace/sbuf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/efi-stub/Makefile
+++ b/misc/efi-stub/Makefile
@@ -1,6 +1,5 @@
 #
 # Copyright (c) 2011 - 2021, Intel Corporation
-# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/misc/efi-stub/boot.c
+++ b/misc/efi-stub/boot.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2011 - 2021, Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/boot.h
+++ b/misc/efi-stub/boot.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2011 - 2021, Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/container.c
+++ b/misc/efi-stub/container.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2021, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/container.h
+++ b/misc/efi-stub/container.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2021, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/efilinux.h
+++ b/misc/efi-stub/efilinux.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2011 - 2021, Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/elf32.c
+++ b/misc/efi-stub/elf32.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2021, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/elf32.h
+++ b/misc/efi-stub/elf32.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2021, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/malloc.c
+++ b/misc/efi-stub/malloc.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2011 - 2021, Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/multiboot.c
+++ b/misc/efi-stub/multiboot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2021, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/pe.c
+++ b/misc/efi-stub/pe.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2011 - 2021, Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/stdlib.h
+++ b/misc/efi-stub/stdlib.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2011 - 2021, Intel Corporation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/hv_prebuild/hv_prebuild.h
+++ b/misc/hv_prebuild/hv_prebuild.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/hv_prebuild/main.c
+++ b/misc/hv_prebuild/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/hv_prebuild/static_checks.c
+++ b/misc/hv_prebuild/static_checks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/hv_prebuild/vm_cfg_checks.c
+++ b/misc/hv_prebuild/vm_cfg_checks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ * Copyright (C) 2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/packaging/100_ACRN
+++ b/misc/packaging/100_ACRN
@@ -1,5 +1,5 @@
 #!/bin/bash
-#* Copyright (c) 2020 Intel Corporation All rights reserved.
+#* Copyright (c) 2020 Intel Corporation.
 # postinst script for acrn kernel
 set -e
 

--- a/misc/packaging/acrn-kernel.postinst
+++ b/misc/packaging/acrn-kernel.postinst
@@ -1,5 +1,5 @@
 #!/bin/bash
-#* Copyright (c) 2020 Intel Corporation All rights reserved.
+#* Copyright (c) 2020 Intel Corporation.
 # postinst script for acrn kernel
 filename="/etc/grub.d/40_custom"
 menu=$(grep ACRN_deb_multiboot2 ${filename}) || true

--- a/misc/services/acrn_manager/acrnctl.c
+++ b/misc/services/acrn_manager/acrnctl.c
@@ -2,7 +2,7 @@
  * ProjectAcrn
  * Acrnctl
  *
- * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *


### PR DESCRIPTION
Many of the license and Intel copyright headers include the "All rights
reserved" string. It is not relevant in the context of the BSD-3-Clause
license that the code is released under. This patch removes those strings
throughout the code (hypervisor, devicemodel and misc).

Tracked-On: #7254
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>