### PR TITLE
mise: life_mngr: fix some minor bugs

### DIFF
--- a/misc/services/life_mngr/life_mngr_win.c
+++ b/misc/services/life_mngr/life_mngr_win.c
@@ -32,7 +32,7 @@
 #define READ_INTERVAL	(100U) /* The time unit is microsecond */
 #define MIN_RESEND_TIME (3U)
 #define SECOND_TO_MS	(1000U)
-#define RETRY_RECV_TIMES	(8U)
+#define RETRY_RECV_TIMES	(100U)
 
 HANDLE hCom2;
 unsigned int resend_time;
@@ -73,7 +73,7 @@ void handle_socket_request(SOCKET sClient, char *req_message)
 	Sleep(6U * SECOND_TO_MS);
 	send(sClient, ack_message, sizeof(ack_message), 0);
 	start_uart_resend(req_message, MIN_RESEND_TIME);
-	send_message_by_uart(hCom2, req_message, sizeof(req_message));
+	send_message_by_uart(hCom2, req_message, strnlen(req_message, BUFF_SIZE));
 	Sleep(2U * READ_INTERVAL);
 	return;
 }

--- a/misc/services/life_mngr/uart.c
+++ b/misc/services/life_mngr/uart.c
@@ -26,6 +26,7 @@ static ssize_t try_receive_message_by_uart(int fd, void *buffer, size_t buf_len)
 	char *tmp;
 
 	do {
+		/* NOTE: Now we can't handle multi command message at one time. */
 		rc = read(fd, buffer + count, buf_len - count);
 		if (rc > 0) {
 			count += rc;

--- a/misc/services/life_mngr/uart.h
+++ b/misc/services/life_mngr/uart.h
@@ -15,7 +15,7 @@
 
 #define SECOND_TO_US 1000000
 #define WAIT_RECV (SECOND_TO_US>>2)
-#define RETRY_RECV_TIMES 20U
+#define RETRY_RECV_TIMES 100U
 
 struct uart_dev {
 	char tty_path[TTY_PATH_MAX]; /**< UART device name */


### PR DESCRIPTION
1. enlarge receive Service VM message time to 10s. Now in some extreme
environments, Service VM will takes more than 1s to ACK the User VM's
requirements.
2. fix a bug to calculate string pointer size.

Tracked-On: #7215
Signed-off-by: Fei Li <fei1.li@intel.com>