### PR TITLE
config tool: Fix service vm cpu affinity issue

### DIFF
--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -44,7 +44,7 @@
 
 <xs:complexType name="CPUAffinityConfiguration">
   <xs:sequence>
-    <xs:element name="pcpu_id" type="xs:integer" default="2" maxOccurs="unbounded">
+    <xs:element name="pcpu_id" type="xs:integer" default="2" minOccurs="0" maxOccurs="unbounded">
       <xs:annotation>
         <xs:documentation>A pCPU that this VM's vCPU is allowed to pin
 to.</xs:documentation>

--- a/misc/config_tools/static_allocators/cpu_affinity.py
+++ b/misc/config_tools/static_allocators/cpu_affinity.py
@@ -13,7 +13,7 @@ def sos_cpu_affinity(etree):
     if common.get_node("//vm[load_order = 'SERVICE_VM']", etree) is None:
         return None
 
-    if common.get_node("//vm[load_order = 'SERVICE_VM' and count(cpu_affinity)]", etree) is not None:
+    if common.get_node("//vm[load_order = 'SERVICE_VM' and count(cpu_affinity/pcpu_id)]", etree) is not None:
         return None
 
     sos_extend_all_cpus = board_cfg_lib.get_processor_info()


### PR DESCRIPTION
default value of minOccurs is "1", which will trigger problem
when user leave pcpu_id blank while preserve cpu_affinity in
service VM.

Tracked-On: #7267
Signed-off-by: hangliu1 <hang1.liu@linux.intel.com>