### PR TITLE
config tool: Fix combined cpu_affinity warning

### DIFF
--- a/misc/config_tools/schema/checks/cpu_assignment.xsd
+++ b/misc/config_tools/schema/checks/cpu_assignment.xsd
@@ -25,7 +25,7 @@
     </xs:annotation>
   </xs:assert>
 
-  <xs:assert test="every $vm in vm satisfies
+  <xs:assert test="every $vm in /acrn-config/vm[load_order != 'SERVICE_VM'] satisfies
                    count(distinct-values(processors//thread[cpu_id = $vm//cpu_affinity/pcpu_id]/core_type)) &lt;= 1">
     <xs:annotation acrn:severity="error" acrn:report-on="$vm//cpu_affinity">
       <xs:documentation>The physical CPUs allocated to the VM "{$vm/name}" have both performance cores {processors//thread[cpu_id = $vm//cpu_affinity/pcpu_id and core_type = 'Core']/cpu_id} and efficient cores {processors//thread[cpu_id = $vm//cpu_affinity/pcpu_id and core_type = 'Atom']/cpu_id}, which is unsupported. Remove either all performance or all efficient cores from the CPU affinity.</xs:documentation>


### PR DESCRIPTION
Service vm could have the combination of big and
little core cpu_affinity setting, fix the assert.

Tracked-On: #7270
Signed-off-by: hangliu1 <hang1.liu@linux.intel.com>