### PR TITLE
deb-pkg: add OVMF_debug.fd in acrn deb

### DIFF
--- a/misc/packaging/deb.json
+++ b/misc/packaging/deb.json
@@ -95,6 +95,10 @@
 			"source":"acrn-hypervisor/devicemodel/bios/OVMF.fd",
 			"target":"usr/share/acrn/bios"
 			},
+"OVMF_debug.fd":{
+			"source":"acrn-hypervisor/devicemodel/bios/OVMF_debug.fd",
+			"target":"usr/share/acrn/bios"
+			},
 "40-watchdog.conf":{
 			"source":"acrn-hypervisor/misc/tools/acrn-crashlog/data/40-watchdog.conf",
 			"target":"usr/share/acrn/crashlog"


### PR DESCRIPTION
add OVMF_debug.fd in acrn deb

Tracked-On: #7272
Signed-off-by: hangliu1 <hang1.liu@linux.intel.com>