### PR TITLE
config_tools: refine virtio devices

### DIFF
--- a/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
@@ -148,7 +148,10 @@
     <usb_xhci/>
     <virtio_devices>
       <console/>
-      <network>WaaG</network>
+      <network>
+        <virtio_framework/>
+        <interface_name>WaaG</interface_name>
+      </network>
       <input/>
       <block>./win10-ltsc.img</block>
     </virtio_devices>
@@ -173,8 +176,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>YaaG</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>

--- a/misc/config_tools/data/cfl-k700-i7/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/shared_launch_6user_vm.xml
@@ -102,7 +102,10 @@
     <usb_xhci/>
     <virtio_devices>
       <console/>
-      <network>WaaG</network>
+      <network>
+        <virtio_framework/>
+        <interface_name>WaaG</interface_name>
+      </network>
       <input/>
       <block>./win10-ltsc.img</block>
     </virtio_devices>
@@ -130,8 +133,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>RT</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>RT</interface_name>
+      </network>
       <input/>
       <block>./core-image-weston-intel-corei7-64.wic</block>
     </virtio_devices>
@@ -158,8 +167,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG3</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>YaaG3</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>
@@ -186,8 +201,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG4</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>YaaG4</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>
@@ -214,8 +235,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG5</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>YaaG5</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>
@@ -242,8 +269,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG6</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>YaaG6</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>

--- a/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
@@ -148,7 +148,10 @@
     <usb_xhci/>
     <virtio_devices>
       <console/>
-      <network>WaaG</network>
+      <network>
+        <virtio_framework/>
+        <interface_name>WaaG</interface_name>
+      </network>
       <input/>
       <block>./win10-ltsc.img</block>
     </virtio_devices>
@@ -173,8 +176,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>YaaG</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>

--- a/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
@@ -110,7 +110,10 @@
     <usb_xhci/>
     <virtio_devices>
       <console/>
-      <network>WaaG</network>
+      <network>
+        <virtio_framework/>
+        <interface_name>WaaG</interface_name>
+      </network>
       <input/>
       <block>./win10-ltsc.img</block>
     </virtio_devices>
@@ -138,8 +141,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>RT</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>RT</interface_name>
+      </network>
       <input/>
       <block>./core-image-weston-intel-corei7-64.wic</block>
     </virtio_devices>
@@ -166,8 +175,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG3</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>YaaG3</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>
@@ -194,8 +209,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG4</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>YaaG4</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>
@@ -222,8 +243,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG5</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>YaaG5</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>
@@ -250,8 +277,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG6</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>YaaG6</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
@@ -148,7 +148,10 @@
     <usb_xhci/>
     <virtio_devices>
       <console/>
-      <network>WaaG</network>
+      <network>
+        <virtio_framework/>
+        <interface_name>WaaG</interface_name>
+      </network>
       <input/>
       <block>./win10-ltsc.img</block>
     </virtio_devices>
@@ -173,8 +176,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>YaaG</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>

--- a/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
@@ -122,7 +122,10 @@
     <usb_xhci/>
     <virtio_devices>
       <console/>
-      <network>WaaG</network>
+      <network>
+	<virtio_framework/>
+	<interface_name>WaaG</interface_name>
+      </network>
       <input/>
       <block>./win10-ltsc.img</block>
     </virtio_devices>
@@ -150,8 +153,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>RT</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+	<virtio_framework/>
+	<interface_name>RT</interface_name>
+      </network>
       <input/>
       <block>./core-image-weston-intel-corei7-64.wic</block>
     </virtio_devices>
@@ -178,8 +187,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG3</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+	<virtio_framework/>
+	<interface_name>YaaG3</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>
@@ -206,8 +221,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG4</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+	<virtio_framework/>
+	<interface_name>YaaG4</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>
@@ -234,8 +255,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG5</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+	<virtio_framework/>
+	<interface_name>YaaG5</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>
@@ -262,8 +289,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>YaaG6</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+	<virtio_framework/>
+	<interface_name>YaaG6</interface_name>
+      </network>
       <input/>
       <block>./YaaG.img</block>
     </virtio_devices>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
@@ -123,8 +123,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>WaaG</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>WaaG</interface_name>
+      </network>
       <input/>
       <block>./win10-ltsc.img</block>
     </virtio_devices>
@@ -153,8 +159,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>RT</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>RT</interface_name>
+      </network>
       <input/>
       <block>./core-image-weston-intel-corei7-64.wic</block>
     </virtio_devices>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
@@ -164,7 +164,10 @@
     <usb_xhci/>
     <virtio_devices>
       <console/>
-      <network>WaaG</network>
+      <network>
+        <virtio_framework/>
+        <interface_name>WaaG</interface_name>
+      </network>
       <input/>
       <block>./win10-ltsc.img</block>
     </virtio_devices>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
@@ -113,8 +113,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>RT</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>RT</interface_name>
+      </network>
       <input/>
       <block>./core-image-weston-intel-corei7-64.wic</block>
     </virtio_devices>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_vxworks.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_vxworks.xml
@@ -99,7 +99,10 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
       <network/>
       <input/>
       <block>./VxWorks.img</block>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
@@ -103,7 +103,10 @@
     <usb_xhci/>
     <virtio_devices>
       <console/>
-      <network>WaaG</network>
+      <network>
+        <virtio_framework/>
+        <interface_name>WaaG</interface_name>
+      </network>
       <input/>
       <block>./win10-ltsc.img</block>
     </virtio_devices>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
@@ -103,7 +103,10 @@
     <usb_xhci/>
     <virtio_devices>
       <console/>
-      <network>WaaG</network>
+      <network>
+        <virtio_framework/>
+        <interface_name>WaaG</interface_name>
+      </network>
       <input/>
       <block>./win10-ltsc.img</block>
     </virtio_devices>
@@ -131,8 +134,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>RT</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>RT</interface_name>
+      </network>
       <input/>
       <block>./core-image-weston-intel-corei7-64.wic</block>
     </virtio_devices>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
@@ -103,7 +103,10 @@
     <usb_xhci/>
     <virtio_devices>
       <console/>
-      <network>WaaG</network>
+      <network>
+        <virtio_framework/>
+        <interface_name>WaaG</interface_name>
+      </network>
       <input/>
       <block>./win10-ltsc.img</block>
     </virtio_devices>
@@ -131,8 +134,14 @@
     <vuart0>Disable</vuart0>
     <usb_xhci/>
     <virtio_devices>
-      <console>@stdio:stdio_port</console>
-      <network>RT</network>
+      <console>
+        <use_type>Virtio console</use_type>
+        <backend_type>stdio</backend_type>
+      </console>
+      <network>
+        <virtio_framework/>
+        <interface_name>RT</interface_name>
+      </network>
       <input/>
       <block>./core-image-weston-intel-corei7-64.wic</block>
     </virtio_devices>

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -253,6 +253,108 @@ CLOSID 0 and the second is mapped to virtual CLOSID 1, etc.</xs:documentation>
   </xs:sequence>
 </xs:complexType>
 
+<xs:simpleType name="VirtioNetworkFrameworkType">
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="Kernel based (Virtual Host)" />
+    <xs:enumeration value="User space based (VBSU)" />
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="VirtioNetworkConfiguration">
+  <xs:sequence>
+    <xs:element name="virtio_framework" type="VirtioNetworkFrameworkType" default="User space based (VBSU)" minOccurs="0">
+      <xs:annotation acrn:title="Virtio framework">
+        <xs:documentation>Specify the virtio framework for specific virtio network device implemented in the Service VM.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="interface_name" minOccurs="0">
+      <xs:annotation acrn:title="Network interface name">
+        <xs:documentation>Specify the network interface name that will appear in the Service VM. Use the `ip a` command in the Service VM to display the network interface names.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[a-zA-Z0-9_\-]+" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:element>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:simpleType name="VirtioConsoleUseType">
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="Virtio console" />
+    <xs:enumeration value="Virtio serial port" />
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="VirtioConsoleBackendType">
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="pty" />
+    <xs:enumeration value="stdio" />
+    <xs:enumeration value="file" />
+    <xs:enumeration value="sock client">
+      <xs:annotation acrn:views="" />
+    </xs:enumeration>
+    <xs:enumeration value="sock server">
+      <xs:annotation acrn:views="" />
+    </xs:enumeration>
+    <xs:enumeration value="tty" >
+      <xs:annotation acrn:views="" />
+    </xs:enumeration>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="VirtioConsoleConfiguration">
+  <xs:sequence>
+    <xs:element name="use_type" type="VirtioConsoleUseType" minOccurs="0">
+      <xs:annotation acrn:title="Use type">
+        <xs:documentation>Specify device type in guest, ether HVC console when user config it as virtio console or /dev/vportXpY
+        device file when user config it as virtio serial port, which can be read and written from the user space.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="backend_type" type="VirtioConsoleBackendType" minOccurs="0">
+      <xs:annotation acrn:title="Backend type">
+        <xs:documentation>Specify backend device type in service VM.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="output_file_path" type="xs:string" minOccurs="0" maxOccurs="1">
+      <xs:annotation acrn:title="Output file path">
+        <xs:documentation>The output file path for the file backend type.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="sock_file_path" type="xs:string" minOccurs="0" maxOccurs="1">
+      <xs:annotation acrn:title="Sock file path">
+        <xs:documentation>The sock file path for the sock server or client backend type.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="tty_device_path" type="xs:string" minOccurs="0" maxOccurs="1">
+      <xs:annotation acrn:title="TTY device path">
+        <xs:documentation>The device path for the tty backend type.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="VirtioInputConfiguration">
+  <xs:sequence>
+    <xs:element name="backend_device_file" type="xs:string" minOccurs="0">
+      <xs:annotation acrn:title="Backend device file">
+        <xs:documentation>Specifying backend device in service vm with device description.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="id" minOccurs="0">
+      <xs:annotation acrn:title="Guest virtio input device unique identifier">
+        <xs:documentation>Specifying unique identifier to distinguish same devices in guest.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[a-zA-Z0-9_\-]*" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:element>
+  </xs:sequence>
+</xs:complexType>
+
 <xs:simpleType name="OSType">
   <xs:restriction base="xs:string">
     <xs:enumeration value="Non-Windows OS" />

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -434,35 +434,35 @@ argument and memory.</xs:documentation>
     </xs:element>
     <xs:element name="virtio_devices">
       <xs:annotation acrn:title="Virt-IO devices" acrn:views="basic" acrn:applicable-vms="post-launched">
-	<xs:documentation>Enable virt-IO devices in post-launched VMs.</xs:documentation>
+        <xs:documentation>Enable virt-IO devices in post-launched VMs.</xs:documentation>
       </xs:annotation>
       <xs:complexType>
         <xs:all>
-          <xs:element name="console" type="xs:string" minOccurs="0">
-            <xs:annotation acrn:views="basic">
-              <xs:documentation>The virtio console device setting. Input format:
-``[@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]``</xs:documentation>
+          <xs:element name="console" type="VirtioConsoleConfiguration" minOccurs="0">
+            <xs:annotation acrn:title="Virtio console device" acrn:views="basic">
+              <xs:documentation>Virtio console device for data input and output.
+              The virtio console BE driver copies data from the frontend's transmitting virtqueue when it receives a kick on virtqueue (implemented as a vmexit).
+              The BE driver then writes the data to backend, and can be implemented as PTY, TTY, STDIO, and regular file.
+              For details, reference to https://projectacrn.github.io/latest/developer-guides/hld/virtio-console.html.</xs:documentation>
             </xs:annotation>
           </xs:element>
-          <xs:element name="network" type="xs:string" minOccurs="0">
-            <xs:annotation acrn:views="basic">
-              <xs:documentation>The virtio network device setting.
-Input format: ``device_name[,vhost][,mac=XX:XX:XX:XX:XX:XX]``.
-The ``device_name`` is the name of the TAP (or MacVTap) device.
-It must include the keyword ``tap``. ``vhost`` specifies the
-vhost backend; otherwise, the VBSU backend is used. The ``mac``
-address is optional.</xs:documentation>
+          <xs:element name="network" type="VirtioNetworkConfiguration" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation acrn:title="Virtio network device" acrn:views="basic">
+              <xs:documentation>The virtio network device emulates a virtual network interface card (NIC) for the VM.
+              The frontend is the virtio network driver, simulating the virtual NIC. The backend could be:
+              1. ``tap`` device /dev/net/tun; 2. ``MacVTap`` device (/dev/tapx); 3. ``vhost`` device /dev/vhost-net.</xs:documentation>
             </xs:annotation>
           </xs:element>
-          <xs:element name="input" type="xs:string" minOccurs="0">
-	    <xs:annotation acrn:views="basic">
-	      <xs:documentation>The virtio input device setting.</xs:documentation>
-	    </xs:annotation>
-	  </xs:element>
+          <xs:element name="input" type="VirtioInputConfiguration" minOccurs="0" maxOccurs="unbounded">
+	        <xs:annotation acrn:title="Virtio input device" acrn:views="basic">
+	          <xs:documentation>The virtio input device creates a virtual human interface device such as a keyboard, mouse, and tablet.
+              It sends Linux input layer events over virtio.</xs:documentation>
+	        </xs:annotation>
+	      </xs:element>
           <xs:element name="block" type="xs:string" minOccurs="0" maxOccurs="unbounded">
-            <xs:annotation acrn:views="basic">
-              <xs:documentation>The virtio block device setting.
-Format: ``[blk partition:][img path]``. Example: ``/dev/sda3:./a/b.img``.</xs:documentation>
+            <xs:annotation acrn:title="Virtio block device" acrn:views="basic">
+              <xs:documentation>The virtio-blk device presents a block device to the VM.
+              Each virtio-blk device appears as a disk inside the VM.</xs:documentation>
             </xs:annotation>
           </xs:element>
         </xs:all>


### PR DESCRIPTION
We have redesigned Virtio devices (network/input/console) for the user, This patch series include refining the schema,  updating the launch script generation logic, and updating the upgrader python script for the new design.