### PR TITLE
packaging: error while loading shared libraries: libSDL2-2.0.so.0

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -459,7 +459,7 @@ address is optional.</xs:documentation>
 	      <xs:documentation>The virtio input device setting.</xs:documentation>
 	    </xs:annotation>
 	  </xs:element>
-          <xs:element name="block" type="xs:string" minOccurs="0">
+          <xs:element name="block" type="xs:string" minOccurs="0" maxOccurs="unbounded">
             <xs:annotation acrn:views="basic">
               <xs:documentation>The virtio block device setting.
 Format: ``[blk partition:][img path]``. Example: ``/dev/sda3:./a/b.img``.</xs:documentation>

--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -90,6 +90,7 @@ def create_acrn_deb(board, scenario, version, build_dir):
         'Package: acrn-hypervisor\n',
         'version: %s \n' % version,
         'Depends: libcjson1\n',
+        'Pre-Depends: libsdl2-dev\n',
         'Section: free \n',
         'Priority: optional \n',
         'Architecture: amd64 \n',


### PR DESCRIPTION
Added the "libsdl2-dev" dependency in file "misc/packaging/gen_acrn_deb.py"

Tracked-On: ACRN-7286
Signed-off-by: zihengL1 <ziheng.li@intel.com>