### PR TITLE
Refine for HPAn setting

### DIFF
--- a/hypervisor/include/arch/x86/asm/vm_config.h
+++ b/hypervisor/include/arch/x86/asm/vm_config.h
@@ -70,12 +70,15 @@ enum acrn_vm_severity {
 	SEVERITY_STANDARD_VM = 0x10U,
 };
 
+struct vm_hpa_regions {
+	uint64_t start_hpa;
+	uint64_t size_hpa;
+};
+
 struct acrn_vm_mem_config {
-	uint64_t start_hpa;	/* the start HPA of VM memory configuration, for pre-launched VMs only */
 	uint64_t size;		/* VM memory size configuration */
-	uint64_t start_hpa2;	/* Start of second HPA for non-contiguous allocations in VM memory configuration,
-				   for pre-launched VMs only */
-	uint64_t size_hpa2;	/* Size of second HPA for non-contiguous allocations in VM memory configuration */
+	uint64_t region_num;
+	struct vm_hpa_regions  *host_regions;
 };
 
 struct target_vuart {

--- a/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
@@ -81,10 +81,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x100000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x100000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_ELF</kern_type>
@@ -119,9 +119,6 @@
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -145,7 +142,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>4096</whole>
+      <size>4096</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <pci_devs>
@@ -179,7 +176,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>

--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -96,10 +96,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x100000000</start_hpa>
-      <size>0x40000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x100000000</start_hpa>
+        <size_hpa>1024</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
@@ -151,9 +151,6 @@
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>

--- a/misc/config_tools/data/cfl-k700-i7/partitioned.xml
+++ b/misc/config_tools/data/cfl-k700-i7/partitioned.xml
@@ -85,10 +85,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x100000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x100000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
@@ -127,10 +127,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x120000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x120000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/cfl-k700-i7/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/shared_launch_6user_vm.xml
@@ -63,10 +63,6 @@
     <clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-      <size>0x20000000</size>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -93,7 +89,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>4096</whole>
+      <size>4096</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <pci_devs>
@@ -134,7 +130,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>1024</whole>
+      <size>1024</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -172,7 +168,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -210,7 +206,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -248,7 +244,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -286,7 +282,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>

--- a/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
@@ -81,10 +81,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x100000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x100000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_ELF</kern_type>
@@ -120,9 +120,6 @@
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -145,7 +142,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>4096</whole>
+      <size>4096</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <pci_devs>
@@ -179,7 +176,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>

--- a/misc/config_tools/data/generic_board/hybrid_rt.xml
+++ b/misc/config_tools/data/generic_board/hybrid_rt.xml
@@ -109,10 +109,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x100000000</start_hpa>
-      <size>0x40000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x100000000</start_hpa>
+        <size_hpa>1024</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
@@ -145,9 +145,6 @@
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>

--- a/misc/config_tools/data/generic_board/partitioned.xml
+++ b/misc/config_tools/data/generic_board/partitioned.xml
@@ -85,10 +85,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x100000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x100000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
@@ -127,10 +127,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x120000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x120000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
@@ -71,10 +71,6 @@
     <clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-      <size>0x20000000</size>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -101,7 +97,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>4096</whole>
+      <size>4096</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <pci_devs>
@@ -142,7 +138,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>1024</whole>
+      <size>1024</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -180,7 +176,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -218,7 +214,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -256,7 +252,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -294,7 +290,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
@@ -81,10 +81,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x100000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x100000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_ELF</kern_type>
@@ -120,9 +120,6 @@
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -145,7 +142,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>4096</whole>
+      <size>4096</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <pci_devs>
@@ -179,7 +176,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>

--- a/misc/config_tools/data/nuc11tnbi5/partitioned.xml
+++ b/misc/config_tools/data/nuc11tnbi5/partitioned.xml
@@ -85,10 +85,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x100000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x100000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
@@ -127,10 +127,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x120000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x120000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
@@ -83,10 +83,6 @@
     <clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-      <size>0x20000000</size>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -113,7 +109,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>4096</whole>
+      <size>4096</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <pci_devs>
@@ -154,7 +150,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>1024</whole>
+      <size>1024</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -192,7 +188,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -230,7 +226,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -268,7 +264,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -306,7 +302,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>

--- a/misc/config_tools/data/qemu/shared.xml
+++ b/misc/config_tools/data/qemu/shared.xml
@@ -64,9 +64,6 @@
     <clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
@@ -81,10 +81,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x100000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x100000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_ELF</kern_type>
@@ -120,9 +120,6 @@
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/partitioned.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/partitioned.xml
@@ -85,10 +85,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x100000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x100000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
@@ -127,10 +127,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x120000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x120000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
@@ -83,10 +83,6 @@
     <clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-      <size>0x20000000</size>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -114,7 +110,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>4096</whole>
+      <size>4096</size>
     </memory>
     <priority>PRIO_LOW</priority>
     <console_vuart>COM Port 1</console_vuart>
@@ -159,7 +155,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>1024</whole>
+      <size>1024</size>
     </memory>
     <priority>PRIO_LOW</priority>
     <console_vuart>COM Port 1</console_vuart>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -73,10 +73,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x100000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x100000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_ELF</kern_type>
@@ -110,9 +110,6 @@
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
@@ -96,10 +96,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x100000000</start_hpa>
-      <size>0x40000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x100000000</start_hpa>
+        <size_hpa>1024</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
@@ -135,9 +135,6 @@
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -164,7 +161,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>4096</whole>
+      <size>4096</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <pci_devs>

--- a/misc/config_tools/data/whl-ipc-i5/partitioned.xml
+++ b/misc/config_tools/data/whl-ipc-i5/partitioned.xml
@@ -77,10 +77,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x100000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x100000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
@@ -121,10 +121,10 @@
       <size>0</size>
     </epc_section>
     <memory>
-      <start_hpa>0x120000000</start_hpa>
-      <size>0x20000000</size>
-      <start_hpa2>0x0</start_hpa2>
-      <size_hpa2>0x0</size_hpa2>
+      <hpa_region>
+        <start_hpa>0x120000000</start_hpa>
+        <size_hpa>512</size_hpa>
+      </hpa_region>
     </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
@@ -63,10 +63,6 @@
     <clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-      <size>0x20000000</size>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -114,7 +110,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>1024</whole>
+      <size>1024</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_vxworks.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_vxworks.xml
@@ -63,10 +63,6 @@
     <clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-      <size>0x20000000</size>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -96,7 +92,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>2048</whole>
+      <size>2048</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
@@ -63,10 +63,6 @@
     <clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-      <size>0x20000000</size>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -93,7 +89,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>4096</whole>
+      <size>4096</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <pci_devs>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
@@ -63,10 +63,6 @@
     <clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-      <size>0x20000000</size>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -93,7 +89,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>4096</whole>
+      <size>4096</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <pci_devs>
@@ -135,7 +131,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>1024</whole>
+      <size>1024</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
@@ -63,10 +63,6 @@
     <clos>
       <vcpu_clos>0</vcpu_clos>
     </clos>
-    <memory>
-      <start_hpa>0</start_hpa>
-      <size>0x20000000</size>
-    </memory>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -93,7 +89,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>4096</whole>
+      <size>4096</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <pci_devs>
@@ -135,7 +131,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>1024</whole>
+      <size>1024</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -173,7 +169,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -205,7 +201,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -237,7 +233,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
@@ -269,7 +265,7 @@
       <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-      <whole>512</whole>
+      <size>512</size>
     </memory>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>

--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -211,7 +211,7 @@ def generate_for_one_vm(board_etree, hv_scenario_etree, vm_scenario_etree, vm_id
     if lapic_ids:
         script.add_dynamic_dm_parameter("add_cpus", f"{' '.join([str(x) for x in sorted(lapic_ids)])}")
 
-    script.add_plain_dm_parameter(f"-m {eval_xpath(vm_scenario_etree, './/memory/whole/text()')}M")
+    script.add_plain_dm_parameter(f"-m {eval_xpath(vm_scenario_etree, './/memory/size/text()')}M")
 
     if eval_xpath(vm_scenario_etree, "//SSRAM_ENABLED") == "y" and \
        eval_xpath(vm_scenario_etree, ".//vm_type/text()") == "RTVM":

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -100,31 +100,32 @@ CLOSID 0 and the second is mapped to virtual CLOSID 1, etc.</xs:documentation>
   </xs:sequence>
 </xs:complexType>
 
+<xs:complexType name="HPARegionType">
+  <xs:sequence>
+    <xs:element name="start_hpa" type="HexFormat">
+      <xs:annotation acrn:title="Start physical address">
+        <xs:documentation>Specify the starting address for non-contiguous allocation.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="size_hpa" type="xs:integer">
+      <xs:annotation acrn:title="Size (MB)">
+        <xs:documentation>Specify the physical memory size for non-contiguous allocation in megabytes.
+The size is a subset of the VM's total memory size specified on the Basic tab.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+  </xs:sequence>
+</xs:complexType>
+
 <xs:complexType name="MemoryInfo">
   <xs:all>
-    <xs:element name="whole" type="xs:integer" default="256">
-      <xs:annotation acrn:title="Memory size (MB)" acrn:views="basic" acrn:applicable-vms="post-launched">
-	<xs:documentation>Specify the physical memory size allocated to this VM in megabytes.</xs:documentation>
+    <xs:element name="size" type="xs:integer" minOccurs="0" default="256">
+      <xs:annotation acrn:title="Memory size (MB)" acrn:views="basic" acrn:applicable-vms="pre-launched, post-launched">
+       <xs:documentation>Specify the physical memory size allocated to this VM in megabytes.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="start_hpa" type="HexFormat" default="0x100000000">
-      <xs:annotation acrn:views="advanced" acrn:applicable-vms="pre-launched, service-vm">
-        <xs:documentation>The starting physical address in host for the VM.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
-    <xs:element name="size" type="MemorySizeType" default="0x20000000" minOccurs="0">
-      <xs:annotation acrn:views="advanced" acrn:applicable-vms="pre-launched, service-vm">
-        <xs:documentation>The memory size in bytes for the VM. Default value is ``0x200000000``.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
-    <xs:element name="start_hpa2" type="HexFormat" default="0x0" minOccurs="0">
-      <xs:annotation acrn:views="advanced" acrn:applicable-vms="pre-launched, service-vm">
-        <xs:documentation>Start of second HPA for non-contiguous allocations in host for the VM.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
-    <xs:element name="size_hpa2" type="MemorySizeType" default="0x0" minOccurs="0">
-      <xs:annotation acrn:views="advanced" acrn:applicable-vms="pre-launched, service-vm">
-        <xs:documentation>Memory size of second HPA for non-contiguous allocations in Bytes for the VM.</xs:documentation>
+    <xs:element name="hpa_region" type="HPARegionType" minOccurs="0" maxOccurs="unbounded">
+      <xs:annotation acrn:title="Physical memory segmentation" acrn:views="advanced" acrn:applicable-vms="pre-launched" >
+        <xs:documentation>Specify Physical memory information for Prelaunched VM </xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:all>

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -358,9 +358,9 @@ Refer SDM 17.19.2 for details, and use with caution.</xs:documentation>
         <xs:documentation>Specify the Intel Software Guard Extensions (SGX) enclave page cache (EPC) section settings.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="memory" type="MemoryInfo">
-      <xs:annotation acrn:views="basic, advanced">
-        <xs:documentation>Specify memory information for Service and User VMs.</xs:documentation>
+    <xs:element name="memory" type="MemoryInfo" minOccurs="0">
+      <xs:annotation acrn:views="basic, advanced" acrn:applicable-vms="pre-launched, post-launched">
+        <xs:documentation>Specify memory information for User VMs.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="priority" type="PriorityType"  default="PRIO_LOW">

--- a/misc/config_tools/static_allocators/memory_allocator.py
+++ b/misc/config_tools/static_allocators/memory_allocator.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 Intel Corporation.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import os
+import sys
+import lib.error
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'library'))
+import common
+
+def import_memory_info(board_etree):
+    ram_range = {}
+    start = board_etree.xpath("/acrn-config/memory/range/@start")
+    size = board_etree.xpath("/acrn-config/memory/range/@size")
+    for i in range(len(start)):
+        start_hex = int(start[i], 16)
+        size_hex = int(size[i], 10)
+        ram_range[start_hex] = size_hex
+
+    return ram_range
+
+def check_hpa(vm_node_info):
+    hpa_node_list = vm_node_info.xpath("./memory/hpa_region/*")
+    hpa_node_list_new = []
+    for hpa_node in hpa_node_list:
+        if int(hpa_node.text, 16) != 0:
+            hpa_node_list_new.append(hpa_node)
+
+    return hpa_node_list_new
+
+def get_memory_info(vm_node_info):
+    start_hpa = []
+    size_hpa = []
+    hpa_info = {}
+
+    whole_node_list = vm_node_info.xpath("./memory/size")
+    if len(whole_node_list) != 0:
+        hpa_info[0] = int(whole_node_list[0].text, 16)
+    hpa_node_list = check_hpa(vm_node_info)
+    if len(hpa_node_list) != 0:
+        for hpa_node in hpa_node_list:
+            if hpa_node.tag == "start_hpa":
+                start_hpa.append(int(hpa_node.text, 16))
+            elif hpa_node.tag == "size_hpa":
+                size_hpa.append(int(hpa_node.text))
+    if len(start_hpa) != 0 and len(start_hpa) == len(start_hpa):
+        for i in range(len(start_hpa)):
+            hpa_info[start_hpa[i]] = size_hpa[i]
+
+    return hpa_info
+
+def alloc_memory(scenario_etree, ram_range_info):
+    vm_node_list = scenario_etree.xpath("/acrn-config/vm[load_order = 'PRE_LAUNCHED_VM']")
+    mem_info_list = []
+    vm_node_index_list = []
+    dic_key = sorted(ram_range_info)
+    for key in dic_key:
+        if key <= 0x100000000:
+            ram_range_info.pop(key)
+
+    for vm_node in vm_node_list:
+        mem_info = get_memory_info(vm_node)
+        mem_info_list.append(mem_info)
+        vm_node_index_list.append(vm_node.attrib["id"])
+
+    ram_range_info = alloc_hpa_region(ram_range_info, mem_info_list, vm_node_index_list)
+    ram_range_info, mem_info_list = alloc_whole_size(ram_range_info, mem_info_list, vm_node_index_list)
+
+    return ram_range_info, mem_info_list, vm_node_index_list
+
+def alloc_hpa_region(ram_range_info, mem_info_list, vm_node_index_list):
+    mem_key = sorted(ram_range_info)
+    for vm_index in range(len(vm_node_index_list)):
+        hpa_key = sorted(mem_info_list[vm_index])
+        for mem_start in mem_key:
+            mem_size = ram_range_info[mem_start]
+            for hpa_start in hpa_key:
+                hpa_size = mem_info_list[vm_index][hpa_start]
+                if hpa_start != 0:
+                    if mem_start < hpa_start and mem_start + mem_size > hpa_start + hpa_size:
+                        ram_range_info[mem_start] = hpa_start - mem_start
+                        ram_range_info[hpa_start - mem_start] = mem_start + mem_size - hpa_start - hpa_size
+                    elif mem_start == hpa_start and mem_start + mem_size > hpa_start + hpa_size:
+                        del ram_range_info[mem_start]
+                        ram_range_info[hpa_start + hpa_size] = mem_start + mem_size - hpa_start - hpa_size
+                    elif mem_start < hpa_start and mem_start + mem_size == hpa_start + hpa_size:
+                        ram_range_info[mem_start] = hpa_start - mem_start
+                    elif mem_start == hpa_start and mem_start + mem_size == hpa_start + hpa_size:
+                        del ram_range_info[mem_start]
+                    elif mem_start > hpa_start or mem_start + mem_size < hpa_start + hpa_size:
+                        raise lib.error.ResourceError(f"Start address of HPA is out of available memory range: vm id: {vm_index}, hpa_start: {hpa_start}.")
+                    elif mem_size < hpa_size:
+                        raise lib.error.ResourceError(f"Size of HPA is out of available memory range: vm id: {vm_index}, hpa_size: {hpa_size}.")
+
+    return ram_range_info
+
+def alloc_whole_size(ram_range_info, mem_info_list, vm_node_index_list):
+    for vm_index in range(len(vm_node_index_list)):
+        if 0 in mem_info_list[vm_index].keys() and mem_info_list[vm_index][0] != 0:
+            remain_size = mem_info_list[vm_index][0]
+            hpa_info = mem_info_list[vm_index]
+            mem_key = sorted(ram_range_info)
+            for mem_start in mem_key:
+                mem_size = ram_range_info[mem_start]
+                if remain_size != 0 and remain_size <= mem_size:
+                    del ram_range_info[mem_start]
+                    hpa_info[mem_start] = remain_size
+                    del hpa_info[0]
+                    if mem_size > remain_size:
+                        ram_range_info[mem_start + remain_size] = mem_size - remain_size
+                    remain_size = 0
+                elif remain_size > mem_size:
+                    hpa_info[mem_start] = mem_size
+                    del ram_range_info[mem_start]
+                    hpa_info[0] = remain_size - mem_size
+                    remain_size = hpa_info[0]
+
+    return ram_range_info, mem_info_list
+
+def write_hpa_info(allocation_etree, mem_info_list, vm_node_index_list):
+    for i in range(len(vm_node_index_list)):
+        vm_id = vm_node_index_list[i]
+        hpa_info = mem_info_list[i]
+        vm_node = common.get_node(f"/acrn-config/vm[@id = '{vm_id}']", allocation_etree)
+        if vm_node is None:
+            vm_node = common.append_node("/acrn-config/vm", None, allocation_etree, id=vm_id)
+        memory_node = common.get_node("./memory", vm_node)
+        if memory_node is None:
+            memory_node = common.append_node(f"./memory", None, vm_node)
+        region_index = 1
+        start_key = sorted(hpa_info)
+        for start_hpa in start_key:
+            hpa_region_node = common.get_node(f"./hpa_region[@id='{region_index}']", memory_node)
+            if hpa_region_node is None:
+                hpa_region_node = common.append_node("./hpa_region", None, memory_node, id=str(region_index).encode('UTF-8'))
+
+                start_hpa_node = common.get_node("./start_hpa", hpa_region_node)
+                if start_hpa_node is None:
+                    common.append_node("./start_hpa", hex(start_hpa), hpa_region_node)
+
+                size_hpa_node = common.get_node("./size_hpa", hpa_region_node)
+                if size_hpa_node is None:
+                    common.append_node("./size_hpa", hex(hpa_info[start_hpa] * 0x100000), hpa_region_node)
+            region_index = region_index + 1
+
+def alloc_vm_memory(board_etree, scenario_etree, allocation_etree):
+    ram_range_info = import_memory_info(board_etree)
+    ram_range_info, mem_info_list, vm_node_index_list = alloc_memory(scenario_etree, ram_range_info)
+    write_hpa_info(allocation_etree, mem_info_list, vm_node_index_list)
+
+def fn(board_etree, scenario_etree, allocation_etree):
+    alloc_vm_memory(board_etree, scenario_etree, allocation_etree)

--- a/misc/config_tools/xforms/vm_configurations.h.xsl
+++ b/misc/config_tools/xforms/vm_configurations.h.xsl
@@ -31,7 +31,6 @@
 
   <xsl:template match="config-data/acrn-config">
     <xsl:call-template name="vm_count" />
-    <xsl:call-template name="pre_launched_vm_hpa" />
     <xsl:call-template name="sos_vm_bootarges" />
   </xsl:template>
 
@@ -50,17 +49,6 @@
       <xsl:value-of select="$newline" />
       <xsl:value-of select="acrn:define('SERVICE_VM_OS_BOOTARGS', 'SERVICE_VM_ROOTFS SERVICE_VM_IDLE SERVICE_VM_BOOTARGS_DIFF', '')" />
     </xsl:if>
-  </xsl:template>
-
-  <xsl:template name ="pre_launched_vm_hpa">
-    <xsl:for-each select="vm">
-      <xsl:if test="acrn:is-pre-launched-vm(load_order)">
-        <xsl:value-of select="acrn:define(concat('VM', @id, '_CONFIG_MEM_START_HPA'), memory/start_hpa, 'UL')" />
-        <xsl:value-of select="acrn:define(concat('VM', @id, '_CONFIG_MEM_SIZE'), memory/size, 'UL')" />
-        <xsl:value-of select="acrn:define(concat('VM', @id, '_CONFIG_MEM_START_HPA2'), memory/start_hpa2, 'UL')" />
-        <xsl:value-of select="acrn:define(concat('VM', @id, '_CONFIG_MEM_SIZE_HPA2'), memory/size_hpa2, 'UL')" />
-      </xsl:if>
-    </xsl:for-each>
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
The current code only supports 2 HPA regions per VM.

So we redesign and extended ACRN to support 2+ HPA regions per VM,
to use host memory better if it is scatted among multiple regions.

This series of patches also change the offline tool to adapter the HPAn
setting, include the schema and xsl change to generate .c and .h.

This patch depend on the config tool allocate HPA patch.