### PR TITLE
doc: fix table CSS font size changing with lists

### DIFF
--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -377,3 +377,15 @@ img.drop-shadow {
 .bg-lightgrey {
     background-color: lightgrey;
 }
+
+/* The style in theme.css for tables uses a slightly smaller font size, but was
+   only affecting paragraphs where the immediate parent was a th or td tag.  Fix
+   this so that all paragraphs within a th or td tag have this style applied.
+   (This shows up if you have a table with a bullet list: the bullet list paragraph
+   fontsize went back to the default.) */
+
+html.writer-html5 .rst-content table.docutils td p {
+   line-height: 1rem;
+   margin-bottom: 0;
+   font-size: .9rem;
+}


### PR DESCRIPTION
The read-the-docs theme uses a reduced font size within tables.  The CSS
used though is overly restrictive and doesn't properly handle tables
containing lists or other constructs where the paragraph tags don't have
the <td> tag within the table as the immediate parent.  Add an
overriding style in our custom CSS to fix this so the font size on lists
within a table are the same as normal paragraphs within a table.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>