### PR TITLE
config tool:add support for bootargs missing

### DIFF
--- a/misc/config_tools/acpi_gen/asl_gen.py
+++ b/misc/config_tools/acpi_gen/asl_gen.py
@@ -829,7 +829,8 @@ def main(args):
     kern_args = common.get_leaf_tag_map(scenario, "os_config", "bootargs")
     kern_type = common.get_leaf_tag_map(scenario, "os_config", "kern_type")
     for vm_id, passthru_devices in dict_passthru_devices.items():
-        if kern_args[int(vm_id)].find('reboot=acpi') == -1 and kern_type[int(vm_id)] in ['KERNEL_BZIMAGE']:
+        bootargs_node= common.get_node(f"//vm[@id='{vm_id}']/os_config/bootargs", scenario_etree)
+        if bootargs_node is not None and kern_args[int(vm_id)].find('reboot=acpi') == -1 and kern_type[int(vm_id)] in ['KERNEL_BZIMAGE']:
             emsg = "you need to specify 'reboot=acpi' in scenario file's bootargs for VM{}".format(vm_id)
             print(emsg)
             err_dic['vm,bootargs'] = emsg


### PR DESCRIPTION
Bugfix:bootargs is optional parameter, which may be not
present in xml as a node, asl_gen.py needs to process
that case.

Tracked-On: #7307
Signed-off-by: hangliu1 <hang1.liu@linux.intel.com>