### PR TITLE
Acrn vgpu sigsegv

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_gpu.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpu.c
@@ -463,9 +463,6 @@ virtio_gpu_reset(void *vdev)
 	}
 	LIST_INIT(&gpu->r2d_list);
 	gpu->vga.enable = true;
-	vdpy_surface_set(gpu->vdpy_handle, &gpu->vga.surf);
-	gpu->vga.surf.width = 0;
-	gpu->vga.surf.stride = 0;
 	pthread_mutex_lock(&gpu->vga_thread_mtx);
 	if (atomic_load(&gpu->vga_thread_status) == VGA_THREAD_EOL) {
 		atomic_store(&gpu->vga_thread_status, VGA_THREAD_RUNNING);
@@ -1409,6 +1406,8 @@ virtio_gpu_vga_render(void *param)
 	struct virtio_gpu *gpu;
 
 	gpu = (struct virtio_gpu*)param;
+	gpu->vga.surf.width = 0;
+	gpu->vga.surf.stride = 0;
 	/* The below logic needs to be refined */
 	while(gpu->vga.enable) {
 		if(gpu->vga.gc->gc_image->vgamode) {

--- a/devicemodel/hw/vdisplay_sdl.c
+++ b/devicemodel/hw/vdisplay_sdl.c
@@ -596,6 +596,12 @@ vdpy_surface_set(int handle, struct surface *surf)
 		return;
 	}
 
+	if (vdpy.tid != pthread_self()) {
+		pr_err("%s: unexpected code path as unsafe 3D ops in multi-threads env.\n",
+			__func__);
+		return;
+	}
+
 	if (surf == NULL ) {
 		vdpy.surf.width = 0;
 		vdpy.surf.height = 0;
@@ -755,6 +761,12 @@ vdpy_surface_update(int handle, struct surface *surf)
 		return;
 	}
 
+	if (vdpy.tid != pthread_self()) {
+		pr_err("%s: unexpected code path as unsafe 3D ops in multi-threads env.\n",
+			__func__);
+		return;
+	}
+
 	if (!surf) {
 		pr_err("Incorrect order of submitting Virtio-GPU cmd.\n");
 	        return;
@@ -787,6 +799,12 @@ void
 vdpy_cursor_define(int handle, struct cursor *cur)
 {
 	if (handle != vdpy.s.n_connect) {
+		return;
+	}
+
+	if (vdpy.tid != pthread_self()) {
+		pr_err("%s: unexpected code path as unsafe 3D ops in multi-threads env.\n",
+			__func__);
 		return;
 	}
 

--- a/devicemodel/hw/vga.c
+++ b/devicemodel/hw/vga.c
@@ -1426,3 +1426,32 @@ vga_vbe_read(struct vmctx *ctx, int vcpu, struct vga *vga,
 
 	return (value);
 }
+
+void vga_deinit(struct vga *vga)
+{
+	struct vga_vdev *vd;
+	struct inout_port iop;
+	int port;
+
+	vd = (struct vga_vdev *)vga->dev;
+
+	for (port = VGA_IOPORT_START; port <= VGA_IOPORT_END; port++) {
+		iop.port = port;
+		iop.size = 1;
+		iop.flags = IOPORT_F_INOUT;
+		iop.handler = NULL;
+		iop.arg = NULL;
+
+		unregister_inout(&iop);
+		//error = unregister_inout(&iop);
+		//assert(error == 0);
+	}
+
+	unregister_mem_fallback(&vd->mr);
+
+	free(vd->vga_ram);
+	vd->vga_ram = NULL;
+
+	free(vd);
+	vga->dev = NULL;
+}

--- a/devicemodel/include/vga.h
+++ b/devicemodel/include/vga.h
@@ -199,4 +199,5 @@ void vga_vbe_write(struct vmctx *ctx, int vcpu, struct vga *vga,
 uint64_t vga_vbe_read(struct vmctx *ctx, int vcpu, struct vga *vga,
 		uint64_t offset, int size);
 
+void vga_deinit(struct vga *vga);
 #endif /* _VGA_H_ */


### PR DESCRIPTION
ACRN-DM will display the framebuffer that is submitted from the virtio-gpu
in guest and this is based on 3D driver. But as the 3D driver is not thread-
safe, it will be better that the 3D ops related with virito-gpu needs to
be called in dedicated-thread env. Otherwise it will trigger the sigsegv
in thread_exiting.
This is the patch set that tries to fix the sigsegv issue.