### PR TITLE
doc: fix doc formatting in xsd files

### DIFF
--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -152,7 +152,7 @@ CLOSID 0 and the second is mapped to virtual CLOSID 1, etc.</xs:documentation>
 
 <xs:simpleType name="VMKernelType">
   <xs:annotation>
-    <xs:documentation>A string with either ``KERNEL_BZIMAGE``, ``KERNEL_ELF`` or
+    <xs:documentation>A string with either ``KERNEL_BZIMAGE`` or
 ``KERNEL_RAWIMAGE``.</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
@@ -165,6 +165,9 @@ CLOSID 0 and the second is mapped to virtual CLOSID 1, etc.</xs:documentation>
 </xs:simpleType>
 
 <xs:simpleType name="ConsoleVuartConfiguration">
+  <xs:annotation>
+    <xs:documentation>A string with either ``None``, ``COM Port 1``, ``COM Port 2``, ``COM Port 3``, or ``PCI``.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="None" />
     <xs:enumeration value="COM Port 1" />
@@ -309,7 +312,7 @@ CLOSID 0 and the second is mapped to virtual CLOSID 1, etc.</xs:documentation>
     <xs:element name="use_type" type="VirtioConsoleUseType" minOccurs="0">
       <xs:annotation acrn:title="Use type">
         <xs:documentation>Specify device type in guest, ether HVC console when user config it as virtio console or /dev/vportXpY
-        device file when user config it as virtio serial port, which can be read and written from the user space.</xs:documentation>
+device file when user config it as virtio serial port, which can be read and written from the user space.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="backend_type" type="VirtioConsoleBackendType" minOccurs="0">
@@ -356,6 +359,9 @@ CLOSID 0 and the second is mapped to virtual CLOSID 1, etc.</xs:documentation>
 </xs:complexType>
 
 <xs:simpleType name="OSType">
+  <xs:annotation>
+    <xs:documentation>A string with either ``Non-Windows OS`` or  ``Windows OS``.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="Non-Windows OS" />
     <xs:enumeration value="Windows OS" />

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -381,7 +381,7 @@ argument and memory.</xs:documentation>
     </xs:element>
     <xs:element name="console_vuart" type="ConsoleVuartConfiguration" default="None">
       <xs:annotation acrn:title="Console virtual UART type" acrn:views="basic">
-        <xs:documentation>Select the console virtual UART (vUART) type. Add the console settings to the kernel command line by typing them in the "Linux kernel command-line parameters" text box (for example, console=ttyS0 for COM port 1).</xs:documentation>
+        <xs:documentation>Select the console virtual UART (vUART) type. Add the console settings to the kernel command line by typing them in the "Linux kernel command-line parameters" text box (for example, ``console=ttyS0`` for COM port 1).</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="mmio_resources" type="MMIOResourcesConfiguration" minOccurs="0">
@@ -425,7 +425,7 @@ argument and memory.</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
         <xs:annotation>
-          <xs:documentation>Input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4</xs:documentation>
+          <xs:documentation>Input format: ``bus#-port#[:bus#-port#: ...]``, for example, ``1-2:2-4``.</xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
           <xs:pattern value="([\d]+-[\d]+){0,1}(:[\d]+-[\d]+)*" />
@@ -441,28 +441,27 @@ argument and memory.</xs:documentation>
           <xs:element name="console" type="VirtioConsoleConfiguration" minOccurs="0">
             <xs:annotation acrn:title="Virtio console device" acrn:views="basic">
               <xs:documentation>Virtio console device for data input and output.
-              The virtio console BE driver copies data from the frontend's transmitting virtqueue when it receives a kick on virtqueue (implemented as a vmexit).
-              The BE driver then writes the data to backend, and can be implemented as PTY, TTY, STDIO, and regular file.
-              For details, reference to https://projectacrn.github.io/latest/developer-guides/hld/virtio-console.html.</xs:documentation>
+The virtio console BE driver copies data from the frontend's transmitting virtqueue when it receives a kick on virtqueue (implemented as a vmexit).
+The BE driver then writes the data to backend, and can be implemented as PTY, TTY, STDIO, and regular file.
+For details, see :ref:`virtio-console`.</xs:documentation>
             </xs:annotation>
           </xs:element>
           <xs:element name="network" type="VirtioNetworkConfiguration" minOccurs="0" maxOccurs="unbounded">
             <xs:annotation acrn:title="Virtio network device" acrn:views="basic">
-              <xs:documentation>The virtio network device emulates a virtual network interface card (NIC) for the VM.
-              The frontend is the virtio network driver, simulating the virtual NIC. The backend could be:
-              1. ``tap`` device /dev/net/tun; 2. ``MacVTap`` device (/dev/tapx); 3. ``vhost`` device /dev/vhost-net.</xs:documentation>
+                <xs:documentation>The virtio network device emulates a virtual network interface card (NIC) for the VM.  The frontend
+is the virtio network driver, simulating the virtual NIC. The backend could be: ``tap`` device /dev/net/tun,
+``MacVTap`` device /dev/tapx, or ``vhost`` device /dev/vhost-net</xs:documentation>
             </xs:annotation>
           </xs:element>
           <xs:element name="input" type="VirtioInputConfiguration" minOccurs="0" maxOccurs="unbounded">
 	        <xs:annotation acrn:title="Virtio input device" acrn:views="basic">
-	          <xs:documentation>The virtio input device creates a virtual human interface device such as a keyboard, mouse, and tablet.
-              It sends Linux input layer events over virtio.</xs:documentation>
+                <xs:documentation>The virtio input device creates a virtual human interface device such as a keyboard,
+mouse, and tablet.  It sends Linux input layer events over virtio.</xs:documentation>
 	        </xs:annotation>
 	      </xs:element>
           <xs:element name="block" type="xs:string" minOccurs="0" maxOccurs="unbounded">
             <xs:annotation acrn:title="Virtio block device" acrn:views="basic">
-              <xs:documentation>The virtio-blk device presents a block device to the VM.
-              Each virtio-blk device appears as a disk inside the VM.</xs:documentation>
+              <xs:documentation>The virtio-blk device presents a block device to the VM. Each virtio-blk device appears as a disk inside the VM.</xs:documentation>
             </xs:annotation>
           </xs:element>
         </xs:all>


### PR DESCRIPTION
Documentation continuation lines must not be indented unless required by
rst syntax.

Added some type explations for enumerations, but would be better to
generate the enumeration values by scanning the tree. Figure that out in
another PR.  (This would prevent the documented list of values from
being out of sync with the actual list of values in the enumeration.)

Tracked-On: #5692

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>