### PR TITLE
packaging: error while loading shared libraries: libSDL2-2.0.so.0

### DIFF
--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -90,7 +90,7 @@ def create_acrn_deb(board, scenario, version, build_dir):
         'Package: acrn-hypervisor\n',
         'version: %s \n' % version,
         'Depends: libcjson1\n',
-        'Pre-Depends: libsdl2-dev\n',
+        'Pre-Depends: libsdl2-2.0-0\n',
         'Section: free \n',
         'Priority: optional \n',
         'Architecture: amd64 \n',


### PR DESCRIPTION
Added the "libsdl2-2.0-0" package in file
"misc/packaging/gen_acrn_deb.py

Tracked-On: projectacrn#7291
Signed-off-by: zihengL1 <ziheng.li@intel.com>