### PR TITLE
config-tools: update nuc11/whl/generic_board board files

### DIFF
--- a/misc/config_tools/data/generic_board/generic_board.xml
+++ b/misc/config_tools/data/generic_board/generic_board.xml
@@ -40,9 +40,9 @@
 	00:14.3 Network controller: Intel Corporation Wi-Fi 6 AX201 (rev 20)
 	Region 0: Memory at 603d1a4000 (64-bit, non-prefetchable) [size=16K]
 	00:15.0 Serial bus controller: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #0 (rev 20)
-	Region 0: Memory at 4017000000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 4017000000 (64-bit, non-prefetchable) [virtual] [size=4K]
 	00:15.1 Serial bus controller: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #1 (rev 20)
-	Region 0: Memory at 4017001000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 4017001000 (64-bit, non-prefetchable) [virtual] [size=4K]
 	00:16.0 Communication controller: Intel Corporation Tiger Lake-LP Management Engine Interface (rev 20)
 	Region 0: Memory at 603d1ad000 (64-bit, non-prefetchable) [size=4K]
 	00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)
@@ -296,10 +296,10 @@
 	ff000000-ffffffff : Reserved
 	  ff000000-ffffffff : pnp 00:05
 	100000000-4b07fffff : System RAM
-	  195600000-196602686 : Kernel code
-	  196800000-19723efff : Kernel rodata
-	  197400000-19776e13f : Kernel data
-	  197a69000-197ffffff : Kernel bss
+	  21f200000-220202666 : Kernel code
+	  220400000-220e3ffff : Kernel rodata
+	  221000000-22136e1ff : Kernel data
+	  221667000-221bfffff : Kernel bss
 	4b0800000-4b3ffffff : RAM buffer
 	4000000000-7fffffffff : PCI Bus 0000:00
 	  4000000000-400fffffff : 0000:00:02.0
@@ -354,7 +354,7 @@
 	3, 5, 6, 7, 10, 11, 12, 13, 15
 	</AVAILABLE_IRQ_INFO>
   <TOTAL_MEM_INFO>
-	16003768 kB
+	16003760 kB
 	</TOTAL_MEM_INFO>
   <CPU_PROCESSOR_INFO>
 	0, 1, 2, 3
@@ -480,6 +480,33 @@
       <capability id="rdtscp_ia32_tsc_aux"/>
       <capability id="intel_64"/>
       <capability id="invariant_tsc"/>
+      <capability id="fast_string"/>
+      <capability id="vmx_pinbased_ctls_irq_exit"/>
+      <capability id="ept"/>
+      <capability id="apicv"/>
+      <capability id="vmx_procbased_ctls_tsc_off"/>
+      <capability id="vmx_procbased_ctls_tpr_shadow"/>
+      <capability id="vmx_procbased_ctls_io_bitmap"/>
+      <capability id="vmx_procbased_ctls_msr_bitmap"/>
+      <capability id="vmx_procbased_ctls_hlt"/>
+      <capability id="vmx_procbased_ctls_secondary"/>
+      <capability id="vmx_exit_ctls_ack_irq"/>
+      <capability id="vmx_exit_ctls_save_pat"/>
+      <capability id="vmx_exit_ctls_load_pat"/>
+      <capability id="vmx_exit_ctls_host_addr64"/>
+      <capability id="vmx_entry_ctls_load_pat"/>
+      <capability id="vmx_entry_ctls_ia32e_mode"/>
+      <capability id="unrestricted_guest"/>
+      <capability id="vmx_procbased_ctls2_vapic"/>
+      <capability id="vmx_procbased_ctls2_ept"/>
+      <capability id="vmx_procbased_ctls2_vpid"/>
+      <capability id="vmx_procbased_ctls2_rdtscp"/>
+      <capability id="vmx_procbased_ctls2_unrestrict"/>
+      <capability id="invept"/>
+      <capability id="invvpid"/>
+      <capability id="ept_2mb_page"/>
+      <capability id="vmx_ept_1gb_page"/>
+      <attribute id="cpuid_level">0x1b</attribute>
       <attribute id="physical_address_bits">39</attribute>
       <attribute id="linear_address_bits">48</attribute>
     </model>
@@ -1042,7 +1069,19 @@
           <capability id="PASID"/>
           <capability id="ATS"/>
           <capability id="PRI"/>
-          <capability id="SR-IOV"/>
+          <capability id="SR-IOV">
+            <initial_vfs>7</initial_vfs>
+            <total_vfs>7</total_vfs>
+            <function_dependency_link>0</function_dependency_link>
+            <first_vf_bdf>
+              <bus>0x0</bus>
+              <device>0x2</device>
+              <function>0x1</function>
+            </first_vf_bdf>
+            <vf_stride>1</vf_stride>
+            <vf_device_id>0x9a49</vf_device_id>
+            <supported_page_sizes>0x553</supported_page_sizes>
+          </capability>
           <device address="0x6">
             <acpi_object>\_SB_.PC00.GFX0.DD06</acpi_object>
             <aml_template>5b821b5c2f045f53425f504330304746583044443036085f4144520a06</aml_template>
@@ -1723,15 +1762,15 @@
           <resource type="memory" min="0x4017000000" max="0x4017000fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
           <capability id="Power Management"/>
           <capability id="Vendor-Specific"/>
-          <dependency type="provides resources to">\_SB_.PC00.I2C1.TPL1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.TPL1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C3.TPD0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C1.TPD0</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C1.UCM1</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C2.TPD0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.TPL1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C3.TPD0</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C0.TPD0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.TPL1</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C3.TPL1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C1.TPD0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C1.TPL1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.TPL1</dependency>
           <device id="PNP0C50">
             <acpi_object>\_SB_.PC00.I2C0.TPD0</acpi_object>
             <compatible_id>PNP0C50</compatible_id>
@@ -1816,11 +1855,11 @@
         <device address="0x150002">
           <acpi_object>\_SB_.PC00.I2C2</acpi_object>
           <aml_template>5b821a5c2f035f53425f5043303049324332085f4144520c02001500</aml_template>
+          <dependency type="provides resources to">\_SB_.PC00.LNK2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.FLM2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.CAM0</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C2.PMIC</dependency>
           <dependency type="provides resources to">\_SB_.PC00.FLM1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK2</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.CAM0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.FLM2</dependency>
           <device id="INT3471" address="0x0">
             <acpi_object>\_SB_.PC00.I2C2.CAM0</acpi_object>
             <compatible_id>INT3471</compatible_id>
@@ -1882,20 +1921,20 @@
         <device address="0x150003">
           <acpi_object>\_SB_.PC00.I2C3</acpi_object>
           <aml_template>5b821a5c2f035f53425f5043303049324333085f4144520c03001500</aml_template>
-          <dependency type="provides resources to">\_SB_.PC00.CLP4</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.CLP0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.CLP5</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.FLM3</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK5</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.CLP3</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK4</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.FLM5</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.CLP1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK3</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.FLM4</dependency>
           <dependency type="provides resources to">\_SB_.PC00.CLP2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.FLM4</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP4</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK5</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK4</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK3</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP5</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.FLM3</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.FLM5</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP3</dependency>
           <device id="PNP0C50">
             <acpi_object>\_SB_.PC00.I2C3.TPD0</acpi_object>
             <compatible_id>PNP0C50</compatible_id>
@@ -2034,10 +2073,10 @@
         <device address="0x190001">
           <acpi_object>\_SB_.PC00.I2C5</acpi_object>
           <aml_template>5b821a5c2f035f53425f5043303049324335085f4144520c01001900</aml_template>
+          <dependency type="provides resources to">\_SB_.PC00.I2C5.PA03</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C5.PA02</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C5.PA01</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C5.PA04</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C5.PA03</dependency>
           <device id="MCHP1930">
             <acpi_object>\_SB_.PC00.I2C5.PA01</acpi_object>
             <acpi_uid>1</acpi_uid>
@@ -2538,8 +2577,8 @@
             <resource type="LargeResourceItemGPIOConnection" id="res1"/>
             <resource type="LargeResourceItemGPIOConnection" id="res2"/>
             <resource type="LargeResourceItemGenericSerialBusConnection" id="res0"/>
-            <dependency type="consumes resources from">\_SB_.GPI0</dependency>
             <dependency type="consumes resources from">\_SB_.PC00.UA00</dependency>
+            <dependency type="consumes resources from">\_SB_.GPI0</dependency>
           </device>
         </device>
         <device address="0x1e0001">
@@ -3243,17 +3282,17 @@
         <resource id="res2" type="memory" min="0xfd6d0000" max="0xfd6dffff" len="0x10000"/>
         <resource id="res1" type="memory" min="0xfd6e0000" max="0xfd6effff" len="0x10000"/>
         <dependency type="provides resources to">\_SB_.PC00.DSC4</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.FLM1</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.DSC1</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM4</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.DSC3</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM0</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM2</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.DSC5</dependency>
         <dependency type="provides resources to">\_SB_.PC00.UA00.BTH0</dependency>
         <dependency type="provides resources to">\_SB_.PC00.FLM3</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.FLM0</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.DSC2</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.DSC3</dependency>
         <dependency type="provides resources to">\_SB_.PC00.FLM5</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.FLM2</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.FLM4</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.DSC5</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM1</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.DSC2</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.DSC1</dependency>
       </device>
       <device id="INTC1051">
         <acpi_object>\_SB_.HIDD</acpi_object>

--- a/misc/config_tools/data/nuc11tnbi5/nuc11tnbi5.xml
+++ b/misc/config_tools/data/nuc11tnbi5/nuc11tnbi5.xml
@@ -40,9 +40,9 @@
 	00:14.3 Network controller: Intel Corporation Wi-Fi 6 AX201 (rev 20)
 	Region 0: Memory at 603d1a4000 (64-bit, non-prefetchable) [size=16K]
 	00:15.0 Serial bus controller: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #0 (rev 20)
-	Region 0: Memory at 4017000000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 4017000000 (64-bit, non-prefetchable) [virtual] [size=4K]
 	00:15.1 Serial bus controller: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #1 (rev 20)
-	Region 0: Memory at 4017001000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 4017001000 (64-bit, non-prefetchable) [virtual] [size=4K]
 	00:16.0 Communication controller: Intel Corporation Tiger Lake-LP Management Engine Interface (rev 20)
 	Region 0: Memory at 603d1ad000 (64-bit, non-prefetchable) [size=4K]
 	00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)
@@ -296,10 +296,10 @@
 	ff000000-ffffffff : Reserved
 	  ff000000-ffffffff : pnp 00:05
 	100000000-4b07fffff : System RAM
-	  195600000-196602686 : Kernel code
-	  196800000-19723efff : Kernel rodata
-	  197400000-19776e13f : Kernel data
-	  197a69000-197ffffff : Kernel bss
+	  21f200000-220202666 : Kernel code
+	  220400000-220e3ffff : Kernel rodata
+	  221000000-22136e1ff : Kernel data
+	  221667000-221bfffff : Kernel bss
 	4b0800000-4b3ffffff : RAM buffer
 	4000000000-7fffffffff : PCI Bus 0000:00
 	  4000000000-400fffffff : 0000:00:02.0
@@ -354,7 +354,7 @@
 	3, 5, 6, 7, 10, 11, 12, 13, 15
 	</AVAILABLE_IRQ_INFO>
   <TOTAL_MEM_INFO>
-	16003768 kB
+	16003760 kB
 	</TOTAL_MEM_INFO>
   <CPU_PROCESSOR_INFO>
 	0, 1, 2, 3
@@ -480,6 +480,33 @@
       <capability id="rdtscp_ia32_tsc_aux"/>
       <capability id="intel_64"/>
       <capability id="invariant_tsc"/>
+      <capability id="fast_string"/>
+      <capability id="vmx_pinbased_ctls_irq_exit"/>
+      <capability id="ept"/>
+      <capability id="apicv"/>
+      <capability id="vmx_procbased_ctls_tsc_off"/>
+      <capability id="vmx_procbased_ctls_tpr_shadow"/>
+      <capability id="vmx_procbased_ctls_io_bitmap"/>
+      <capability id="vmx_procbased_ctls_msr_bitmap"/>
+      <capability id="vmx_procbased_ctls_hlt"/>
+      <capability id="vmx_procbased_ctls_secondary"/>
+      <capability id="vmx_exit_ctls_ack_irq"/>
+      <capability id="vmx_exit_ctls_save_pat"/>
+      <capability id="vmx_exit_ctls_load_pat"/>
+      <capability id="vmx_exit_ctls_host_addr64"/>
+      <capability id="vmx_entry_ctls_load_pat"/>
+      <capability id="vmx_entry_ctls_ia32e_mode"/>
+      <capability id="unrestricted_guest"/>
+      <capability id="vmx_procbased_ctls2_vapic"/>
+      <capability id="vmx_procbased_ctls2_ept"/>
+      <capability id="vmx_procbased_ctls2_vpid"/>
+      <capability id="vmx_procbased_ctls2_rdtscp"/>
+      <capability id="vmx_procbased_ctls2_unrestrict"/>
+      <capability id="invept"/>
+      <capability id="invvpid"/>
+      <capability id="ept_2mb_page"/>
+      <capability id="vmx_ept_1gb_page"/>
+      <attribute id="cpuid_level">0x1b</attribute>
       <attribute id="physical_address_bits">39</attribute>
       <attribute id="linear_address_bits">48</attribute>
     </model>
@@ -1042,7 +1069,19 @@
           <capability id="PASID"/>
           <capability id="ATS"/>
           <capability id="PRI"/>
-          <capability id="SR-IOV"/>
+          <capability id="SR-IOV">
+            <initial_vfs>7</initial_vfs>
+            <total_vfs>7</total_vfs>
+            <function_dependency_link>0</function_dependency_link>
+            <first_vf_bdf>
+              <bus>0x0</bus>
+              <device>0x2</device>
+              <function>0x1</function>
+            </first_vf_bdf>
+            <vf_stride>1</vf_stride>
+            <vf_device_id>0x9a49</vf_device_id>
+            <supported_page_sizes>0x553</supported_page_sizes>
+          </capability>
           <device address="0x6">
             <acpi_object>\_SB_.PC00.GFX0.DD06</acpi_object>
             <aml_template>5b821b5c2f045f53425f504330304746583044443036085f4144520a06</aml_template>
@@ -1723,15 +1762,15 @@
           <resource type="memory" min="0x4017000000" max="0x4017000fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
           <capability id="Power Management"/>
           <capability id="Vendor-Specific"/>
-          <dependency type="provides resources to">\_SB_.PC00.I2C1.TPL1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.TPL1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C3.TPD0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C1.TPD0</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C1.UCM1</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C2.TPD0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.TPL1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C3.TPD0</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C0.TPD0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.TPL1</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C3.TPL1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C1.TPD0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C1.TPL1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.TPL1</dependency>
           <device id="PNP0C50">
             <acpi_object>\_SB_.PC00.I2C0.TPD0</acpi_object>
             <compatible_id>PNP0C50</compatible_id>
@@ -1816,11 +1855,11 @@
         <device address="0x150002">
           <acpi_object>\_SB_.PC00.I2C2</acpi_object>
           <aml_template>5b821a5c2f035f53425f5043303049324332085f4144520c02001500</aml_template>
+          <dependency type="provides resources to">\_SB_.PC00.LNK2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.FLM2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.CAM0</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C2.PMIC</dependency>
           <dependency type="provides resources to">\_SB_.PC00.FLM1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK2</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.CAM0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.FLM2</dependency>
           <device id="INT3471" address="0x0">
             <acpi_object>\_SB_.PC00.I2C2.CAM0</acpi_object>
             <compatible_id>INT3471</compatible_id>
@@ -1882,20 +1921,20 @@
         <device address="0x150003">
           <acpi_object>\_SB_.PC00.I2C3</acpi_object>
           <aml_template>5b821a5c2f035f53425f5043303049324333085f4144520c03001500</aml_template>
-          <dependency type="provides resources to">\_SB_.PC00.CLP4</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.CLP0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.CLP5</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.FLM3</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK5</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.CLP3</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK4</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.FLM5</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.CLP1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK3</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.FLM4</dependency>
           <dependency type="provides resources to">\_SB_.PC00.CLP2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.FLM4</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP4</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK5</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK4</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK3</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP5</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.FLM3</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.FLM5</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP3</dependency>
           <device id="PNP0C50">
             <acpi_object>\_SB_.PC00.I2C3.TPD0</acpi_object>
             <compatible_id>PNP0C50</compatible_id>
@@ -2034,10 +2073,10 @@
         <device address="0x190001">
           <acpi_object>\_SB_.PC00.I2C5</acpi_object>
           <aml_template>5b821a5c2f035f53425f5043303049324335085f4144520c01001900</aml_template>
+          <dependency type="provides resources to">\_SB_.PC00.I2C5.PA03</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C5.PA02</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C5.PA01</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C5.PA04</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C5.PA03</dependency>
           <device id="MCHP1930">
             <acpi_object>\_SB_.PC00.I2C5.PA01</acpi_object>
             <acpi_uid>1</acpi_uid>
@@ -2538,8 +2577,8 @@
             <resource type="LargeResourceItemGPIOConnection" id="res1"/>
             <resource type="LargeResourceItemGPIOConnection" id="res2"/>
             <resource type="LargeResourceItemGenericSerialBusConnection" id="res0"/>
-            <dependency type="consumes resources from">\_SB_.GPI0</dependency>
             <dependency type="consumes resources from">\_SB_.PC00.UA00</dependency>
+            <dependency type="consumes resources from">\_SB_.GPI0</dependency>
           </device>
         </device>
         <device address="0x1e0001">
@@ -3243,17 +3282,17 @@
         <resource id="res2" type="memory" min="0xfd6d0000" max="0xfd6dffff" len="0x10000"/>
         <resource id="res1" type="memory" min="0xfd6e0000" max="0xfd6effff" len="0x10000"/>
         <dependency type="provides resources to">\_SB_.PC00.DSC4</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.FLM1</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.DSC1</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM4</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.DSC3</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM0</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM2</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.DSC5</dependency>
         <dependency type="provides resources to">\_SB_.PC00.UA00.BTH0</dependency>
         <dependency type="provides resources to">\_SB_.PC00.FLM3</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.FLM0</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.DSC2</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.DSC3</dependency>
         <dependency type="provides resources to">\_SB_.PC00.FLM5</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.FLM2</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.FLM4</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.DSC5</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM1</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.DSC2</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.DSC1</dependency>
       </device>
       <device id="INTC1051">
         <acpi_object>\_SB_.HIDD</acpi_object>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
@@ -109,7 +109,7 @@
       <TPM2>n</TPM2>
     </mmio_resources>
     <pci_devs>
-      <pci_dev>00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
+      <pci_dev>00:17.0 SATA controller: Intel Corporation Cannon Point-LP SATA Controller [AHCI Mode] (rev 30)</pci_dev>
       <pci_dev>03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
   </vm>

--- a/misc/config_tools/data/whl-ipc-i5/whl-ipc-i5.xml
+++ b/misc/config_tools/data/whl-ipc-i5/whl-ipc-i5.xml
@@ -252,10 +252,10 @@
 	ff000000-ffffffff : Reserved
 	  ff000000-ffffffff : pnp 00:0e
 	100000000-26dffffff : System RAM
-	  169c00000-16ac02556 : Kernel code
-	  16ae00000-16b83cfff : Kernel rodata
-	  16ba00000-16bd6637f : Kernel data
-	  16c02c000-16c5fffff : Kernel bss
+	  162400000-163402556 : Kernel code
+	  163600000-16403cfff : Kernel rodata
+	  164200000-16456637f : Kernel data
+	  16482c000-164dfffff : Kernel bss
 	26e000000-26fffffff : RAM buffer
 	</IOMEM_INFO>
   <BLOCK_DEVICE_INFO>
@@ -373,6 +373,33 @@
       <capability id="rdtscp_ia32_tsc_aux"/>
       <capability id="intel_64"/>
       <capability id="invariant_tsc"/>
+      <capability id="fast_string"/>
+      <capability id="vmx_pinbased_ctls_irq_exit"/>
+      <capability id="ept"/>
+      <capability id="apicv"/>
+      <capability id="vmx_procbased_ctls_tsc_off"/>
+      <capability id="vmx_procbased_ctls_tpr_shadow"/>
+      <capability id="vmx_procbased_ctls_io_bitmap"/>
+      <capability id="vmx_procbased_ctls_msr_bitmap"/>
+      <capability id="vmx_procbased_ctls_hlt"/>
+      <capability id="vmx_procbased_ctls_secondary"/>
+      <capability id="vmx_exit_ctls_ack_irq"/>
+      <capability id="vmx_exit_ctls_save_pat"/>
+      <capability id="vmx_exit_ctls_load_pat"/>
+      <capability id="vmx_exit_ctls_host_addr64"/>
+      <capability id="vmx_entry_ctls_load_pat"/>
+      <capability id="vmx_entry_ctls_ia32e_mode"/>
+      <capability id="unrestricted_guest"/>
+      <capability id="vmx_procbased_ctls2_vapic"/>
+      <capability id="vmx_procbased_ctls2_ept"/>
+      <capability id="vmx_procbased_ctls2_vpid"/>
+      <capability id="vmx_procbased_ctls2_rdtscp"/>
+      <capability id="vmx_procbased_ctls2_unrestrict"/>
+      <capability id="invept"/>
+      <capability id="invvpid"/>
+      <capability id="ept_2mb_page"/>
+      <capability id="vmx_ept_1gb_page"/>
+      <attribute id="cpuid_level">0x16</attribute>
       <attribute id="physical_address_bits">39</attribute>
       <attribute id="linear_address_bits">48</attribute>
     </model>
@@ -1864,10 +1891,10 @@
           </status>
           <resource id="res1" type="irq" int="16"/>
           <resource id="res0" type="memory" min="0xfe020000" max="0xfe020fff" len="0x1000"/>
+          <dependency type="provides resources to">\_SB_.PCI0.I2C0.UCMX</dependency>
+          <dependency type="provides resources to">\_SB_.PCI0.I2C0.TPD0</dependency>
           <dependency type="provides resources to">\_SB_.PCI0.I2C0.TPL1</dependency>
           <dependency type="provides resources to">\_SB_.PCI0.I2C0.HDAC</dependency>
-          <dependency type="provides resources to">\_SB_.PCI0.I2C0.TPD0</dependency>
-          <dependency type="provides resources to">\_SB_.PCI0.I2C0.UCMX</dependency>
           <dependency type="provides resources to">\_SB_.PCI0.I2C0.PA01</dependency>
           <device id="INT0000">
             <acpi_object>\_SB_.PCI0.I2C0.HDAC</acpi_object>
@@ -1953,8 +1980,8 @@
           <resource id="res1" type="irq" int="17"/>
           <resource id="res0" type="memory" min="0xfe022000" max="0xfe022fff" len="0x1000"/>
           <dependency type="provides resources to">\_SB_.PCI0.I2C1.UCMX</dependency>
-          <dependency type="provides resources to">\_SB_.PCI0.I2C1.TPD0</dependency>
           <dependency type="provides resources to">\_SB_.PCI0.I2C1.TPL1</dependency>
+          <dependency type="provides resources to">\_SB_.PCI0.I2C1.TPD0</dependency>
           <device id="XXXX0000">
             <acpi_object>\_SB_.PCI0.I2C1.TPD0</acpi_object>
             <compatible_id>PNP0C50</compatible_id>
@@ -2011,17 +2038,17 @@
           </status>
           <resource id="res1" type="irq" int="18"/>
           <resource id="res0" type="memory" min="0xfe024000" max="0xfe024fff" len="0x1000"/>
-          <dependency type="provides resources to">\_SB_.PCI0.LNK1</dependency>
-          <dependency type="provides resources to">\_SB_.PCI0.LNK0</dependency>
-          <dependency type="provides resources to">\_SB_.PCI0.I2C2.CAM0</dependency>
           <dependency type="provides resources to">\_SB_.PCI0.CLP0</dependency>
-          <dependency type="provides resources to">\_SB_.PCI0.I2C2.PMIC</dependency>
-          <dependency type="provides resources to">\_SB_.PCI0.LNK3</dependency>
-          <dependency type="provides resources to">\_SB_.PCI0.I2C2.TPL1</dependency>
           <dependency type="provides resources to">\_SB_.PCI0.CLP3</dependency>
-          <dependency type="provides resources to">\_SB_.PCI0.I2C2.TPD0</dependency>
           <dependency type="provides resources to">\_SB_.PCI0.CLP2</dependency>
+          <dependency type="provides resources to">\_SB_.PCI0.I2C2.CAM0</dependency>
+          <dependency type="provides resources to">\_SB_.PCI0.LNK0</dependency>
+          <dependency type="provides resources to">\_SB_.PCI0.I2C2.PMIC</dependency>
+          <dependency type="provides resources to">\_SB_.PCI0.I2C2.TPL1</dependency>
           <dependency type="provides resources to">\_SB_.PCI0.I2C2.UCMX</dependency>
+          <dependency type="provides resources to">\_SB_.PCI0.LNK1</dependency>
+          <dependency type="provides resources to">\_SB_.PCI0.LNK3</dependency>
+          <dependency type="provides resources to">\_SB_.PCI0.I2C2.TPD0</dependency>
           <device id="INT3471" address="0x0">
             <acpi_object>\_SB_.PCI0.I2C2.CAM0</acpi_object>
             <compatible_id>INT3471</compatible_id>
@@ -2109,11 +2136,11 @@
           </status>
           <resource id="res1" type="irq" int="19"/>
           <resource id="res0" type="memory" min="0xfe026000" max="0xfe026fff" len="0x1000"/>
+          <dependency type="provides resources to">\_SB_.PCI0.LNK2</dependency>
+          <dependency type="provides resources to">\_SB_.PCI0.I2C3.TPD0</dependency>
+          <dependency type="provides resources to">\_SB_.PCI0.I2C3.UCMX</dependency>
           <dependency type="provides resources to">\_SB_.PCI0.CLP1</dependency>
           <dependency type="provides resources to">\_SB_.PCI0.I2C3.TPL1</dependency>
-          <dependency type="provides resources to">\_SB_.PCI0.I2C3.TPD0</dependency>
-          <dependency type="provides resources to">\_SB_.PCI0.LNK2</dependency>
-          <dependency type="provides resources to">\_SB_.PCI0.I2C3.UCMX</dependency>
           <device id="XXXX0000">
             <acpi_object>\_SB_.PCI0.I2C3.TPD0</acpi_object>
             <compatible_id>PNP0C50</compatible_id>


### PR DESCRIPTION
Because Board Inspector modifies the SR-IOV function,
VF information is correctly captured when Board Inspector
collects Board information. So update the board xmls

Tracked-On: #7031
Signed-off-by: zhongzhenx.liu <zhongzhenx.liu@intel.com>