### PR TITLE
hv: remove an unnecessary code line

### DIFF
--- a/hypervisor/boot/guest/elf_loader.c
+++ b/hypervisor/boot/guest/elf_loader.c
@@ -89,7 +89,6 @@ static void *do_load_elf32(struct acrn_vm *vm)
 	void *elf_entry = NULL, *p_elf_bss = NULL;
 	uint32_t i;
 
-	p_elf_header32 = (struct elf32_hdr *)p_elf_img;
 	/* Currently only ET_EXEC is supported */
 	if (p_elf_header32->e_type == ET_EXEC) {
 		p_prg_tbl_head32 = (struct elf32_prog_entry *)(p_elf_img + p_elf_header32->e_phoff);


### PR DESCRIPTION
This patch is to eliminate a code scan warning.

p_elf_header32 was given a value when it was declared, but later it was
given the same value again. Just remove the later one.

Tracked-On: #7318

Signed-off-by: Zhou, Wu <wu.zhou@intel.com>