### PR TITLE
deb-pkg: add OVMF_debug.fd in .deb.conf

### DIFF
--- a/.deb.conf
+++ b/.deb.conf
@@ -103,6 +103,10 @@
 			"source":"devicemodel/bios/OVMF.fd",
 			"target":"usr/share/acrn/bios"
 			},
+"OVMF_debug.fd":{
+			"source":"devicemodel/bios/OVMF_debug.fd",
+			"target":"usr/share/acrn/bios"
+			},
 "40-watchdog.conf":{
 			"source":"misc/debug_tools/acrn_crashlog/data/40-watchdog.conf",
 			"target":"usr/share/acrn/crashlog"


### PR DESCRIPTION
Bugfix for OVMF_debug.fd

Tracked-On: #8744
Signed-off-by: hangliu1 <hang1.liu@linux.intel.com>