### PR TITLE
doc: Fix virtio-blk.html/hv-rdt.html statement error

### DIFF
--- a/doc/developer-guides/hld/hv-rdt.rst
+++ b/doc/developer-guides/hld/hv-rdt.rst
@@ -48,7 +48,7 @@ to enforce the settings.
 
       <RDT>
             <RDT_ENABLED>y</RDT_ENABLED>
-            <CDP_ENABLED</CDP_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
             <CLOS_MASK>0xF</CLOS_MASK>
 
 Once the cache mask is set of each individual CPU, the respective CLOS ID

--- a/doc/developer-guides/hld/virtio-blk.rst
+++ b/doc/developer-guides/hld/virtio-blk.rst
@@ -81,7 +81,7 @@ The Device Model configuration command syntax for virtio-blk is::
     The default values for sector size and physical sector size are 512
   - ``range``: configured as ``range=<start lba in file>/<sub file size>``
     meaning the virtio-blk will only access part of the file, from the
-    ``<start lba in file>`` to ``<start lba in file> + <sub file site>``.
+    ``<start lba in file>`` to ``<start lba in file> + <sub file size>``.
 
 A simple example for virtio-blk:
 


### PR DESCRIPTION
1. Fix Incorrect site write in virtio-blk.html range configuration
2. Fix hv-rdt.html CDP_ENABLED parameter configuration error

Signed-off-by: zhongzhenx.liu <zhongzhenx.liu@intel.com>