### PR TITLE
hv: remove pgentry_present field in struct pgtable

### DIFF
--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -80,19 +80,15 @@ static inline void ppt_clflush_pagewalk(const void* entry __attribute__((unused)
 {
 }
 
-static inline uint64_t ppt_pgentry_present(uint64_t pte)
-{
-	return pte & PAGE_PRESENT;
-}
 
 static inline void ppt_nop_tweak_exe_right(uint64_t *entry __attribute__((unused))) {}
 static inline void ppt_nop_recover_exe_right(uint64_t *entry __attribute__((unused))) {}
 
 static const struct pgtable ppt_pgtable = {
 	.default_access_right = (PAGE_PRESENT | PAGE_RW | PAGE_USER),
+	.pgentry_present_mask = PAGE_PRESENT,
 	.pool = &ppt_page_pool,
 	.large_page_support = ppt_large_page_support,
-	.pgentry_present = ppt_pgentry_present,
 	.clflush_pagewalk = ppt_clflush_pagewalk,
 	.tweak_exe_right = ppt_nop_tweak_exe_right,
 	.recover_exe_right = ppt_nop_recover_exe_right,

--- a/hypervisor/include/arch/x86/asm/pgtable.h
+++ b/hypervisor/include/arch/x86/asm/pgtable.h
@@ -170,13 +170,18 @@ enum _page_table_level {
 
 struct pgtable {
 	uint64_t default_access_right;
+	uint64_t pgentry_present_mask;
 	struct page_pool *pool;
 	bool (*large_page_support)(enum _page_table_level level, uint64_t prot);
-	uint64_t (*pgentry_present)(uint64_t pte);
 	void (*clflush_pagewalk)(const void *p);
 	void (*tweak_exe_right)(uint64_t *entry);
 	void (*recover_exe_right)(uint64_t *entry);
 };
+
+static inline bool pgentry_present(const struct pgtable *table, uint64_t pte)
+{
+	return ((table->pgentry_present_mask & (pte)) != 0UL);
+}
 
 /**
  * @brief Address space translation


### PR DESCRIPTION
  Page table entry present check is page table type
  specific and static, e.g. just need to check bit0
  of page entry for entries of MMU page table and
  bit2~bit0 for EPT page table case. hence no need to
  check it by callback function every time.

  This patch remove 'pgentry_present' callback field and
  add a new bitmask field for this page entry present check.
  It can get better performance especially when this
  check is executed frequently.

Tracked-On: #7327
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Reviewed-by: Fei Li <fei1.li@intel.com>
Reviewed-by: Yu Wang <yu1.wang@intel.com>