### PR TITLE
hv: fix core type error when launch RTVM use atom core

### DIFF
--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -492,7 +492,7 @@ static int32_t set_vcpuid_extended_function(struct acrn_vm *vm)
 
 static inline bool is_percpu_related(uint32_t leaf)
 {
-	return ((leaf == 0x1U) || (leaf == 0xbU) || (leaf == 0xdU) || (leaf == 0x19U) || (leaf == 0x80000001U) || (leaf == 0x2U));
+	return ((leaf == 0x1U) || (leaf == 0xbU) || (leaf == 0xdU) || (leaf == 0x19U) || (leaf == 0x80000001U) || (leaf == 0x2U) || (leaf == 0x1aU));
 }
 
 int32_t set_vcpuid_entries(struct acrn_vm *vm)


### PR DESCRIPTION
When CPUID executes with EAX set to 1AH, the processor returns information about hybrid capabilities.
This information is percpu related, and should be obtained directly from the physical cpu.

Tracked-On: #6899
Signed-off-by: Tw <wei.tan@intel.com>