### PR TITLE
board_inspector: parse cpu IDs in decimal rather than hexadecimal

### DIFF
--- a/misc/config_tools/board_inspector/extractors/20-cache.py
+++ b/misc/config_tools/board_inspector/extractors/20-cache.py
@@ -16,7 +16,7 @@ def extract_topology(root_node, caches_node):
     for thread in threads:
         subleaf = 0
         while True:
-            cpu_id = int(get_node(thread, "cpu_id/text()"), base=16)
+            cpu_id = int(get_node(thread, "cpu_id/text()"))
             leaf_4 = parse_cpuid(4, subleaf, cpu_id)
             cache_type = leaf_4.cache_type
             if cache_type == 0:


### PR DESCRIPTION
Unlike other CPU IDs, the cpu_id field under //processors//thread in the
board XML is in decimal as it is assigned by the kernel continuously,
starting from 0. However, the cache info extractor today parses them as
hexadecimal numbers, leading to incomplete cache info when more than 10
processors are present on the board. This patch fixes this issue.

Tracked-On: #6689
Signed-off-by: Junjie Mao <junjie.mao@intel.com>