### PR TITLE
Fix the memory leak in virtio-gpu

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_gpu.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpu.c
@@ -1680,12 +1680,13 @@ virtio_gpu_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		}
 	}
 
+	vdpy_deinit(gpu->vdpy_handle);
+
 	if (gpu) {
 		pthread_mutex_destroy(&gpu->mtx);
 		free(gpu);
 	}
 	virtio_gpu_device_cnt--;
-	vdpy_deinit(gpu->vdpy_handle);
 }
 
 uint64_t

--- a/devicemodel/hw/pci/virtio/virtio_gpu.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpu.c
@@ -1026,6 +1026,7 @@ static struct dma_buf_info *virtio_gpu_create_udmabuf(struct virtio_gpu *gpu,
 		info->dmabuf_fd = dmabuf_fd;
 		atomic_store(&info->ref_count, 1);
 	}
+	free(list);
 	return info;
 }
 

--- a/devicemodel/hw/vdisplay_sdl.c
+++ b/devicemodel/hw/vdisplay_sdl.c
@@ -941,6 +941,7 @@ vdpy_sdl_display_thread(void *data)
 	}
 	vdpy.dpy_win = NULL;
 	vdpy.dpy_renderer = NULL;
+	vdpy.dpy_img = NULL;
 	vdpy.dpy_win = SDL_CreateWindow("ACRN_DM",
 					vdpy.org_x, vdpy.org_y,
 					vdpy.width, vdpy.height,
@@ -1010,8 +1011,10 @@ vdpy_sdl_display_thread(void *data)
 	/* SDL display_thread will exit because of DM request */
 	pthread_mutex_destroy(&vdpy.vdisplay_mutex);
 	pthread_cond_destroy(&vdpy.vdisplay_signal);
-	if (vdpy.dpy_img)
+	if (vdpy.dpy_img) {
 		pixman_image_unref(vdpy.dpy_img);
+		vdpy.dpy_img = NULL;
+	}
 	/* Continue to thread cleanup */
 
 	if (vdpy.dpy_texture) {

--- a/devicemodel/hw/vdisplay_sdl.c
+++ b/devicemodel/hw/vdisplay_sdl.c
@@ -1090,7 +1090,7 @@ vdpy_init()
 		pr_err("Failed to create the sdl_display_thread.\n");
 		return 0;
 	}
-
+	pthread_setname_np(vdpy.tid, "acrn_vdisplay");
 	count = 0;
 	/* Wait up to 200ms so that the vdpy_sdl_display_thread is ready to
 	 * handle the 3D request


### PR DESCRIPTION
The PR tries to fix the below issues in  the virtio-gpu.
   a. incorrect access after free. virtio-gpu already frees the
allocated memory in course of reboot cycle. But the pointer is
not cleared to NULL. This will cause the incorrect access after free.

   b. the memory_leak after enabling GPU zero-copy for
the virtio-gpu.
