### PR TITLE
config_tools: add virtio gpu

### DIFF
--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -300,6 +300,10 @@ def generate_for_one_vm(board_etree, hv_scenario_etree, vm_scenario_etree, vm_id
             script.add_virtual_device("virtio-blk", options=os.path.join(f"${{{var}}}", rootfs_img))
             script.add_deinit_command(f"unmount_partition ${{{var}}}")
 
+    for virtio_gpu in eval_xpath_all(vm_scenario_etree, ".//virtio_devices/gpu[text() != '']/text()"):
+        if virtio_gpu is not None:
+            script.add_virtual_device("virtio-gpu", options=virtio_gpu)
+
     # Passthrough PCI devices
     bdf_regex = re.compile("([0-9a-f]{2}):([0-1][0-9a-f]).([0-7])")
     for passthru_device in eval_xpath_all(vm_scenario_etree, ".//pci_devs/*/text()"):

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -464,6 +464,12 @@ mouse, and tablet.  It sends Linux input layer events over virtio.</xs:documenta
               <xs:documentation>The virtio-blk device presents a block device to the VM. Each virtio-blk device appears as a disk inside the VM.</xs:documentation>
             </xs:annotation>
           </xs:element>
+          <xs:element name="gpu" type="xs:string" minOccurs="0">
+            <xs:annotation acrn:title="Virtio GPU device" acrn:views="basic">
+              <xs:documentation>The virtio GPU device presents a GPU device to the VM.
+              This feature enables you to view the VM's GPU output in the Service VM.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
         </xs:all>
       </xs:complexType>
     </xs:element>


### PR DESCRIPTION
Virtio gpu device UI will be implemented after 3.0.
As a workaround, this patch simply adds the virtio gpu entry in schema
and launch script generation logic.

Tracked-On: #7301
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>