### PR TITLE
doc: remove use of :option: role in XSD files

### DIFF
--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -324,9 +324,9 @@ RDT, setting this option to ``y`` is ignored.</xs:documentation>
       <xs:annotation>
         <xs:documentation>Specify the cache capacity bitmask for the CLOS; only continuous '1' bits
 are allowed. The value will be ignored when hardware does not support RDT.
-This option takes effect only if :option:`hv.FEATURES.RDT.RDT_ENABLED` is set to ``y``.
-As :option:`vm.clos.vcpu_clos` specifies the index of the CLOS to be associated with the given vCPU,
-:option:`hv.FEATURES.RDT.CLOS_MASK` of that CLOS would impact the performance of the given vCPU.</xs:documentation>
+This option takes effect only if the Hypervisor RDT feature is enabled.
+As the vcpu_clos option specifies the index of the CLOS to be associated with the given vCPU,
+this CLOS mask option of that CLOS would impact the performance of the given vCPU.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MBA_DELAY" type="xs:string" minOccurs="0"  maxOccurs="unbounded">


### PR DESCRIPTION
We're changing how to reference config option names in v3.0, as well as
switching documentation to use the DX-friendly names instead of XML
element names.  Remove reference in the XSD files to option
documentation for now.

Tracked-On: #5692

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>