### PR TITLE
config_tools: list dependencies on Python libraries in requirements.txt

### DIFF
--- a/misc/config_tools/requirements.txt
+++ b/misc/config_tools/requirements.txt
@@ -1,0 +1,4 @@
+defusedxml
+lxml
+elementpath == 2.4.0
+xmlschema == 1.9.2


### PR DESCRIPTION
This patch adds a requirements.txt file that lists the libraries and their
versions the ACRN configuration toolset needs. The versions of elementpath
and xmlschema are fixed to the latest one supporting Python 3.6 due to the
requirement of the customized overlay.

Such requirements apply to both the board inspector and the XML
manipulation part of the configurator.

Tracked-On: #6690
Signed-off-by: Junjie Mao <junjie.mao@intel.com>