### PR TITLE
misc: refine cache config

### DIFF
--- a/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
@@ -18,14 +18,6 @@
         <RDT_ENABLED>n</RDT_ENABLED>
         <CDP_ENABLED>n</CDP_ENABLED>
         <VCAT_ENABLED>n</VCAT_ENABLED>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
       </RDT>
       <HYPERV_ENABLED>y</HYPERV_ENABLED>
       <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>

--- a/misc/config_tools/data/cfl-k700-i7/partitioned.xml
+++ b/misc/config_tools/data/cfl-k700-i7/partitioned.xml
@@ -18,14 +18,6 @@
         <RDT_ENABLED>n</RDT_ENABLED>
         <CDP_ENABLED>n</CDP_ENABLED>
         <VCAT_ENABLED>n</VCAT_ENABLED>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
       </RDT>
       <HYPERV_ENABLED>y</HYPERV_ENABLED>
       <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>

--- a/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
@@ -18,14 +18,6 @@
         <RDT_ENABLED>n</RDT_ENABLED>
         <CDP_ENABLED>n</CDP_ENABLED>
         <VCAT_ENABLED>n</VCAT_ENABLED>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
       </RDT>
       <HYPERV_ENABLED>y</HYPERV_ENABLED>
       <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>

--- a/misc/config_tools/data/generic_board/hybrid_rt.xml
+++ b/misc/config_tools/data/generic_board/hybrid_rt.xml
@@ -15,22 +15,6 @@
       <RDT>
         <RDT_ENABLED>n</RDT_ENABLED>
         <CDP_ENABLED>n</CDP_ENABLED>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
-        <CLOS_MASK>0xfff</CLOS_MASK>
       </RDT>
       <HYPERV_ENABLED>y</HYPERV_ENABLED>
       <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>

--- a/misc/config_tools/data/generic_board/partitioned.xml
+++ b/misc/config_tools/data/generic_board/partitioned.xml
@@ -18,14 +18,6 @@
         <RDT_ENABLED>n</RDT_ENABLED>
         <CDP_ENABLED>n</CDP_ENABLED>
         <VCAT_ENABLED>n</VCAT_ENABLED>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
       </RDT>
       <HYPERV_ENABLED>y</HYPERV_ENABLED>
       <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>

--- a/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
@@ -18,14 +18,6 @@
         <RDT_ENABLED>n</RDT_ENABLED>
         <CDP_ENABLED>y</CDP_ENABLED>
         <VCAT_ENABLED>n</VCAT_ENABLED>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
       </RDT>
       <HYPERV_ENABLED>y</HYPERV_ENABLED>
       <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
@@ -18,14 +18,6 @@
         <RDT_ENABLED>n</RDT_ENABLED>
         <CDP_ENABLED>n</CDP_ENABLED>
         <VCAT_ENABLED>n</VCAT_ENABLED>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
       </RDT>
       <HYPERV_ENABLED>y</HYPERV_ENABLED>
       <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>

--- a/misc/config_tools/data/nuc11tnbi5/partitioned.xml
+++ b/misc/config_tools/data/nuc11tnbi5/partitioned.xml
@@ -18,14 +18,6 @@
         <RDT_ENABLED>n</RDT_ENABLED>
         <CDP_ENABLED>n</CDP_ENABLED>
         <VCAT_ENABLED>n</VCAT_ENABLED>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
       </RDT>
       <HYPERV_ENABLED>y</HYPERV_ENABLED>
       <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>

--- a/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
@@ -18,14 +18,6 @@
         <RDT_ENABLED>n</RDT_ENABLED>
         <CDP_ENABLED>y</CDP_ENABLED>
         <VCAT_ENABLED>n</VCAT_ENABLED>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
       </RDT>
       <HYPERV_ENABLED>y</HYPERV_ENABLED>
       <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
@@ -18,14 +18,6 @@
         <RDT_ENABLED>n</RDT_ENABLED>
         <CDP_ENABLED>n</CDP_ENABLED>
         <VCAT_ENABLED>n</VCAT_ENABLED>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
       </RDT>
       <HYPERV_ENABLED>y</HYPERV_ENABLED>
       <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/partitioned.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/partitioned.xml
@@ -18,14 +18,6 @@
         <RDT_ENABLED>n</RDT_ENABLED>
         <CDP_ENABLED>n</CDP_ENABLED>
         <VCAT_ENABLED>n</VCAT_ENABLED>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
       </RDT>
       <HYPERV_ENABLED>y</HYPERV_ENABLED>
       <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
@@ -18,14 +18,6 @@
         <RDT_ENABLED>n</RDT_ENABLED>
         <CDP_ENABLED>n</CDP_ENABLED>
         <VCAT_ENABLED>n</VCAT_ENABLED>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
-        <CLOS_MASK>0xfffff</CLOS_MASK>
       </RDT>
       <HYPERV_ENABLED>y</HYPERV_ENABLED>
       <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -277,6 +277,11 @@ These settings can only be changed at build time.</xs:documentation>
 Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
       </xs:annotation>
     </xs:element>
+    <xs:element name="CACHE_REGION" type="CacheRegionType" minOccurs="0" maxOccurs="1">
+      <xs:annotation>
+        <xs:documentation>Specify the cache setting.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:all>
 </xs:complexType>
 

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -320,20 +320,6 @@ RDT, setting this option to ``y`` is ignored.</xs:documentation>
         <xs:documentation>Enable virtualization of the Cache Allocation Technology (CAT) feature in RDT. CAT enables you to allocate cache to VMs, providing isolation to avoid performance interference from other VMs.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="CLOS_MASK" type="xs:string"  minOccurs="0" maxOccurs="unbounded">
-      <xs:annotation>
-        <xs:documentation>Specify the cache capacity bitmask for the CLOS; only continuous '1' bits
-are allowed. The value will be ignored when hardware does not support RDT.
-This option takes effect only if :option:`hv.FEATURES.RDT.RDT_ENABLED` is set to ``y``.
-As :option:`vm.clos.vcpu_clos` specifies the index of the CLOS to be associated with the given vCPU,
-:option:`hv.FEATURES.RDT.CLOS_MASK` of that CLOS would impact the performance of the given vCPU.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
-    <xs:element name="MBA_DELAY" type="xs:string" minOccurs="0"  maxOccurs="unbounded">
-      <xs:annotation>
-        <xs:documentation>Memory Bandwidth Allocation delay value.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
   </xs:sequence>
 </xs:complexType>
 
@@ -344,6 +330,40 @@ As :option:`vm.clos.vcpu_clos` specifies the index of the CLOS to be associated 
         <xs:documentation>Enable Software SRAM. This feature reserves memory buffers as always-cached memory to improve an application's real-time performance.</xs:documentation>
       </xs:annotation>
     </xs:element>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:simpleType name="CacheType">
+  <xs:annotation>
+    <xs:documentation>Option: Unified, Code, Data</xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="Unified"/>
+    <xs:enumeration value="Code" />
+    <xs:enumeration value="Data" />
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="CachePolicyType">
+  <xs:sequence>
+    <xs:element name="VM" type="xs:string" />
+    <xs:element name="VCPU" type="xs:integer" />
+    <xs:element name="TYPE" type="CacheType" minOccurs="1"/>
+    <xs:element name="CLOS_MASK" type="HexFormat" />
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="CacheAllocationType">
+  <xs:sequence>
+    <xs:element name="CACHE_ID" type="xs:integer"/>
+    <xs:element name="CACHE_LEVEL" type="xs:integer"/>
+    <xs:element name="POLICY" type="CachePolicyType"  minOccurs="1" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="CacheRegionType">
+  <xs:sequence>
+    <xs:element name="CACHE_ALLOCATION" type="CacheAllocationType"  minOccurs="1" maxOccurs="unbounded"/>
   </xs:sequence>
 </xs:complexType>
 

--- a/misc/config_tools/static_allocators/clos.py
+++ b/misc/config_tools/static_allocators/clos.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 Intel Corporation.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'library'))
+import common
+import re
+from collections import defaultdict
+from itertools import combinations
+
+def create_clos_node(etree, vm_id, index_list):
+    allocation_vm_node = common.get_node(f"/acrn-config/vm[@id = '{vm_id}']", etree)
+    if allocation_vm_node is None:
+        allocation_vm_node = common.append_node("/acrn-config/vm", None, etree, id = vm_id)
+    if common.get_node("./clos", allocation_vm_node) is None:
+        clos_node = common.append_node("./clos", None, allocation_vm_node)
+        for index in index_list:
+            common.append_node(f"./vcpu_clos", str(index), clos_node)
+
+def find_cache2_id(mask, cache2_id_list):
+    for cache2 in cache2_id_list:
+        if mask[cache2] != "None":
+            return cache2
+    return "None"
+
+def merge_policy_list(mask_list, cache2_id_list):
+    index = 0
+    result_list = []
+    for index,mask in enumerate(mask_list):
+        merged = 0
+        if index == 0:
+            result_list.append(mask)
+            continue
+        for result in result_list:
+            if result["l3"] != mask["l3"]:
+                continue
+            else:
+                cache2_id = find_cache2_id(mask, cache2_id_list)
+                if cache2_id == "None" or result[cache2_id] == mask[cache2_id]:
+                    merged = 1
+                    break
+                if result[cache2_id] == "None":
+                    merged = 1
+                    result[cache2_id] = mask[cache2_id]
+                    break
+        if merged == 0:
+            result_list.append(mask)
+    return result_list
+
+def gen_all_clos_index(board_etree, scenario_etree, allocation_etree):
+    policy_list = []
+    allocation_list = scenario_etree.xpath(f"//POLICY")
+    cache2_id_list = scenario_etree.xpath("//CACHE_ALLOCATION[CACHE_LEVEL = 2]/CACHE_ID/text()")
+    cache2_id_list.sort()
+
+    for policy in allocation_list:
+        cache_level = common.get_node("../CACHE_LEVEL/text()", policy)
+        cache_id = common.get_node("../CACHE_ID/text()", policy)
+        vcpu = common.get_node("./VCPU/text()", policy)
+        mask = common.get_node("./CLOS_MASK/text()", policy)
+        tmp = (cache_level, cache_id, vcpu, mask)
+        policy_list.append(tmp)
+
+    vCPU_list = scenario_etree.xpath(f"//POLICY/VCPU/text()")
+    l3_mask_list = scenario_etree.xpath(f"//CACHE_ALLOCATION[CACHE_LEVEL = 3]/POLICY/CLOS_MASK")
+    mask_list = []
+    for vCPU in vCPU_list:
+        dict_tmp = {}
+        l3_mask = l2_mask = "None"
+        l3_mask_list = scenario_etree.xpath(f"//CACHE_ALLOCATION[CACHE_LEVEL = 3]/POLICY[VCPU = '{vCPU}']/CLOS_MASK/text()")
+        if len(l3_mask_list) > 0:
+            l3_mask = l3_mask_list[0]
+        dict_tmp["l3"] = l3_mask
+
+        l2_mask_list = scenario_etree.xpath(f"//CACHE_ALLOCATION[CACHE_LEVEL = 2]/POLICY[VCPU = '{vCPU}']/CLOS_MASK")
+        if len(l2_mask_list) > 0:
+            l2_mask = l2_mask_list[0].text
+            cache_id = scenario_etree.xpath(f"//CACHE_ALLOCATION[CACHE_LEVEL = 2 and POLICY/VCPU = '{vCPU}']/CACHE_ID/text()")[0]
+        for cache2 in cache2_id_list:
+            if cache2 == cache_id:
+                dict_tmp[cache_id] = l2_mask
+            else:
+                dict_tmp[cache2] = "None"
+        mask_list.append(dict_tmp)
+    mask_list = merge_policy_list(mask_list, cache2_id_list)
+    return mask_list
+
+def get_clos_index(cache_level, cache_id, clos_mask):
+    mask_list = common.get_mask_list(cache_level, cache_id)
+    idx = 0
+    for mask in mask_list:
+        idx += 1
+        if mask == clos_mask:
+            break
+    return idx
+def get_clos_id(mask_list, l2_id, l2_mask, l3_mask):
+    for mask in mask_list:
+        if mask[l2_id] == l2_mask and mask["l3"] == l3_mask:
+            return mask_list.index(mask)
+    return 0
+
+def alloc_clos_index(board_etree, scenario_etree, allocation_etree, mask_list):
+    vm_node_list = scenario_etree.xpath("//vm")
+    for vm_node in vm_node_list:
+        vmname = common.get_node("./name/text()", vm_node)
+        allocation_list = scenario_etree.xpath(f"//CACHE_ALLOCATION[POLICY/VM = '{vmname}']")
+        for allocation in allocation_list:
+            index_list = []
+            cache_level = common.get_node("./CACHE_LEVEL/text()", allocation)
+            cache_id = common.get_node("./CACHE_ID/text()", allocation)
+            clos_mask_list = allocation.xpath(f".//POLICY[VM = '{vmname}']/CLOS_MASK/text()")
+
+            for clos_mask in clos_mask_list:
+                index = get_clos_id(mask_list, cache_id, clos_mask, "None")
+                index_list.append(index)
+            create_clos_node(allocation_etree, common.get_node("./@id", vm_node), index_list)
+
+def creat_mask_list_node(board_etree, scenario_etree, allocation_etree, mask_list):
+    allocation_hv_node = common.get_node(f"//hv", allocation_etree)
+    if allocation_hv_node is None:
+        allocation_hv_node = common.append_node("//hv", None, allocation_etree, id = vm_id)
+    cache2_id_list = scenario_etree.xpath("//CACHE_ALLOCATION[CACHE_LEVEL = 2]/CACHE_ID/text()")
+    cache2_id_list.sort()
+    if common.get_node("./clos_mask[@id = l3]", allocation_hv_node) is None:
+        clos_mask = common.append_node("./clos_mask", None, allocation_hv_node, id="l3")
+        for i in range(0, len(mask_list)):
+            if mask_list[i]["l3"] == "None":
+                value = "0xffff"
+            else:
+                value = str(mask_list[i]["l3"])
+            common.append_node(f"./clos", value, clos_mask)
+
+        for cache2 in cache2_id_list:
+            if common.get_node("./clos_mask[@id = '{cache2}']", allocation_hv_node) is None:
+                clos_mask = common.append_node("./clos_mask", None, allocation_hv_node, id=cache2)
+            for i in range(0, len(mask_list)):
+                if mask_list[i][cache2] == "None":
+                    value = "0xffff"
+                else:
+                    value = str(mask_list[i][cache2] )
+                common.append_node(f"./clos", value, clos_mask)
+
+def fn(board_etree, scenario_etree, allocation_etree):
+    mask_list = gen_all_clos_index(board_etree, scenario_etree, allocation_etree)
+    creat_mask_list_node(board_etree, scenario_etree, allocation_etree, mask_list)
+    alloc_clos_index(board_etree, scenario_etree, allocation_etree, mask_list)

--- a/misc/config_tools/xforms/lib.xsl
+++ b/misc/config_tools/xforms/lib.xsl
@@ -564,12 +564,12 @@
 
   <!-- Board-specific functions-->
   <func:function name="acrn:get-normalized-closinfo-rdt-res-str">
-    <xsl:variable name="rdt_resource" select="translate(substring-before(substring-after(//CLOS_INFO, 'rdt resources supported:'), 'rdt resource clos max:'), $whitespaces, '')" />
+    <xsl:variable name="rdt_resource" select="acrn:string-join(//cache[capability/@id='CAT']/@level, ', ', 'L', '')" />
     <func:result select="$rdt_resource" />
   </func:function>
 
   <func:function name="acrn:get-normalized-closinfo-rdt-clos-max-str">
-    <xsl:variable name="rdt_res_clos_max" select="translate(substring-before(substring-after(//CLOS_INFO, 'rdt resource clos max:'), 'rdt resource mask max:'), $whitespaces, '')" />
+    <xsl:variable name="rdt_res_clos_max" select="acrn:string-join(//cache[capability/@id='CAT']/capability/clos_number, ', ', '', '')"/>
     <func:result select="$rdt_res_clos_max" />
   </func:function>
 

--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -152,12 +152,6 @@
     </xsl:otherwise>
   </xsl:choose>
   <xsl:if test="acrn:is-rdt-supported()">
-    <xsl:for-each select="hv/FEATURES/RDT/MBA_DELAY">
-      <xsl:value-of select="acrn:define(concat('MBA_MASK_', position() - 1), current(), 'U')" />
-    </xsl:for-each>
-    <xsl:for-each select="hv/FEATURES/RDT/CLOS_MASK">
-      <xsl:value-of select="acrn:define(concat('CLOS_MASK_', position() - 1), current(), 'U')" />
-    </xsl:for-each>
     <xsl:value-of select="$endif" />
   </xsl:if>
 </xsl:template>

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -68,8 +68,9 @@
       <xsl:value-of select="acrn:ifdef('CONFIG_RDT_ENABLED')" />
 
       <xsl:for-each select="vm">
-          <xsl:value-of select="concat('static uint16_t ', concat('vm', @id, '_vcpu_clos'), '[', count(clos/vcpu_clos), 'U] = {')" />
-          <xsl:value-of select="acrn:string-join(clos/vcpu_clos, ', ', '', 'U')" />
+          <xsl:variable name="vm_id" select="@id" />
+          <xsl:value-of select="concat('static uint16_t ', concat('vm', @id, '_vcpu_clos'), '[', count(//allocation-data/acrn-config/vm[@id=$vm_id]/clos/vcpu_clos), 'U] = {')" />
+          <xsl:value-of select="acrn:string-join(//allocation-data/acrn-config/vm[@id=$vm_id]/clos/vcpu_clos, ', ', '', 'U')" />
           <xsl:text>};</xsl:text>
           <xsl:value-of select="$newline" />
       </xsl:for-each>
@@ -179,18 +180,17 @@
     <xsl:value-of select="acrn:ifdef('CONFIG_RDT_ENABLED')" />
     <xsl:value-of select="acrn:initializer('pclosids', concat('vm', ../@id, '_vcpu_clos'))" />
 
-    <xsl:value-of select="acrn:initializer('num_pclosids', concat(count(vcpu_clos), 'U'))" />
-
+    <xsl:variable name="vm_id" select="../@id" />
+    <xsl:value-of select="acrn:initializer('num_pclosids', concat(count(//allocation-data/acrn-config/vm[@id=$vm_id]/clos/vcpu_clos), 'U'))" />
     <xsl:if test="acrn:is-vcat-enabled() and ../virtual_cat_support[text() = 'y']">
       <xsl:variable name="rdt_res_str" select="acrn:get-normalized-closinfo-rdt-res-str()" />
-      <xsl:variable name="closid" select="vcpu_clos[1]" />
 
       <xsl:if test="contains($rdt_res_str, 'L2')">
-        <xsl:value-of select="acrn:initializer('max_l2_pcbm', concat(../../hv/FEATURES/RDT/CLOS_MASK[$closid + 1], 'U'))" />
+        <xsl:value-of select="acrn:initializer('max_l2_pcbm', concat(math:max(//allocation-data/acrn-config/vm[@id=$vm_id]/clos/vcpu_clos), 'U'))" />
       </xsl:if>
 
       <xsl:if test="contains($rdt_res_str, 'L3')">
-        <xsl:value-of select="acrn:initializer('max_l3_pcbm', concat(../../hv/FEATURES/RDT/CLOS_MASK[$closid + 1], 'U'))" />
+        <xsl:value-of select="acrn:initializer('max_l3_pcbm', concat(math:max(//allocation-data/acrn-config/vm[@id=$vm_id]/clos/vcpu_clos), 'U'))" />
       </xsl:if>
     </xsl:if>
 


### PR DESCRIPTION
The current RDT setting requires users to calculate the CLOS mask and
the details, it is not a user-friendly setting.

So we redesigned RDT, users can easily specify the cache of each vcpu
for VMs.

This patch add an RDT region element for schema, calculate and generate
all the mask and rdt parameters by config tool to generates rdt_info
struct for board.c.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@intel.com>