### PR TITLE
config_tools: update virtio console to support multiple console sockets

### DIFF
--- a/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
@@ -147,7 +147,6 @@
     <virtio_devices>
       <console/>
       <network>
-        <virtio_framework/>
         <interface_name>WaaG</interface_name>
       </network>
       <input/>
@@ -181,7 +180,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>YaaG</interface_name>
       </network>
       <input/>

--- a/misc/config_tools/data/cfl-k700-i7/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/shared_launch_6user_vm.xml
@@ -102,7 +102,6 @@
     <virtio_devices>
       <console/>
       <network>
-        <virtio_framework/>
         <interface_name>WaaG</interface_name>
       </network>
       <input/>
@@ -143,7 +142,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>RT</interface_name>
       </network>
       <input/>
@@ -181,7 +179,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>YaaG3</interface_name>
       </network>
       <input/>
@@ -219,7 +216,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>YaaG4</interface_name>
       </network>
       <input/>
@@ -257,7 +253,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>YaaG5</interface_name>
       </network>
       <input/>
@@ -295,7 +290,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>YaaG6</interface_name>
       </network>
       <input/>

--- a/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
@@ -147,7 +147,6 @@
     <virtio_devices>
       <console/>
       <network>
-        <virtio_framework/>
         <interface_name>WaaG</interface_name>
       </network>
       <input/>
@@ -181,7 +180,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>YaaG</interface_name>
       </network>
       <input/>

--- a/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
@@ -102,7 +102,6 @@
     <virtio_devices>
       <console/>
       <network>
-        <virtio_framework/>
         <interface_name>WaaG</interface_name>
       </network>
       <input/>
@@ -143,7 +142,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>RT</interface_name>
       </network>
       <input/>
@@ -181,7 +179,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>YaaG3</interface_name>
       </network>
       <input/>
@@ -219,7 +216,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>YaaG4</interface_name>
       </network>
       <input/>
@@ -257,7 +253,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>YaaG5</interface_name>
       </network>
       <input/>
@@ -295,7 +290,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>YaaG6</interface_name>
       </network>
       <input/>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
@@ -147,7 +147,6 @@
     <virtio_devices>
       <console/>
       <network>
-        <virtio_framework/>
         <interface_name>WaaG</interface_name>
       </network>
       <input/>
@@ -181,7 +180,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>YaaG</interface_name>
       </network>
       <input/>

--- a/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
@@ -114,8 +114,7 @@
     <virtio_devices>
       <console/>
       <network>
-	<virtio_framework/>
-	<interface_name>WaaG</interface_name>
+        <interface_name>WaaG</interface_name>
       </network>
       <input/>
       <block>./win10-ltsc.img</block>
@@ -155,8 +154,7 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-	<virtio_framework/>
-	<interface_name>RT</interface_name>
+        <interface_name>RT</interface_name>
       </network>
       <input/>
       <block>./core-image-weston-intel-corei7-64.wic</block>
@@ -193,8 +191,7 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-	<virtio_framework/>
-	<interface_name>YaaG3</interface_name>
+        <interface_name>YaaG3</interface_name>
       </network>
       <input/>
       <block>./YaaG.img</block>
@@ -231,8 +228,7 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-	<virtio_framework/>
-	<interface_name>YaaG4</interface_name>
+        <interface_name>YaaG4</interface_name>
       </network>
       <input/>
       <block>./YaaG.img</block>
@@ -269,8 +265,7 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-	<virtio_framework/>
-	<interface_name>YaaG5</interface_name>
+        <interface_name>YaaG5</interface_name>
       </network>
       <input/>
       <block>./YaaG.img</block>
@@ -307,8 +302,7 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-	<virtio_framework/>
-	<interface_name>YaaG6</interface_name>
+        <interface_name>YaaG6</interface_name>
       </network>
       <input/>
       <block>./YaaG.img</block>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
@@ -119,7 +119,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>WaaG</interface_name>
       </network>
       <input/>
@@ -161,7 +160,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>RT</interface_name>
       </network>
       <input/>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
@@ -175,7 +175,6 @@
     <virtio_devices>
       <console/>
       <network>
-        <virtio_framework/>
         <interface_name>WaaG</interface_name>
       </network>
       <input/>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
@@ -123,7 +123,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>RT</interface_name>
       </network>
       <input/>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
@@ -103,7 +103,6 @@
     <virtio_devices>
       <console/>
       <network>
-        <virtio_framework/>
         <interface_name>WaaG</interface_name>
       </network>
       <input/>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
@@ -103,7 +103,6 @@
     <virtio_devices>
       <console/>
       <network>
-        <virtio_framework/>
         <interface_name>WaaG</interface_name>
       </network>
       <input/>
@@ -144,7 +143,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>RT</interface_name>
       </network>
       <input/>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
@@ -103,7 +103,6 @@
     <virtio_devices>
       <console/>
       <network>
-        <virtio_framework/>
         <interface_name>WaaG</interface_name>
       </network>
       <input/>
@@ -144,7 +143,6 @@
         <backend_type>stdio</backend_type>
       </console>
       <network>
-        <virtio_framework/>
         <interface_name>RT</interface_name>
       </network>
       <input/>

--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -262,22 +262,23 @@ def generate_for_one_vm(board_etree, hv_scenario_etree, vm_scenario_etree, vm_id
         elif backend_device_file is not None:
             script.add_virtual_device("virtio-input", options=backend_device_file)
 
-    for backend_type in eval_xpath_all(vm_scenario_etree, ".//virtio_devices/console/backend_type[text() != '']/text()"):
+    for virtio_console_etree in eval_xpath_all(vm_scenario_etree, ".//virtio_devices/console"):
         preceding_mask = ""
-        use_type = eval_xpath(vm_scenario_etree, ".//virtio_devices/console/use_type/text()")
+        use_type = eval_xpath(virtio_console_etree, "./use_type/text()")
+        backend_type = eval_xpath(virtio_console_etree, "./backend_type/text()")
         if use_type == "Virtio console":
             preceding_mask = "@"
 
         if backend_type == "file":
-            output_file_path = eval_xpath(vm_scenario_etree, ".//virtio_devices/console/output_file_path/text()")
+            output_file_path = eval_xpath(virtio_console_etree, "./output_file_path/text()")
             script.add_virtual_device("virtio-console", options=f"{preceding_mask}file:file_port={output_file_path}")
         elif backend_type == "tty":
-            tty_file_path = eval_xpath(vm_scenario_etree, ".//virtio_devices/console/tty_device_path/text()")
+            tty_file_path = eval_xpath(virtio_console_etree, "./tty_device_path/text()")
             script.add_virtual_device("virtio-console", options=f"{preceding_mask}tty:tty_port={tty_file_path}")
         elif backend_type == "sock server" or backend_type == "sock client":
-            sock_file_path = eval_xpath(vm_scenario_etree, ".//virtio_devices/console/sock_file_path/text()")
+            sock_file_path = eval_xpath(virtio_console_etree, "./sock_file_path/text()")
             script.add_virtual_device("virtio-console", options=f"socket:{os.path.basename(sock_file_path).split('.')[0]}={sock_file_path}:{backend_type.replace('sock ', '')}")
-        else:
+        elif backend_type == "pty" or backend_type == "stdio":
             script.add_virtual_device("virtio-console", options=f"{preceding_mask}{backend_type}:{backend_type}_port")
 
     for interface_name in eval_xpath_all(vm_scenario_etree, ".//virtio_devices/network/interface_name[text() != '']/text()"):

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -443,7 +443,7 @@ argument and memory.</xs:documentation>
       </xs:annotation>
       <xs:complexType>
         <xs:all>
-          <xs:element name="console" type="VirtioConsoleConfiguration" minOccurs="0">
+          <xs:element name="console" type="VirtioConsoleConfiguration" minOccurs="0" maxOccurs="unbounded">
             <xs:annotation acrn:title="Virtio console device" acrn:views="basic">
               <xs:documentation>Virtio console device for data input and output.
 The virtio console BE driver copies data from the frontend's transmitting virtqueue when it receives a kick on virtqueue (implemented as a vmexit).


### PR DESCRIPTION
1. updates virtio console in schema and launch script generation logic to support multiple console sockets.
2. update upgrader.py script for virtio devices.
    1) add virtio gpu logic in the upgrader.py script.
    2) fix the upgraded virtio elements issue.
    3) add the logic to remove the element with an empty value in the XML file to use the default value.