### PR TITLE
HV: vPCI: fix two monir bugs

### DIFF
--- a/hypervisor/dm/vpci/ivshmem.c
+++ b/hypervisor/dm/vpci/ivshmem.c
@@ -221,7 +221,7 @@ static int32_t ivshmem_mmio_handler(struct io_request *io_req, void *data)
 	return 0;
 }
 
-static int32_t read_ivshmem_vdev_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+static int32_t read_ivshmem_vdev_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	*val = pci_vdev_read_vcfg(vdev, offset, bytes);
 

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -582,7 +582,7 @@ void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev)
 			pci_vdev_write_vcfg(vdev, PCIR_VENDOR, 2U, vid);
 			pci_vdev_write_vcfg(vdev, PCIR_DEVICE, 2U, did);
 		} else {
-			/* VF is unassinged  */
+			/* VF is unassinged: when VF was first created, the VF's BARs hasn't been assigned */
 			uint32_t bar_idx;
 
 			for (bar_idx = 0U; bar_idx < vdev->nr_bars; bar_idx++) {

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -48,6 +48,21 @@ static inline struct msix_table_entry *get_msix_table_entry(const struct pci_vde
 }
 
 /**
+ * @brief Reading MSI-X Capability Structure
+ *
+ * @pre vdev != NULL
+ * @pre vdev->pdev != NULL
+ */
+void read_pt_vmsix_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+{
+	if (vdev->msix.is_vmsix_on_msi) {
+		*val = pci_vdev_read_vcfg(vdev, offset, bytes);
+	} else {
+		read_vmsix_cap_reg(vdev, offset, bytes, val);
+	}
+}
+
+/**
  * @brief Writing MSI-X Capability Structure
  *
  * @pre vdev != NULL

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -146,7 +146,7 @@ static void deinit_vhostbridge(__unused struct pci_vdev *vdev)
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
  */
-static int32_t read_vhostbridge_cfg(const struct pci_vdev *vdev, uint32_t offset,
+static int32_t read_vhostbridge_cfg(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
 	*val = pci_vdev_read_vcfg(vdev, offset, bytes);

--- a/hypervisor/dm/vpci/vmcs9900.c
+++ b/hypervisor/dm/vpci/vmcs9900.c
@@ -12,8 +12,8 @@
 #include "vpci_priv.h"
 #include <errno.h>
 
-#define MCS9900_MMIO_BAR        0U
-#define MCS9900_MSIX_BAR        1U
+#define MCS9900_MMIO_BAR	0U
+#define MCS9900_MSIX_BAR	1U
 
 /*
  * @pre vdev != NULL
@@ -32,12 +32,10 @@ void trigger_vmcs9900_msix(struct pci_vdev *vdev)
 	}
 }
 
-static int32_t read_vmcs9900_cfg(const struct pci_vdev *vdev,
-				       uint32_t offset, uint32_t bytes,
-				       uint32_t * val)
+static int32_t read_vmcs9900_cfg(struct pci_vdev *vdev,
+		uint32_t offset, uint32_t bytes, uint32_t * val)
 {
 	*val = pci_vdev_read_vcfg(vdev, offset, bytes);
-
 	return 0;
 }
 

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -532,15 +532,17 @@ static int32_t write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 	return ret;
 }
 
-static int32_t read_pt_dev_cfg(const struct pci_vdev *vdev, uint32_t offset,
+static int32_t read_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 		uint32_t bytes, uint32_t *val)
 {
 	int32_t ret = 0;
 
 	if (cfg_header_access(offset)) {
 		read_cfg_header(vdev, offset, bytes, val);
-	} else if (msicap_access(vdev, offset) || msixcap_access(vdev, offset)) {
+	} else if (msicap_access(vdev, offset)) {
 		*val = pci_vdev_read_vcfg(vdev, offset, bytes);
+	} else if (msixcap_access(vdev, offset)) {
+		read_pt_vmsix_cap_reg(vdev, offset, bytes, val);
 	} else if (sriovcap_access(vdev, offset)) {
 		read_sriov_cap_reg(vdev, offset, bytes, val);
 	} else {

--- a/hypervisor/dm/vpci/vpci_bridge.c
+++ b/hypervisor/dm/vpci/vpci_bridge.c
@@ -80,7 +80,7 @@ static void deinit_vpci_bridge(__unused struct pci_vdev *vdev)
 	vdev->user = NULL;
 }
 
-static int32_t read_vpci_bridge_cfg(const struct pci_vdev *vdev, uint32_t offset,
+static int32_t read_vpci_bridge_cfg(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
 	if ((offset + bytes) <= 0x100U) {

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -153,7 +153,9 @@ void deinit_vmsi(const struct pci_vdev *vdev);
 
 void init_vmsix_pt(struct pci_vdev *vdev);
 int32_t add_vmsix_capability(struct pci_vdev *vdev, uint32_t entry_num, uint8_t bar_num);
+void read_vmsix_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 bool write_vmsix_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+void read_pt_vmsix_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 void write_pt_vmsix_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 uint32_t rw_vmsix_table(struct pci_vdev *vdev, struct io_request *io_req);
 int32_t vmsix_handle_table_mmio_access(struct io_request *io_req, void *priv_data);

--- a/hypervisor/dm/vpci/vroot_port.c
+++ b/hypervisor/dm/vpci/vroot_port.c
@@ -76,7 +76,7 @@ static void deinit_vrp(__unused struct pci_vdev *vdev)
 	vdev->user = NULL;
 }
 
-static int32_t read_vrp_cfg(const struct pci_vdev *vdev, uint32_t offset,
+static int32_t read_vrp_cfg(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
 	*val = pci_vdev_read_vcfg(vdev, offset, bytes);

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -104,7 +104,7 @@ struct pci_vdev_ops {
        void    (*init_vdev)(struct pci_vdev *vdev);
        void    (*deinit_vdev)(struct pci_vdev *vdev);
        int32_t (*write_vdev_cfg)(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-       int32_t (*read_vdev_cfg)(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+       int32_t (*read_vdev_cfg)(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 };
 
 struct pci_vdev {


### PR DESCRIPTION
1. MSI-X vectors may been changed by system software or driver software on runtime.
So we should pass htrough Message Control Register to guest.
2. Service may use VFs, so ACRN hypervisor should map VF BARs for PF to let PF
could initialize VF by firmware or PF's driver.

Tracked-On: #7275
Signed-off-by: Fei Li <fei1.li@intel.com>