### PR TITLE
config_tools: add 'configurator' to error message

### DIFF
--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -241,4 +241,4 @@ if __name__ == "__main__":
     elif args.deb_mode == 'configurator':
         create_configurator_deb(args.build_dir)
     else:
-        print("ERROR: Please check the value of deb_mode: the value shall be acrn_all or board_inspector.")
+        print("ERROR: Please check the value of deb_mode: the value shall be acrn_all, board_inspector or configurator.")


### PR DESCRIPTION
A new target is available to the gen_acrn_deb.py script, namely
'configurator'. The error message in case the user passes an incorrect target
provides the valid option but did not mention this new 'configurator' target.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>