### PR TITLE
hv: remove obsolete declarations related to RDT

### DIFF
--- a/hypervisor/arch/x86/rdt.c
+++ b/hypervisor/arch/x86/rdt.c
@@ -23,8 +23,6 @@ const uint16_t hv_clos = 0U;
  * each resource's clos max value to have consistent allocation.
  */
 #ifdef CONFIG_RDT_ENABLED
-/* TODO: once config-tool is ready to generate this information for us, we could remove these static definitions */
-extern struct rdt_type res_cap_info[RDT_NUM_RESOURCES];
 
 /*
  * @pre res == RDT_RESOURCE_L3 || res == RDT_RESOURCE_L2 || res == RDT_RESOURCE_MBA

--- a/hypervisor/include/arch/x86/asm/board.h
+++ b/hypervisor/include/arch/x86/asm/board.h
@@ -11,6 +11,7 @@
 #include <asm/host_pm.h>
 #include <pci.h>
 #include <misc_cfg.h>
+#include <asm/rdt.h>
 
 /* forward declarations */
 struct acrn_vm;
@@ -29,9 +30,7 @@ struct vmsix_on_msi_info {
 extern struct dmar_info plat_dmar_info;
 
 #ifdef CONFIG_RDT_ENABLED
-extern union clos_config platform_l2_clos_array[MAX_CACHE_CLOS_NUM_ENTRIES];
-extern union clos_config platform_l3_clos_array[MAX_CACHE_CLOS_NUM_ENTRIES];
-extern union clos_config platform_mba_clos_array[MAX_MBA_CLOS_NUM_ENTRIES];
+extern struct rdt_type res_cap_info[RDT_NUM_RESOURCES];
 #endif
 
 extern const struct cpu_state_table board_cpu_state_tbl;


### PR DESCRIPTION
Since CAT support for hybrid platform is landed, let's remove some old declarations
which are no longer used.

Tracked-On: #6690
Signed-off-by: Tw <wei.tan@intel.com>