### PR TITLE
misc: config_tools: Add Check for RTVM pCPU assignment

### DIFF
--- a/misc/config_tools/schema/checks/cpu_assignment.xsd
+++ b/misc/config_tools/schema/checks/cpu_assignment.xsd
@@ -18,10 +18,10 @@
     </xs:annotation>
   </xs:assert>
 
-  <xs:assert test="every $pcpu in /acrn-config/vm[load_order = 'PRE_LAUNCHED_VM' and vm_type = 'RTVM']//cpu_affinity//pcpu_id satisfies
+  <xs:assert test="every $pcpu in /acrn-config/vm[vm_type = 'RTVM']//cpu_affinity//pcpu_id satisfies
                    count(/acrn-config/vm[@id != $pcpu/ancestor::vm//companion_vmid ]//cpu_affinity[.//pcpu_id = $pcpu]) &lt;= 1">
     <xs:annotation acrn:severity="error" acrn:report-on="//vm//cpu_affinity[.//pcpu_id = $pcpu]">
-      <xs:documentation>Physical CPU {$pcpu} is assigned to pre-launched real-time VM (RTVM) "{$pcpu/ancestor::vm/name}" and thus cannot be shared among multiple VMs. Look for, and probably remove, any affinity assignments to {$pcpu} in this VM's settings: {//vm[cpu_affinity//pcpu_id = $pcpu]/name}.</xs:documentation>
+      <xs:documentation>Physical CPU {$pcpu} is assigned to real-time VM (RTVM) "{$pcpu/ancestor::vm/name}" and thus cannot be shared among multiple VMs. Look for, and probably remove, any affinity assignments to {$pcpu} in this VM's settings: {//vm[cpu_affinity//pcpu_id = $pcpu]/name}.</xs:documentation>
     </xs:annotation>
   </xs:assert>
 


### PR DESCRIPTION
Previously we have checks to make sure pre-launched RTVM does not share
pCPU with others. This patch extends this check to all RTVMs.

Tracked-On: #7361
Signed-off-by: Yifan Liu <yifan1.liu@intel.com>