### PR TITLE
[acrn-configuration tool] make scenario shared file error cp error

### DIFF
--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -116,11 +116,12 @@ def create_acrn_deb(board, scenario, version, build_dir):
             continue
         source = cur_dir + source
         target = deb_dir + target
-        if os.path.exists(target):
-            run_command('cp %s %s' % (source, target), cur_dir)
-        else:
-            run_command('mkdir -p %s' % target, cur_dir)
-            run_command('cp %s %s' % (source, target), cur_dir)
+        if os.path.exists(source):
+            if os.path.exists(target):
+                run_command('cp %s %s' % (source, target), cur_dir)
+            else:
+                run_command('mkdir -p %s' % target, cur_dir)
+                run_command('cp %s %s' % (source, target), cur_dir)
 
     run_command('cp ./misc/packaging/acrn-hypervisor.postinst ./build/acrn_release_deb/DEBIAN/postinst', cur_dir)
     run_command('chmod +x ./build/acrn_release_deb/etc/grub.d/100_ACRN', cur_dir)


### PR DESCRIPTION
Fixed the problem that the "'cp %s %s' % (source, target), cur_dir" command
is still executed when there is no ACPI_VM.bin file after build.

Tracked-On: projectacrn#7366
Signed-off-by: Ziheng Li <ziheng.li@intel.com>