### PR TITLE
Acrn vgpu edid

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_gpu.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpu.c
@@ -554,6 +554,7 @@ virtio_gpu_cmd_get_edid(struct virtio_gpu_command *cmd)
 	memset(&resp, 0, sizeof(resp));
 	/* Only one EDID block is enough */
 	resp.size = 128;
+	resp.hdr.type = VIRTIO_GPU_RESP_OK_EDID;
 	virtio_gpu_update_resp_fence(&cmd->hdr, &resp.hdr);
 	vdpy_get_edid(gpu->vdpy_handle, resp.edid, resp.size);
 	memcpy(cmd->iov[1].iov_base, &resp, sizeof(resp));
@@ -1228,6 +1229,7 @@ virtio_gpu_ctrl_bh(void *data)
 		switch (cmd.hdr.type) {
 		case VIRTIO_GPU_CMD_GET_EDID:
 			virtio_gpu_cmd_get_edid(&cmd);
+			break;
 		case VIRTIO_GPU_CMD_GET_DISPLAY_INFO:
 			virtio_gpu_cmd_get_display_info(&cmd);
 			break;

--- a/devicemodel/hw/pci/virtio/virtio_gpu.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpu.c
@@ -1485,6 +1485,7 @@ virtio_gpu_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 			gpu->vq,
 			BACKEND_VBSU);
 
+	gpu->vdpy_handle = vdpy_init();
 	gpu->base.mtx = &gpu->mtx;
 	gpu->base.device_caps = VIRTIO_GPU_S_HOSTCAPS;
 
@@ -1623,7 +1624,6 @@ virtio_gpu_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		pr_err("%s, set modern io bar(BAR5) failed.\n", __func__);
 		return rc;
 	}
-	gpu->vdpy_handle = vdpy_init();
 
 	pthread_mutex_init(&gpu->vga_thread_mtx, NULL);
 	/* VGA Compablility */

--- a/devicemodel/hw/vdisplay_sdl.c
+++ b/devicemodel/hw/vdisplay_sdl.c
@@ -1217,5 +1217,9 @@ int vdpy_parse_cmd_option(const char *opts)
 		pr_info("virtual display: windowed.\n");
 	}
 
+	vdpy.info.xoff = 0;
+	vdpy.info.yoff = 0;
+	vdpy.info.width = vdpy.width;
+	vdpy.info.height = vdpy.height;
 	return error;
 }


### PR DESCRIPTION
The virtio_gpu in guest_vm will try to fetch the EDID/Display_info to query
the supported resolution. Now acrn-dm doesn't handle the request of
VIRTIO_GPU_CMD_GET_EDID/VIRTIO_GPU_CMD_GET_DISPLAY_INFO.
This patch set tries to fix the above issue.