### PR TITLE
hv: vtd: reset the one-shot bits for GCMD_REG

### DIFF
--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -445,7 +445,7 @@ static int32_t dmar_register_hrhd(struct dmar_drhd_rt *dmar_unit)
 	 * register to control remapping hardware. Global Status Register is the corresponding read-only register to
 	 * report remapping hardware status.
 	 */
-	dmar_unit->gcmd = iommu_read32(dmar_unit, DMAR_GSTS_REG);
+	dmar_unit->gcmd = iommu_read32(dmar_unit, DMAR_GSTS_REG) & 0x96FFFFFFU; // Reset the one-shot bits;
 
 	dmar_unit->cap_msagaw = dmar_unit_get_msagw(dmar_unit);
 


### PR DESCRIPTION
If multiple control fields in GCMD_REG register need to be modified, software
must serialize the modifications through multiple writes to this register.

So one-shot bits (bits 30-29, 27 and 24) in gcmd should not been set.
Otherwise, other control field may be written to GCMD_REG at the same time
with one-shot bit (Clearing one-shot bit has no effect, software sets this field
would set/update this control field used by hardware).

Tracked-On: #7381
Signed-off-by: Fei Li <fei1.li@intel.com>