### PR TITLE
[acrn-configuration tool] make scenario shared file error cp error

### DIFF
--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -127,8 +127,9 @@ def create_acrn_deb(board, scenario, version, build_dir):
     run_command('chmod +x ./build/acrn_release_deb/etc/grub.d/100_ACRN', cur_dir)
     run_command('chmod +x ./build/acrn_release_deb/DEBIAN/postinst', cur_dir)
     run_command('sed -i \'s/\r//\' ./build/acrn_release_deb/DEBIAN/postinst', cur_dir)
-    run_command('chmod +x ./build/acrn_release_deb/DEBIAN/preinst', cur_dir)
-    run_command('sed -i \'s/\r//\' ./build/acrn_release_deb/DEBIAN/preinst', cur_dir)
+    if os.path.exists('./build/acrn_release_deb/DEBIAN/preinst'):
+        run_command('chmod +x ./build/acrn_release_deb/DEBIAN/preinst', cur_dir)
+        run_command('sed -i \'s/\r//\' ./build/acrn_release_deb/DEBIAN/preinst', cur_dir)
 
     ret = run_command('dpkg -b acrn_release_deb acrn-%s-%s-%s.deb' % (board, scenario, version), build_dir)
     if ret != 0:


### PR DESCRIPTION
Fixed the error that the "'chmod +x ./build/acrn_release_deb/DEBIAN/preinst'"
command and "sed -i \'s/\r//\' ./build/acrn_release_deb/DEBIAN/preinst" command
are still executed when there is no "./build/acrn_release_deb/DEBIAN/preinst"
file after build.

Tracked-On: projectacrn#7383
Signed-off-by: Ziheng Li <ziheng.li@intel.com>