### PR TITLE
misc: fix the issue of create hv node

### DIFF
--- a/misc/config_tools/static_allocators/clos.py
+++ b/misc/config_tools/static_allocators/clos.py
@@ -122,7 +122,7 @@ def alloc_clos_index(board_etree, scenario_etree, allocation_etree, mask_list):
 def creat_mask_list_node(board_etree, scenario_etree, allocation_etree, mask_list):
     allocation_hv_node = common.get_node(f"//hv", allocation_etree)
     if allocation_hv_node is None:
-        allocation_hv_node = common.append_node("//hv", None, allocation_etree, id = vm_id)
+        allocation_hv_node = common.append_node(f"/acrn-config/hv", None, allocation_etree)
     cache2_id_list = scenario_etree.xpath("//CACHE_ALLOCATION[CACHE_LEVEL = 2]/CACHE_ID/text()")
     cache2_id_list.sort()
     if common.get_node("./clos_mask[@id = l3]", allocation_hv_node) is None:

--- a/misc/config_tools/static_allocators/main.py
+++ b/misc/config_tools/static_allocators/main.py
@@ -25,7 +25,7 @@ def main(args):
     board_etree = lxml.etree.parse(args.board)
     scenario_etree = lxml.etree.parse(args.scenario)
     allocation_etree = lxml.etree.ElementTree(element=lxml.etree.fromstring("<acrn-config></acrn-config>"))
-    for script in [f for f in os.listdir(scripts_path) if f.endswith(".py") and f != current]:
+    for script in sorted([f for f in os.listdir(scripts_path) if f.endswith(".py") and f != current]):
         module_name = os.path.splitext(script)[0]
         module = import_module(f"{module_name}")
         module.fn(board_etree, scenario_etree, allocation_etree)


### PR DESCRIPTION
There was an issue of create hv node by clos module, the direct cause
is the create logic and the indirect cause is these modules of
static_allocators was not sorted before run which cause some platform
have issue and CI could not found.

So this patch fix the create issue and sorted the modules list to make
sure all these platform could work well and get the same allocation.xml

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@intel.com>