### PR TITLE
config_tools: do not apply distinct-values on a union of node-set

### DIFF
--- a/misc/config_tools/schema/checks/vbdf_assignment.xsd
+++ b/misc/config_tools/schema/checks/vbdf_assignment.xsd
@@ -7,7 +7,7 @@
 
   <xs:assert test="every $root in /acrn-config satisfies
                    every $vm in $root/vm satisfies
-		   every $vbdf in distinct-values($root/hv//vuart_connection[type='pci']/endpoint[vm_name=$vm/name]/vbdf/text() | $root/hv//IVSHMEM_VM[VM_NAME=$vm/name]/VBDF/text()) satisfies
+		   every $vbdf in $root/hv//vuart_connection[type='pci']/endpoint[vm_name=$vm/name]/vbdf/text() | $root/hv//IVSHMEM_VM[VM_NAME=$vm/name]/VBDF/text() satisfies
 		   count($root/hv//vuart_connection[type='pci']/endpoint[vm_name=$vm/name and vbdf=$vbdf] | $root/hv//IVSHMEM_VM[VM_NAME=$vm/name and VBDF=$vbdf]) = 1">
     <xs:annotation acrn:severity="error" acrn:report-on="$root/hv//vuart_connection[type='pci']/endpoint[vm_name=$vm/name and vbdf=$vbdf] | $root/hv//IVSHMEM_VM[VM_NAME=$vm/name and VBDF=$vbdf]">
       <xs:documentation>VM "{$vm/name}" contains multiple virtual UART controllers and/or IVSHMEM interfaces using BDF {$vbdf}. Adjust the BDF of those devices.</xs:documentation>


### PR DESCRIPTION
The latest version of the elementpath library (i.e. 2.5.0) fails to
evaluate an XPATH which feeds a union of node sets to the `distinct-values`
function. An exception will be raised in such case, which eventually causes
the hypervisor build to fail.

This patch removes the usage of `distinct-values` function in the
XPATH. This may cause some additional delays to the evaluation of the
assertion, but at least will not impact the build even the latest versions
of the Python libraries are used.

Tracked-On: #7372
Signed-off-by: Junjie Mao <junjie.mao@intel.com>