### PR TITLE
config_tools: update the hugepage algorithm

### DIFF
--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -81,7 +81,6 @@
   </xsl:variable>
   <xsl:variable name="sos_bootargs" select="normalize-space(str:replace(//vm[acrn:is-service-vm(load_order)]/os_config/bootargs[text()], $sos_rootfs, ''))" />
   <xsl:variable name="maxcpunum" select="count(//vm[acrn:is-service-vm(load_order)]/cpu_affinity//pcpu_id)" />
-  <xsl:variable name="hugepages" select="round(number(substring-before(//board-data//TOTAL_MEM_INFO, 'kB')) div (1024 * 1024)) - 3" />
   <xsl:variable name="maxcpus">
     <xsl:choose>
       <xsl:when test="$maxcpunum != 0">
@@ -94,7 +93,7 @@
   </xsl:variable>
   <xsl:variable name="hugepage_kernelstring">
     <xsl:if test="//board-data//processors//capability[@id='gbyte_pages']">
-      <xsl:value-of select="concat('hugepagesz=1G hugepages=', $hugepages)" />
+      <xsl:value-of select="concat('hugepagesz=1G hugepages=', //allocation-data//vm[acrn:is-service-vm(load_order)]/hugepages/gb, ' hugepagesz=2M hugepages=', //allocation-data//vm[acrn:is-service-vm(load_order)]/hugepages/mb)" />
     </xsl:if>
   </xsl:variable>
   <xsl:value-of select="acrn:define('SERVICE_VM_ROOTFS', concat($quot, $sos_rootfs, ' ', $quot), '')" />


### PR DESCRIPTION
update the hugepages algorithm as the following steps.
1. calculate the total hugepages of service vm using the formula.
   "total memory - the memory consumed by pre-launched VMs - 3G
   -1G(memory need by service vm supporting virtio gpu)
   -300M*num(number of virtio gpu instance)"
2. calculate hugepage 2M/1G based post-launched vm memory setting.
3. correct the 2M/1G hugepages with the total hugepages in step 1.
   "correct_mb, correct_gb= math.modf(total hugepages - the memory
    consumed by Post_launched vm)
    hugepages_1gb = hugepages_1gb + correct_gb
    hugepages_2mb = hugepages_2mb + math.ceil(correct_mb*1024/2)"

Tracked-On: #7301
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>