### PR TITLE
doc: tweak option config doc processing for missing attributes

### DIFF
--- a/doc/scripts/configdoc.xsl
+++ b/doc/scripts/configdoc.xsl
@@ -108,14 +108,17 @@
             </xsl:when>
             <xsl:otherwise>
               <xsl:choose>
+                  <xsl:when test="count(xs:annotation/@acrn:applicable-vms)=0 and count($parent/xs:annotation/@acrn:applicable-vms)=0 and count($parent/../xs:annotation/@acrn:applicable-vms)=0 and count($parent/../../xs:annotation/@acrn:applicable-vms)=0 and count($parent/../../../xs:annotation/@acrn:applicable-vms)=0">
+                      <xsl:text>|icon-pre-launched-vm| |icon-post-launched-vm| |icon-service-vm| </xsl:text>
+                  </xsl:when>
                 <xsl:when test="count(xs:annotation/@acrn:applicable-vms)=0">
-                  <xsl:if test="contains($parent/xs:annotation/@acrn:applicable-vms,'pre-launched') or contains($parent/../xs:annotation/@acrn:applicable-vms,'pre-launched') or    contains($parent/../../xs:annotation/@acrn:applicable-vms,'pre-launched')">
+                    <xsl:if test="contains($parent/xs:annotation/@acrn:applicable-vms,'pre-launched') or contains($parent/../xs:annotation/@acrn:applicable-vms,'pre-launched') or    contains($parent/../../xs:annotation/@acrn:applicable-vms,'pre-launched') or contains($parent/../../../xs:annotation/@acrn:applicable-vms,'pre-launched')">
                     <xsl:text>|icon-pre-launched-vm| </xsl:text>
                   </xsl:if>
-                  <xsl:if test="contains($parent/xs:annotation/@acrn:applicable-vms,'post-launched') or  contains($parent/../xs:annotation/@acrn:applicable-vms,'post-launched') or  contains($parent/../../xs:annotation/@acrn:applicable-vms,'post-launched')">
+                  <xsl:if test="contains($parent/xs:annotation/@acrn:applicable-vms,'post-launched') or  contains($parent/../xs:annotation/@acrn:applicable-vms,'post-launched') or  contains($parent/../../xs:annotation/@acrn:applicable-vms,'post-launched') or contains($parent/../../../xs:annotation/@acrn:applicable-vms,'post-launched')">
                     <xsl:text>|icon-post-launched-vm| </xsl:text>
                   </xsl:if>
-                  <xsl:if test="contains($parent/xs:annotation/@acrn:applicable-vms,'service-vm') or  contains($parent/../xs:annotation/@acrn:applicable-vms,'service-vm') or      contains($parent/../../xs:annotation/@acrn:applicable-vms,'service-vm')">
+                  <xsl:if test="contains($parent/xs:annotation/@acrn:applicable-vms,'service-vm') or  contains($parent/../xs:annotation/@acrn:applicable-vms,'service-vm') or      contains($parent/../../xs:annotation/@acrn:applicable-vms,'service-vm') or contains($parent/../../../xs:annotation/@acrn:applicable-vms,'service-vm')">
                     <xsl:text>|icon-service-vm| </xsl:text>
                   </xsl:if>
                 </xsl:when>
@@ -134,23 +137,30 @@
             </xsl:otherwise>
           </xsl:choose>
           <xsl:text>/ </xsl:text>
-          <xsl:if test="xs:annotation/@acrn:views=''">
-            <xsl:text>|icon-not-available| </xsl:text>
-          </xsl:if>
-          <xsl:if test="count(xs:annotation/@acrn:views)=0">
-            <xsl:if test="contains($parent/xs:annotation/@acrn:views,'basic') or  contains($parent/../xs:annotation/@acrn:views,'basic') or contains($parent/../../xs:annotation/@acrn:views,'basic')">
-              <xsl:text>|icon-basic| </xsl:text>
-            </xsl:if>
-            <xsl:if test="contains($parent/xs:annotation/@acrn:views,'advanced') or  contains($parent/../xs:annotation/@acrn:views,'advanced') or contains($parent/../../xs:annotation/@acrn:views,'advanced')">
-              <xsl:text>|icon-advanced| </xsl:text>
-            </xsl:if>
-          </xsl:if>
-          <xsl:if test="contains(xs:annotation/@acrn:views,'basic')">
-            <xsl:text>|icon-basic| </xsl:text>
-          </xsl:if>
-          <xsl:if test="contains(xs:annotation/@acrn:views,'advanced')">
-            <xsl:text>|icon-advanced| </xsl:text>
-          </xsl:if>
+          <xsl:choose>
+              <xsl:when test="count(xs:annotation/@acrn:views)=0 and count($parent/xs:annotation/@acrn:views)=0 and count($parent/../xs:annotation/@acrn:views)=0 and count($parent/../../xs:annotation/@acrn:views)=0 and count($parent/../../../xs:annotation/@acrn:views)=0">
+                <xsl:text>|icon-basic| |icon-advanced|</xsl:text>
+              </xsl:when>
+              <xsl:when test="xs:annotation/@acrn:views=''">
+                <xsl:text>|icon-not-available| </xsl:text>
+              </xsl:when>
+              <xsl:when test="count(xs:annotation/@acrn:views)=0">
+                <xsl:if test="contains($parent/xs:annotation/@acrn:views,'basic') or  contains($parent/../xs:annotation/@acrn:views,'basic') or contains($parent/../../xs:annotation/@acrn:views,'basic') or contains($parent/../../../xs:annotation/@acrn:views,'basic')">
+                  <xsl:text>|icon-basic| </xsl:text>
+                </xsl:if>
+                <xsl:if test="contains($parent/xs:annotation/@acrn:views,'advanced') or  contains($parent/../xs:annotation/@acrn:views,'advanced') or contains($parent/../../xs:annotation/@acrn:views,'advanced') or contains($parent/../../../xs:annotation/@acrn:views,'advanced')">
+                  <xsl:text>|icon-advanced| </xsl:text>
+                </xsl:if>
+              </xsl:when>
+            <xsl:otherwise>
+              <xsl:if test="contains(xs:annotation/@acrn:views,'basic')">
+                <xsl:text>|icon-basic| </xsl:text>
+              </xsl:if>
+              <xsl:if test="contains(xs:annotation/@acrn:views,'advanced')">
+                <xsl:text>|icon-advanced| </xsl:text>
+              </xsl:if>
+            </xsl:otherwise>
+          </xsl:choose>
         </xsl:variable>
         <xsl:if test="$option-icons!=''">
           <xsl:value-of select="concat('   ',$option-icons,$newline)"/>


### PR DESCRIPTION
When an element in the schema does not have an acrn:applicable-vms or
acrn:views (as opposed to having the attribute with an empty value,
acrn:views="") we need to look up the ancestors to see if any of them
have an element with such an attribute defined.  If non of the ancestors
have that attribute defined, then the intrepretation is that the element
can be found for all VMs or for both basic and advanced tabs.

Tweak the xslt processing of the schema data to option config doc to
reflect these semantics.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>