### PR TITLE
doc: fix malformed virtio gpu device description

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -472,7 +472,7 @@ mouse, and tablet.  It sends Linux input layer events over virtio.</xs:documenta
           <xs:element name="gpu" type="xs:string" minOccurs="0">
             <xs:annotation acrn:title="Virtio GPU device" acrn:views="basic">
               <xs:documentation>The virtio GPU device presents a GPU device to the VM.
-              This feature enables you to view the VM's GPU output in the Service VM.</xs:documentation>
+This feature enables you to view the VM's GPU output in the Service VM.</xs:documentation>
             </xs:annotation>
           </xs:element>
         </xs:all>


### PR DESCRIPTION
xs:documentation content has an indented line that causes the reST
formatting of the generated content to be off (leading spaces on lines
are significant to reST formatting).

Tracked-On: #5692

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>