### PR TITLE
config-tools: remove 'nomwait' from board_inspector's requirement

### DIFF
--- a/misc/config_tools/board_inspector/README
+++ b/misc/config_tools/board_inspector/README
@@ -10,4 +10,5 @@ Please run this script under native Linux environment with root privilege.
 OS requirement:
 	Release:	Ubuntu 18.04+
 	Tools:		cpuid, rdmsr, lspci, lxml, dmidecode (optional)
-	kernel cmdline: "idle=nomwait iomem=relaxed intel_idle.max_cstate=0 intel_pstate=disable"
+	kernel cmdline: "iomem=relaxed intel_idle.max_cstate=0 intel_pstate=disable" or
+			"idle=nomwait iomem=relaxed intel_idle.max_cstate=0 intel_pstate=disable" for Apollo Lake

--- a/misc/config_tools/board_inspector/legacy/acpi.py
+++ b/misc/config_tools/board_inspector/legacy/acpi.py
@@ -439,12 +439,12 @@ def store_cx_data(sysnode1, sysnode2, config):
 
             if idle_driver.find("acpi_idle") == -1:
                 logging.info("Failed to collect processor power states because the current CPU idle driver " \
-                "does not expose C-state data. If you need ACPI C-states in post-launched VMs, append 'idle=nomwait' " \
-                "to the kernel command line in GRUB config file.")
+                "does not expose C-state data. If you need ACPI C-states in post-launched VMs, append " \
+                "'intel_idle.max_cstate=0' to the kernel command line in GRUB config file.")
                 if idle_driver.find("intel_idle") == 0:
                     logging.info("Failed to collect processor power states because the current CPU idle driver " \
-                    "does not expose C-state data. If you need ACPI C-states in post-launched VMs, append 'idle=nomwait' " \
-                    "to the kernel command line in GRUB config file.")
+                    "does not expose C-state data. If you need ACPI C-states in post-launched VMs, append " \
+                    "'intel_idle.max_cstate=0' to the kernel command line in GRUB config file.")
                 else:
                     logging.info("Failed to collect processor power states because the platform does not provide " \
                     "C-state data. If you need ACPI C-states in post-launched VMs, enable C-state support in BIOS.")

--- a/misc/packaging/acrn-board-inspector.postinst
+++ b/misc/packaging/acrn-board-inspector.postinst
@@ -9,7 +9,7 @@ sed -i '/GRUB_DEFAULT/d' ${filename}
 sed -i '/GRUB_TIMEOUT/d' ${filename}
 sed -i '/GRUB_HIDDEN_TIMEOUT/d' ${filename}
 sed -i '/GRUB_CMDLINE_LINUX_DEFAULT/d' ${filename}
-sed -i '$a GRUB_CMDLINE_LINUX_DEFAULT="quiet splash idle=nomwait iomem=relaxed intel_idle.max_cstate=0 intel_pstate=disable"' ${filename}
+sed -i '$a GRUB_CMDLINE_LINUX_DEFAULT="quiet splash iomem=relaxed intel_idle.max_cstate=0 intel_pstate=disable"' ${filename}
 sed -i '$a GRUB_TIMEOUT=20' ${filename}
 
 sync


### PR DESCRIPTION
This patch is about the bug that VMs can't idle.

ACRN enables VM's C-state by extracting host's C-state table.
The C-state table has two types of interfaces: system-IO and mwait. VMs
just need one of them. ACRN can support both.

Currently we are telling users to use the system-IO type. That is, by
adding 'nomwait intel_idle.max_cstate=0' to host Linux's CMD line when
using board_inspector. (The reaseon we were using system-IO is that
mwait was buggy on Apollo Lake.)

But recent tests show that system-IO is somehow buggy. Linux c-state
driver(no matter intel_cstate or acpi_cstate) fails to enter idle state
with system-IO. This can always be reproduced on native environments.
MPERF counters show CPU cores are not in real idle state as expected.

To enable C-state in VMs, we have to switch to mwait.
As ACRN has already supported both system-IO and mwait, we don't have
to modify any code. We just need to tell user to use mwait instead of
system-IO.
That is, don't add 'nomwait intel_idle.max_cstate=0' to host Linux's
CMD line when using board_inspector. Just add 'intel_idle.max_cstate=0'

Due to the Apollo Lake's mwait bug, 'nomwait' is still needed for
Apollo Lake as an exception.

Tracked-On: #7371

Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Signed-off-by: Zhou, Wu <wu.zhou@intel.com>