### PR TITLE
dm: optimize the sub parameter of "-s" compatibility

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -799,6 +799,7 @@ static struct option long_options[] = {
 	{"version",		no_argument,		0, 'v' },
 	{"gvtargs",		required_argument,	0, 'G' },
 	{"help",		no_argument,		0, 'h' },
+	{"mac_seed",		required_argument,	0, CMD_OPT_MAC_SEED},
 
 	/* Following cmd option only has long option */
 #ifdef CONFIG_VM_CFG
@@ -941,6 +942,10 @@ main(int argc, char *argv[])
 					"invalid virtio poll interval %s",
 					optarg);
 			}
+			break;
+		case CMD_OPT_MAC_SEED:
+			pr_warn("The \"--mac_seed\" parameter is obsolete\n");
+			pr_warn("Please use the \"virtio-net,<device_type>=<name> mac_seed=<seed_string>\"\n");
 			break;
 		case CMD_OPT_DEBUGEXIT:
 			debugexit_enabled = true;

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -310,6 +310,12 @@ pci_parse_slot(char *opt)
 		goto done;
 	}
 
+	if ((strcmp("pci-gvt", emul) == 0) || (strcmp("virtio-hdcp", emul) == 0)
+			|| (strcmp("npk", emul) == 0) || (strcmp("virtio-coreu", emul) == 0)) {
+		pr_warn("The \"%s\" parameter is obsolete and ignored\n", emul);
+		goto done;
+	}
+
 	/* <bus>:<slot>:<func> */
 	if (parse_bdf(str, &bnum, &snum, &fnum, 10) != 0)
 		snum = -1;


### PR DESCRIPTION
This patch checks the change of "-s" sub parameters, which was
obsoleted or moved and the print some warnings msg or show the new
format.

The following obsoleted parameters are covered:

-s ,pci-gvt
-s ,virtio-hdcp
-s ,npk
-s ,virtio-coreu
--mac_seed

Reviewed-by: VanCutsem Geoffroy <geoffroy.vancutsem@intel.com>
Signed-off-by: Chenli Wei <chenli.wei@intel.com>