### PR TITLE
doc: fix the make configurator fails issue

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -132,6 +132,7 @@ To set up the ACRN build environment on the development computer:
            libusb-1.0-0-dev \
            python3 \
            python3-pip \
+           python3.8-venv \
            libblkid-dev \
            e2fslibs-dev \
            pkg-config \


### PR DESCRIPTION
The current code need python3.8-venv to build some modules, so we
should add these requirement to "Getting Started Guide".

This patch modify the getting-started.rst to generate new guide.

Signed-off-by: Chenli Wei <chenli.wei@intel.com>