### PR TITLE
hv: fix post RTVM booting failure with SSRAM

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -540,11 +540,14 @@ static void prepare_service_vm_memmap(struct acrn_vm *vm)
 
 	/* remove Software SRAM region from Service VM EPT, to prevent Service VM from using clflush to
 	 * flush the Software SRAM cache.
-	 * This is applicable to prelaunch RTVM case only, for post-launch RTVM, Service VM is trusted.
-	 * When system don't have Software SRAM or not enabled, get_software_sram_size() will return 0.
-	 * In this case no mem region will be removed.
+	 * This is applicable to prelaunch RTVM case only. And only the part that prelaunch RTVM uses needs
+	 * to be removed from Service VM EPT.
+	 *
+	 * PRE_RTVM_SW_SRAM_MAX_SIZE is the size of Software SRAM that prelaunch RTVM uses, presumed to be
+	 * starting from Software SRAM base. For other cases, PRE_RTVM_SW_SRAM_MAX_SIZE should be defined
+	 * as 0, and no region is removed from Service VM EPT.
 	 */
-	ept_del_mr(vm, pml4_page, service_vm_hpa2gpa(get_software_sram_base()), get_software_sram_size());
+	ept_del_mr(vm, pml4_page, service_vm_hpa2gpa(get_software_sram_base()), PRE_RTVM_SW_SRAM_MAX_SIZE);
 
 	/* unmap Intel IOMMU register pages for below reason:
 	 * Service VM can detect IOMMU capability in its ACPI table hence it may access


### PR DESCRIPTION
When booting prelaunch RTVM with SSRAM enabled, we need to delete the
SSRAM region that is used by prelaunch RTVM from Service VM EPT mapping.
If it is not used, or it is not fully used, the SSRAM or the rest SSRAM
should be in Service VM map.

But current code has a issue that it always deletes all SSRAM region
from Service VM EPT, even when no SSRAM is enabled for prelaunch RTVM.

This could cause the post RTVM with SSRAM boot failure, as DM checks and
removes SSRAM region from Service VM EPT during post RTVM setup.

Changing get_software_sram_size() to PRE_RTVM_SW_SRAM_MAX_SIZE could
solve the issue, as PRE_RTVM_SW_SRAM_MAX_SIZE is the SSRAM size that
prelaunch RTVM actually uses.

Tracked-On: #7401

Signed-off-by: Zhou, Wu <wu.zhou@intel.com>