### PR TITLE
misc: deb: Fix the ServiceVM kernel line in ACRN grub entry

### DIFF
--- a/misc/packaging/acrn-hypervisor.postinst
+++ b/misc/packaging/acrn-hypervisor.postinst
@@ -26,7 +26,12 @@ done < <(blkid |grep ext4 |grep ${type})
 
 filename="/etc/grub.d/40_custom"
 
-kernelimg=$(grep module ${filename} | tail -1 || true)
+if ls /boot/vmlinuz*acrn-service-vm* 1> /dev/null 2>&1;then
+    service_vm_kernel=$(ls -tr /boot/vmlinuz-*acrn-service-vm* | tail -1)
+else
+    service_vm_kernel=$(ls /boot/vmlinuz-* | tail -1)
+fi
+kernelimg="module2 $service_vm_kernel Linux_bzImage"
 
 if [ $SCENARIO == shared ];then
     cat>"${filename}"<<EOF


### PR DESCRIPTION
After replacing partitioned ACRN deb with shared deb, the stale
multiboot module for ACPI1.bin was left in ACRN grub entry because it
was taken as kernel image.

Tracked-On: #7400
Signed-off-by: Calvin Zhang <calvinzhang.cool@gmail.com>