### PR TITLE
Acrn edid fix

### DIFF
--- a/devicemodel/hw/vdisplay_sdl.c
+++ b/devicemodel/hw/vdisplay_sdl.c
@@ -353,22 +353,17 @@ vdpy_edid_set_dtd(uint8_t *dtd, const frame_param *frame)
 }
 
 static void
-vdpy_edid_set_descripter(uint8_t *edid, uint8_t is_dtd,
+vdpy_edid_set_descripter(uint8_t *desc, uint8_t is_dtd,
 		uint8_t tag, const base_param *b_param)
 {
-	static uint8_t offset;
-	uint8_t *desc;
 	frame_param frame;
 	const char* text;
 	uint16_t len;
 
-	offset = 54;
-	desc = edid + offset;
 
 	if (is_dtd) {
 		vdpy_edid_set_frame(&frame, b_param);
 		vdpy_edid_set_dtd(desc, &frame);
-		offset += 18;
 		return;
 	}
 	desc[3] = tag;
@@ -408,7 +403,6 @@ vdpy_edid_set_descripter(uint8_t *edid, uint8_t is_dtd,
 	default:
 		break;
 	}
-	offset += 18;
 }
 
 static uint8_t
@@ -431,6 +425,7 @@ vdpy_edid_generate(uint8_t *edid, size_t size, struct edid_info *info)
 	uint16_t id_manuf;
 	uint16_t id_product;
 	uint32_t serial;
+	uint8_t *desc;
 	base_param b_param, c_param;
 
 	vdpy_edid_set_baseparam(&b_param, info->prefx, info->prefy);
@@ -496,15 +491,19 @@ vdpy_edid_generate(uint8_t *edid, size_t size, struct edid_info *info)
 
 	/* edid[125:54], Detailed Timing Descriptor - 18 bytes x 4 */
 	// Detailed Timing Descriptor 1
+	desc = edid + 54;
 	vdpy_edid_set_baseparam(&c_param, VDPY_MAX_WIDTH, VDPY_MAX_HEIGHT);
-	vdpy_edid_set_descripter(edid, 0x1, 0, &c_param);
+	vdpy_edid_set_descripter(desc, 0x1, 0, &c_param);
 	// Detailed Timing Descriptor 2
+	desc += 18;
 	vdpy_edid_set_baseparam(&c_param, VDPY_DEFAULT_WIDTH, VDPY_DEFAULT_HEIGHT);
-	vdpy_edid_set_descripter(edid, 0x1, 0, &c_param);
+	vdpy_edid_set_descripter(desc, 0x1, 0, &c_param);
 	// Display Product Name (ASCII) String Descriptor (tag #FCh)
-	vdpy_edid_set_descripter(edid, 0, 0xfc, &b_param);
+	desc += 18;
+	vdpy_edid_set_descripter(desc, 0, 0xfc, &b_param);
 	// Display Product Serial Number Descriptor (tag #FFh)
-	vdpy_edid_set_descripter(edid, 0, 0xff, &b_param);
+	desc += 18;
+	vdpy_edid_set_descripter(desc, 0, 0xff, &b_param);
 
 	/* EDID[126], Extension Block Count */
 	edid[126] = 0;  // no Extension Block

--- a/devicemodel/hw/vdisplay_sdl.c
+++ b/devicemodel/hw/vdisplay_sdl.c
@@ -105,6 +105,7 @@ static const struct timing_entry {
 	uint32_t byte_t3;// byte idx in the Established Timings III Descriptor
 	uint32_t bit;   // bit idx
 	uint8_t hz;     // frequency
+	bool	is_std; // the flag of standard mode
 } timings[] = {
 	/* Established Timings I & II (all @ 60Hz) */
 	{ .hpixel = 1024, .vpixel =  768, .byte  = 36, .bit = 3, .hz = 60},
@@ -112,8 +113,10 @@ static const struct timing_entry {
 	{ .hpixel =  640, .vpixel =  480, .byte  = 35, .bit = 5, .hz = 60 },
 
 	/* Standard Timings */
-	{ .hpixel = 1920, .vpixel = 1080, .hz = 60 },
-	{ .hpixel = 1280, .vpixel =  720, .hz = 60 },
+	{ .hpixel = 1920, .vpixel = 1080, .hz = 60,  .is_std = true },
+	{ .hpixel = 1280, .vpixel =  720, .hz = 60,  .is_std = true },
+	{ .hpixel = 1440, .vpixel =  900, .hz = 60,  .is_std = true },
+	{ .hpixel = 1680, .vpixel =  1050, .hz = 60, .is_std = true },
 };
 
 typedef struct frame_param{
@@ -269,7 +272,7 @@ vdpy_edid_set_timing(uint8_t *addr, const base_param *b_param, TIMING_MODE mode)
 				return;
 			}
 		case STDT: // Standard Timings
-			if(stdcnt < 8 && (timing->hpixel == b_param->h_pixel)) {
+			if(stdcnt < 8 && timing->is_std) {
 				hpixel = (timing->hpixel >> 3) - 31;
 				if (timing->hpixel == 0 ||
 				    timing->vpixel == 0) {
@@ -304,9 +307,9 @@ vdpy_edid_set_timing(uint8_t *addr, const base_param *b_param, TIMING_MODE mode)
 				}
 				break;
 			} else {
-				return;
+				continue;
 			}
-
+			break;
 		default:
 			return;
 		}


### PR DESCRIPTION
Now the function of edid_generate has some problems in constructing
the detailed_timing_block and standard mode blocks, which causes that
too few modes are parsed from EDID in guest_vm.

This patch set tries to fix the incorrect logic in EDID
detailed_timing_block and standard mode blocks so that the guest_vm
can parse the correct modes from EDID.