### PR TITLE
config_tools: bug fix for virtio

### DIFF
--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -274,7 +274,7 @@ def generate_for_one_vm(board_etree, hv_scenario_etree, vm_scenario_etree, vm_id
         backend_device_file = eval_xpath(virtio_input_etree, "./backend_device_file[text() != '']/text()")
         unique_identifier = eval_xpath(virtio_input_etree, "./id[text() != '']/text()")
         if backend_device_file is not None and unique_identifier is not None:
-            script.add_virtual_device("virtio-input", options=f"{backend_device_file},id={unique_identifier}")
+            script.add_virtual_device("virtio-input", options=f"{backend_device_file},id:{unique_identifier}")
         elif backend_device_file is not None:
             script.add_virtual_device("virtio-input", options=backend_device_file)
 

--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -297,10 +297,14 @@ def generate_for_one_vm(board_etree, hv_scenario_etree, vm_scenario_etree, vm_id
         elif backend_type == "pty" or backend_type == "stdio":
             script.add_virtual_device("virtio-console", options=f"{preceding_mask}{backend_type}:{backend_type}_port")
 
-    for interface_name in eval_xpath_all(vm_scenario_etree, ".//virtio_devices/network/interface_name[text() != '']/text()"):
+    for virtio_network_etree in eval_xpath_all(vm_scenario_etree, ".//virtio_devices/network"):
+        virtio_framework = eval_xpath(virtio_network_etree, "./virtio_framework/text()")
+        interface_name = eval_xpath(virtio_network_etree, "./interface_name/text()")
         params = interface_name.split(",", maxsplit=1)
         tap_conf = f"tap={params[0]}"
         params = [tap_conf] + params[1:]
+        if virtio_framework == "Kernel based (Virtual Host)":
+            params.append("vhost")
         script.add_init_command(f"mac=$(cat /sys/class/net/e*/address)")
         params.append(f"mac_seed=${{mac:0:17}}-{vm_name}")
         script.add_virtual_device("virtio-net", options=",".join(params))


### PR DESCRIPTION
1. Add logic for virtio_framework in launch script.
    If the user select "Kernel based (Virtual Host)" in virtio_framework entry, the "vhost" string will be added to the dm parameter.
2. Update the text format of backend_device_file.
    Currently, the “backend_device_file” entry is a text combination of the elements `//device-classes/inputs/input/name` and `//device-classes/inputs/input/phys`. The format <name>:<phys> is shown in UI and the generated launch scripts.
    However, we find ":" in some device physical path in adl-s-crb platform, this will result in script can't correctly distinguish <name> and <phys> by a colon. And we are not sure if colon will be found in the name variable in the future.
    So this patch updates the text format of backend_device_file to "Device name: xxx, Device physical path: xxx", and the new text format will be shown in the UI and the generated launch script.