### PR TITLE
config_tools: fix can't find deb in build stage issue

### DIFF
--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -198,7 +198,7 @@ def create_configurator_deb(build_dir):
     config_tools_path = Path(__file__).parent.parent / 'config_tools'
     configurator_path = config_tools_path / 'configurator'
     scenario_config_path = project_base / "misc" / "config_tools" / "scenario_config"
-    deb_dir = configurator_path / 'src-tauri' / 'target' / 'release' / 'bundle' / 'deb'
+    deb_dir = configurator_path / 'packages' / 'configurator' / 'src-tauri' / 'target' / 'release' / 'bundle' / 'deb'
 
     # clean old directory
     if os.path.isdir(deb_dir):


### PR DESCRIPTION
fix can't find deb in build stage issue

Tracked-On: #6691
Signed-off-by: Weiyi Feng <weiyix.feng@intel.com>