### PR TITLE
config_tools: drop version constraints on elementpath and xmlschema

### DIFF
--- a/misc/config_tools/requirements.txt
+++ b/misc/config_tools/requirements.txt
@@ -1,4 +1,4 @@
 defusedxml
 lxml
-elementpath == 2.4.0
-xmlschema == 1.9.2
+elementpath
+xmlschema


### PR DESCRIPTION
After commit f8f1689a8 ("config_tools: do not apply distinct-values on a
union of node-set"), it has been confirmed that the reported build issue no
longer exists when using the latest elementpath (2.5.0) and
xmlschema (1.10.0). So this patch removes the version constraints in
requirements.txt.

Tracked-On: #7372
Signed-off-by: Junjie Mao <junjie.mao@intel.com>