### PR TITLE
config-tools: limit the tooltip box max-width

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
@@ -171,4 +171,8 @@ export default {
   position: absolute;
   right: 0;
 }
+
+.n-popover {
+  max-width: 50%;
+}
 </style>


### PR DESCRIPTION
The tooltip box's default width is inconsistent with the screen width.
It could run off the configurator window when the tooltip text is long.
Limit it to 50%.

Tracked-On: #7442

Signed-off-by: Zhou, Wu <wu.zhou@intel.com>