### PR TITLE
config-tools: ivshmem.vm_name changes with name edit

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -67,6 +67,7 @@
 
               @deleteVM="deleteVM"
               @scenarioConfigFormDataUpdate="scenarioConfigFormDataUpdate"
+              @vmNameChange="vmNameChange"
           />
         </div>
       </div>
@@ -209,6 +210,7 @@ export default {
               this.scenario.vm.splice(postvmlist[i], 1);
             }
           }
+          this.vmNameChange('', this.scenario.vm[currentVMIndex].name)
           this.scenario.vm.splice(currentVMIndex, 1);
           this.updateCurrentFormSchema()
           this.updateCurrentFormData()
@@ -226,6 +228,18 @@ export default {
         })
       }
       this.updateCurrentFormData()
+    },
+    vmNameChange(newname, oldname) {
+      let hvdata = this.scenario.hv
+      for (let key in hvdata.FEATURES.IVSHMEM.IVSHMEM_REGION) {
+        let region = hvdata.FEATURES.IVSHMEM.IVSHMEM_REGION[key]
+        for (let key1 in region.IVSHMEM_VMS.IVSHMEM_VM) {
+          let ivshmem_vm = region.IVSHMEM_VMS.IVSHMEM_VM[key1];
+          if (ivshmem_vm.VM_NAME === oldname) {
+            ivshmem_vm.VM_NAME = newname
+          }
+        }
+      }
     },
     assignVMID() {
       let vm_priority = {

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
@@ -62,7 +62,7 @@ i18n.useLocal(localizeEn);
 export default {
   name: "ConfigForm",
   components: {Icon, Minus, VueForm},
-  emits: ['scenarioConfigFormDataUpdate', 'deleteVM'],
+  emits: ['scenarioConfigFormDataUpdate', 'deleteVM', 'vmNameChange'],
   props: {
     currentActiveVMID: {type: Number},
     currentFormSchema: {type: Object},
@@ -109,6 +109,10 @@ export default {
       let newID = newValue.hasOwnProperty('@id') ? newValue['@id'] : -1;
       let oldID = oldValue.hasOwnProperty('@id') ? oldValue['@id'] : -1;
       if (newID === oldID) {
+        if (oldValue.name != newValue.name) {
+          this.$emit('vmNameChange', newValue.name, oldValue.name)
+        }
+
         this.$emit('scenarioConfigFormDataUpdate', newID, newValue)
       }
       // this.$emit('update:scenarioData', this.formData)


### PR DESCRIPTION
This patch is to fix the issue that when user edits VM name, the VM_NAME
field in IVSHMEM data doesn't sync.

To fix this, configForm emits a 'vmNameChange' when VM name is edited.
Then old name is replaced with new name. And when deleting VM, the old
name is replaced with null.

Tracked-On: #7445

Signed-off-by: Zhou, Wu <wu.zhou@intel.com>