### PR TITLE
Fix make configurator not picking up schema changes

### DIFF
--- a/misc/config_tools/configurator/README.md
+++ b/misc/config_tools/configurator/README.md
@@ -78,15 +78,17 @@ make configurator
 Run following command in the 'acrn-hypervisor' directory.
 
 ```shell
-cd misc/config_tools
+cd misc\config_tools
 python scenario_config/schema_slicer.py
 python scenario_config/jsonschema/convert.py
 xmllint --xinclude schema/datachecks.xsd > schema/allchecks.xsd
 
 python -m build
+del configurator/packages/configurator/thirdLib/acrn_config_tools-3.0-py3-none-any.whl
 
 cd configurator
 python packages/configurator/thirdLib/manager.py install
+yarn
 yarn build
 ```
 

--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -209,6 +209,7 @@ def create_configurator_deb(build_dir):
     add_cmd_list(cmd_list, 'python3 converter.py', scenario_config_path / "jsonschema")
     add_cmd_list(cmd_list, 'bash -c "xmllint --xinclude schema/datachecks.xsd > schema/allchecks.xsd"', config_tools_path)
     add_cmd_list(cmd_list, 'python3 -m build', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "rm -f ./configurator/packages/configurator/thirdLib/acrn_config_tools-3.0-py3-none-any.whl"', config_tools_path)
     add_cmd_list(cmd_list, 'python3 packages/configurator/thirdLib/manager.py install', configurator_path)
     add_cmd_list(cmd_list, 'yarn', configurator_path)
     add_cmd_list(cmd_list, 'yarn build', configurator_path)


### PR DESCRIPTION
Artifacts left over from a previous ``make configurator`` build prevented
changes to a schema (.xsd) file from getting incorporated into a
subsequent ``make configurator`` build.

Tracked-on: #7461

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>