### PR TITLE
doc: update GSG for virtio-gpu dependency libraries

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -147,7 +147,8 @@ To set up the ACRN build environment on the development computer:
            libpixman-1-dev \
            libsdl2-dev \
            libegl-dev \
-           libgles-dev
+           libgles-dev \
+           libdrm-dev
 
 #. Install Python package dependencies:
 


### PR DESCRIPTION
commit 78f702e ("Use libdrm library for drm access") adds the dependency on
libdrm library. GSG needs to be updated accordingly. Otherwise, compilation
error occurs like below:
hw/pci/virtio/virtio_gpu.c:21:10: fatal error: libdrm/drm_fourcc.h: No such file or directory
   21 | #include <libdrm/drm_fourcc.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.

Tracked-On: #7464

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>