### PR TITLE
config tool: fix d3hot_reset unbind tap create issue

### DIFF
--- a/misc/config_tools/launch_config/launch_script_template.sh
+++ b/misc/config_tools/launch_config/launch_script_template.sh
@@ -52,7 +52,7 @@ function unbind_device() {
 function create_tap() {
     # create a unique tap device for each VM
     tap=$1
-    tap_exist=$(ip a | grep "$tap: " | awk '{print $1}')
+    tap_exist=$(ip a show dev $tap)
     if [ "$tap_exist"x != "x" ]; then
         echo "$tap TAP device already available, reusing it."
     else
@@ -187,7 +187,7 @@ function add_passthrough_device() {
     physical_bdf=$2
     options=$3
 
-    unbind_device $physical_bdf
+    unbind_device ${physical_bdf%,*}
 
     # bus, device and function as decimal integers
     bus_temp=${physical_bdf#*:};     bus=$((16#${bus_temp%:*}))


### PR DESCRIPTION
The config tool supports auto add d3hot_reset option to
the windows vm script when user configure the usb passthru event,
but it's not handled in the template script or not the pci event
will not unbind successfully while launching the windows guest.
One more fix is for the existing tap network interface check function.

Tracked-On: #7363
Signed-off-by: lirui34 <ruix.li@intel.com>