### PR TITLE
misc: acrnd: fix a minor build Werror

### DIFF
--- a/misc/services/acrn_manager/acrnctl.c
+++ b/misc/services/acrn_manager/acrnctl.c
@@ -657,7 +657,7 @@ static int valid_start_args(struct acrnctl_cmd *cmd, int argc, char *argv[])
 {
 	char df_opt[16] = "VM_NAME";
 
-	if (argc != 2 || ((argv + 1) && !strcmp(argv[1], "help"))) {
+	if (argc != 2 || !strcmp(argv[1], "help")) {
 		printf("acrnctl %s %s\n", cmd->cmd, df_opt);
 		return -1;
 	}


### PR DESCRIPTION
The comparison ((argv + 1)) will always evaluate as 'true' for the pointer
operand in 'argv + 8' must not be NULL.

Tracked-On: #7453
Signed-off-by: Fei Li <fei1.li@intel.com>