### PR TITLE
Move MAX_IR_ENTRIES  to offline tool

### DIFF
--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -128,6 +128,7 @@ struct dmar_drhd_rt {
 
 	uint64_t root_table_addr;
 	uint64_t ir_table_addr;
+	/* MAX_IR_ENTRIES is roundup (to power of 2) of CONFIG_MAX_PT_IRQ_ENTRIES. */
 	uint64_t irte_alloc_bitmap[MAX_IR_ENTRIES / 64U];
 	uint64_t irte_reserved_bitmap[MAX_IR_ENTRIES / 64U];
 	uint64_t qi_queue;

--- a/hypervisor/include/arch/x86/asm/vtd.h
+++ b/hypervisor/include/arch/x86/asm/vtd.h
@@ -42,13 +42,6 @@
 #define DMAR_ICS_REG    0x9cU    /* Invalidation complete status register */
 #define DMAR_IRTA_REG   0xb8U    /* Interrupt remapping table addr register */
 
-/* Make sure all PT IRQs work w/ interrupt remapping or post interrupt */
-#if (CONFIG_MAX_PT_IRQ_ENTRIES <= 256)
-#define MAX_IR_ENTRIES 256
-#else
-#define MAX_IR_ENTRIES  powerof2_roundup(CONFIG_MAX_PT_IRQ_ENTRIES)
-#endif
-
 /* Values for entry_type in ACPI_DMAR_DEVICE_SCOPE - device types */
 enum acpi_dmar_scope_type {
 	ACPI_DMAR_SCOPE_TYPE_NOT_USED       = 0,

--- a/hypervisor/include/lib/util.h
+++ b/hypervisor/include/lib/util.h
@@ -25,27 +25,6 @@
 /** Replaces 'x' by the string "x". */
 #define STRINGIFY(x) #x
 
-/*
- * This algorithm get the round up 2^n
- *
- * n = input - 1;    0x1002 ---->  0x1001
- * n |= n >> 1;      0x1001 | 0x800
- * n |= n >> 2;      0x1801 | 0x600
- * n |= n >> 4;      0x1e01 | 0x1e0
- * n |= n >> 8;      0x1fe1 | 0x1f
- * n |= n >> 16;     0x1fff
- * n |= n >> 32;     0x1fff
- * n += 1;           0x2000
- */
-#define ROUND0(x)  ((x)-1)
-#define ROUND1(x)  (ROUND0(x) |(ROUND0(x)>>1))
-#define ROUND2(x)  (ROUND1(x) |(ROUND1(x)>>2))
-#define ROUND4(x)  (ROUND2(x) |(ROUND2(x)>>4))
-#define ROUND8(x)  (ROUND4(x) |(ROUND4(x)>>8))
-#define ROUND16(x) (ROUND8(x) |(ROUND8(x)>>16))
-#define ROUND32(x) (ROUND16(x) |(ROUND16(x)>>32))
-#define powerof2_roundup(x) ((ROUND32(x) == (~0UL)) ? ~0UL : (ROUND32(x) +1))
-
 /* Macro used to check if a value is aligned to the required boundary.
  * Returns TRUE if aligned; FALSE if not aligned
  * NOTE:  The required alignment must be a power of 2 (2, 4, 8, 16, 32, etc)

--- a/misc/config_tools/static_allocators/board_capability.py
+++ b/misc/config_tools/static_allocators/board_capability.py
@@ -7,6 +7,20 @@
 
 import common
 
+def powerof2_roundup(value):
+    return 0 if value == 0 else (1 << (value - 1).bit_length())
+
+# Make sure all PT IRQs work w/ interrupt remapping or post interrupt
+def create_max_ir_entries(scenario_etree, allocation_etree):
+    pt_irq_entries = common.get_node(f"//MAX_PT_IRQ_ENTRIES/text()", scenario_etree)
+    if (pt_irq_entries is not None) and (int(pt_irq_entries) > 256):
+        ir_entries = powerof2_roundup(int(pt_irq_entries))
+    else:
+        ir_entries = 256
+
+    common.append_node("/acrn-config/hv/MAX_IR_ENTRIES", ir_entries, allocation_etree)
+
 def fn(board_etree, scenario_etree, allocation_etree):
     pci_bus_nums =  board_etree.xpath("//bus[@type='pci']/@address")
     common.append_node("/acrn-config/platform/MAX_PCI_BUS_NUM", hex(max(map(lambda x: int(x, 16), pci_bus_nums)) + 1), allocation_etree)
+    create_max_ir_entries(scenario_etree, allocation_etree)

--- a/misc/config_tools/xforms/vm_configurations.h.xsl
+++ b/misc/config_tools/xforms/vm_configurations.h.xsl
@@ -34,6 +34,7 @@
     <xsl:call-template name="vm_count" />
     <xsl:call-template name="sos_vm_bootarges" />
     <xsl:call-template name="vm_vuart_num" />
+    <xsl:value-of select = "acrn:define('MAX_IR_ENTRIES', //MAX_IR_ENTRIES, 'U')" />
   </xsl:template>
 
   <xsl:template name ="vm_vuart_num">


### PR DESCRIPTION
There is an issue of calculate 2^n roundup of CONFIG_MAX_PT_IRQ_ENTRIES,
and the code style is very ugly when we use macro to fix it.

So this series move MAX_IR_ENTRIES to offline tool to fix the issue and
clear HV code.