### PR TITLE
misc: configurator: Fix user-input working directory not working

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Welcome/NewConfiguration.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Welcome/NewConfiguration.vue
@@ -59,6 +59,9 @@ export default {
       if (folderPath[0] === '~') {
         folderPath = window.systemInfo.homeDir + window.systemInfo.pathSplit + folderPath.substring(1)
       }
+      if (folderPath.charAt(folderPath.length - 1) !== window.systemInfo.pathSplit) {
+        folderPath = folderPath + window.systemInfo.pathSplit;
+      }
       this.WorkingFolder = folderPath;
 
       configurator.readDir(folderPath, false)


### PR DESCRIPTION
User-input working directory will not work if there's no path split at
the end. This patch checks and adds if no path split at the end of
working directory path.

Tracked-On: #7484
Signed-off-by: Yifan Liu <yifan1.liu@intel.com>