### PR TITLE
misc: configurator: Use more precise acrn version identifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,11 @@ T := $(CURDIR)
 
 # ACRN Version Information
 include VERSION
-export FULL_VERSION=$(MAJOR_VERSION).$(MINOR_VERSION)$(EXTRA_VERSION)
+SCM_VERSION := $(shell [ -d .git ] && git describe --exact-match 1>/dev/null 2>&1 || git describe --dirty)
+ifneq ($(SCM_VERSION),)
+	SCM_VERSION := "-"$(SCM_VERSION)
+endif
+export FULL_VERSION=$(MAJOR_VERSION).$(MINOR_VERSION)$(EXTRA_VERSION)$(SCM_VERSION)
 
 ifdef TARGET_DIR
   $(warning TARGET_DIR is obsoleted because generated configuration files are now stored in the build directory)
@@ -117,7 +121,7 @@ board_inspector:
 
 configurator:
 	@if [ -x "$(YARN_BIN)" ] && [ -x "$(CARGO_BIN)" ]; then \
-	  python3 misc/packaging/gen_acrn_deb.py configurator $(ROOT_OUT) ; \
+	  python3 misc/packaging/gen_acrn_deb.py configurator $(ROOT_OUT) --version=$(FULL_VERSION); \
 	else \
 	  echo -e "'yarn' or 'cargo' utility is not available. Unable to create Debian package for configurator."; \
 	fi

--- a/misc/config_tools/configurator/packages/configurator/src/components/common/Footer.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/components/common/Footer.vue
@@ -19,17 +19,12 @@ export default {
     }
   },
   mounted() {
-    this.getAppVersion()
+	this.version = packageVersion
   },
   methods: {
     home() {
       this.$router.push('/')
     },
-    getAppVersion() {
-      getVersion().then((version) => {
-        this.version = version
-      })
-    }
   }
 }
 </script>

--- a/misc/config_tools/configurator/packages/configurator/vite.config.js
+++ b/misc/config_tools/configurator/packages/configurator/vite.config.js
@@ -1,8 +1,12 @@
 import path from "path";
+import child_process from "child_process"
 
 import {defineConfig} from 'vite'
 import vue from '@vitejs/plugin-vue'
 import tauri from "./thirdLib/tauri-plugin";
+
+const packageVersion = child_process.execSync('git describe --dirty')
+console.log("packageVersion: " + packageVersion)
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -13,5 +17,8 @@ export default defineConfig({
     },
     build: {
         outDir: path.resolve(__dirname, 'build')
+    },
+    define: {
+        packageVersion: JSON.stringify(packageVersion.toString())
     }
 })

--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -190,7 +190,7 @@ def create_acrn_board_inspector_deb(version, build_dir):
     return
 
 
-def create_configurator_deb(build_dir):
+def create_configurator_deb(version, build_dir):
     cmd_list = []
 
     # get folder path
@@ -214,13 +214,14 @@ def create_configurator_deb(build_dir):
     add_cmd_list(cmd_list, 'yarn build', configurator_path)
     run_cmd_list(cmd_list)
 
-    deb_name = [x for x in os.listdir(deb_dir) if x.endswith('.deb')]
-    if not deb_name:
+    orig_deb_name = [x for x in os.listdir(deb_dir) if x.endswith('.deb')]
+    if not orig_deb_name:
         print('ERROR! No acrn-configurator deb found!')
         return
-    deb_name = deb_name[0]
-    with open(deb_dir / deb_name, 'rb') as src:
-        with open(os.path.join(build_dir, deb_name), 'wb') as dest:
+    orig_deb_name = orig_deb_name[0]
+    dist_deb_name = 'acrn-configurator-{ver}.deb'.format(ver=version)
+    with open(deb_dir / orig_deb_name, 'rb') as src:
+        with open(os.path.join(build_dir, dist_deb_name), 'wb') as dest:
             dest.write(src.read())
     return
 
@@ -242,6 +243,6 @@ if __name__ == "__main__":
     elif args.deb_mode == 'acrn_all':
         create_acrn_deb(args.board_name, args.scenario, args.version, args.build_dir)
     elif args.deb_mode == 'configurator':
-        create_configurator_deb(args.build_dir)
+        create_configurator_deb(args.version, args.build_dir)
     else:
         print("ERROR: Please check the value of deb_mode: the value shall be acrn_all, board_inspector or configurator.")


### PR DESCRIPTION
Display acrn version string from `git describe --dirty` at UI footer to
help testing. Append the same version to deb package name as well.

Tracked-On: #7488
Signed-off-by: Calvin Zhang <calvinzhang.cool@gmail.com>