### PR TITLE
config_tools: using XPATH expression to handle input data

### DIFF
--- a/misc/config_tools/configurator/pyodide/loadBoard.py
+++ b/misc/config_tools/configurator/pyodide/loadBoard.py
@@ -2,7 +2,6 @@
 __package__ = 'configurator.pyodide'
 
 import json
-import logging
 from copy import deepcopy
 
 import elementpath
@@ -21,11 +20,7 @@ def get_dynamic_scenario(board):
     board_xml = etree.fromstring(board)
 
     def get_enum(source, options, obj_type):
-        if options == "//inputs/input":
-            inputs_etree = [x for x in elementpath.select(source, options) if x is not None]
-            elements = [f"Device name: {str(elementpath.select(i, './name/text()')[0])}, Device physical path: {str(elementpath.select(i, './phys/text()')[0])}" for i in inputs_etree]
-        else:
-            elements = [str(x) for x in elementpath.select(source, options) if x]
+        elements = [str(x) for x in elementpath.select(source, options) if x]
         elements = list(set(elements))
         if not elements:
             elements = ['']
@@ -47,10 +42,7 @@ def get_dynamic_scenario(board):
         # get enum data
         enum = function(source, selector, obj_type)
         if sorted_func:
-            try:
-                enum = sorted(enum, key=eval(sorted_func))
-            except IndexError as e:
-                logging.warning(e)
+            enum = sorted(enum, key=eval(sorted_func))
         return enum
 
     def dynamic_enum_apply(obj):

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -395,8 +395,9 @@ device file when user config it as virtio serial port, which can be read and wri
 <xs:complexType name="VirtioInputConfiguration">
   <xs:sequence>
     <xs:element name="backend_device_file" type="xs:string" minOccurs="0">
-      <xs:annotation acrn:title="Backend device file" acrn:widget-options="'placeholder': '/dev/input/eventX'" acrn:options="//inputs/input"
-                     acrn:options-sorted-by="lambda s: (s.split('Device name: ')[1].split(', Device physical path')[0], s.split('Device physical path: ')[1])">
+      <xs:annotation acrn:title="Backend device file" acrn:widget-options="'placeholder': '/dev/input/eventX'"
+                     acrn:options="for $input in //inputs/input return concat('Device name: ', $input/name/text(), ', Device physical path: ', $input/phys/text())"
+                     acrn:options-sorted-by="lambda s: s">
         <xs:documentation>Specifying backend device in service vm with device description.</xs:documentation>
       </xs:annotation>
     </xs:element>


### PR DESCRIPTION
XPATH 2.0 already supports functions like for-expressions,
so we use XPATH expression instead of the python code to format
virtio input data.

Tracked-On: #6691
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>