### PR TITLE
misc: add assert for vUART connection

### DIFF
--- a/misc/config_tools/schema/checks/vuart_config.xsd
+++ b/misc/config_tools/schema/checks/vuart_config.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2022 Intel Corporation. -->
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+
+<xs:schema xml:id="root"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:acrn="https://projectacrn.org">
+
+  <xs:assert test="every $vuart_connection in /acrn-config//vuart_connection satisfies
+                   every $vm_name in $vuart_connection/endpoint/vm_name/text() satisfies
+                   count($vuart_connection/endpoint[./vm_name/text()=$vm_name]) = 1">
+    <xs:annotation acrn:severity="error" acrn:report-on="$vuart_connection/endpoint">
+      <xs:documentation>VM "{$vm_name}" can't connected to itself</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+</xs:schema>

--- a/misc/config_tools/schema/datachecks.xsd
+++ b/misc/config_tools/schema/datachecks.xsd
@@ -14,6 +14,7 @@
       <xi:include href="checks/vbdf_assignment.xsd" xpointer="xpointer(id('root')/*)" />
       <xi:include href="checks/vm_types.xsd" xpointer="xpointer(id('root')/*)" />
       <xi:include href="checks/passthrough_devices.xsd" xpointer="xpointer(id('root')/*)" />
+      <xi:include href="checks/vuart_config.xsd" xpointer="xpointer(id('root')/*)" />
 
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
The current UI have no live-check to check whether a VM connect to
itself.

So we add an assert to the schema and return error when user connect a
VM to itself.

Signed-off-by: Chenli Wei <chenli.wei@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>