### PR TITLE
board_inspector.py fails to run on target with clean Ubuntu installation

### DIFF
--- a/misc/packaging/acrn-board-inspector.postinst
+++ b/misc/packaging/acrn-board-inspector.postinst
@@ -2,6 +2,8 @@
 #* Copyright (c) 2020 Intel Corporation SPDX-License-Identifier: BSD-3-Clause
 # postinst script for acrn-board-inspector
 
+pip3 install xmlschema
+
 set -e
 
 filename='/etc/default/grub'


### PR DESCRIPTION
Python package is not in debian package, so put its installation
process in the acrn-board-inspector.postinst script

Tracked-On: projectacrn#7498
Signed-off-by: Ziheng Li <ziheng.li@intel.com>