### PR TITLE
misc: configurator: report the errors on clicking save button

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -356,7 +356,10 @@ export default {
         configurator.writeFile(this.WorkingFolder + 'scenario.xml', scenarioXMLData)
             .then(() => {
               step = 1
-              configurator.pythonObject.validateScenario(this.board.content, scenarioXMLData)
+              this.errors = configurator.pythonObject.validateScenario(this.board.content, scenarioXMLData)
+              if (this.errors.length != 0) {
+                  throw "validation failed"
+              }
             })
             .then(() => {
               step = 2

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/cpu_affinity.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/cpu_affinity.vue
@@ -114,7 +114,7 @@ export default {
       return `${this.rootFormData.name} vCPU ${index}`
     },
     addPCPU(index) {
-      this.defaultVal.pcpu.splice(index + 1, 0, {pcpu_id: null, real_time_vcpu: false})
+      this.defaultVal.pcpu.splice(index + 1, 0, {pcpu_id: null, real_time_vcpu: "n"})
     },
     removePCPU(index) {
       if (this.defaultVal.pcpu.length === 1) {


### PR DESCRIPTION
On clicking save button, current scenario configuration is validated and
errors should be prompted out if any.

BTW, fix unrecognized value in cpu affinity object.

Fixes: 5a3b38f778 ("config-tools: add confirm message")
Tracked-On: #7469
Signed-off-by: Calvin Zhang <calvinzhang.cool@gmail.com>