### PR TITLE
config_tools: clean up configurator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ clean:
 	$(MAKE) -C $(T)/misc OUT_DIR=$(TOOLS_OUT) clean
 	$(MAKE) -C $(T)/doc BUILDDIR=$(DOC_OUT) clean
 	rm -rf $(ROOT_OUT)
+	python3 misc/packaging/gen_acrn_deb.py clean $(ROOT_OUT) --version=$(FULL_VERSION);
 
 .PHONY: install life_mngr-install
 install: hypervisor-install devicemodel-install tools-install

--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -226,6 +226,23 @@ def create_configurator_deb(version, build_dir):
             dest.write(src.read())
     return
 
+def clean_configurator_deb(version, build_dir):
+    cmd_list = []
+
+    # get folder path
+    project_base = Path(__file__).parent.parent.parent
+    config_tools_path = Path(__file__).parent.parent / 'config_tools'
+
+    add_cmd_list(cmd_list, 'bash -c "find -name "*.log" -delete"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "find -name "*.whl" -delete"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "find -name "*.egg-info" -prune -exec rm -rf {} \;"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "find -name "node_modules" -prune -exec rm -rf {} \;"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "find -name "build" -prune -exec rm -rf {} \;"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "find -name "target" -prune -exec rm -rf {} \;"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "rm -rf dist"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "python ./configurator/packages/configurator/thirdLib/manager.py clean"', config_tools_path)
+    run_cmd_list(cmd_list)
+    return
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -245,5 +262,7 @@ if __name__ == "__main__":
         create_acrn_deb(args.board_name, args.scenario, args.version, args.build_dir)
     elif args.deb_mode == 'configurator':
         create_configurator_deb(args.version, args.build_dir)
+    elif args.deb_mode == 'clean':
+        clean_configurator_deb(args.version, args.build_dir)
     else:
         print("ERROR: Please check the value of deb_mode: the value shall be acrn_all, board_inspector or configurator.")


### PR DESCRIPTION
This patch use 'make clean' to clean up the files left after
a 'make configurator'.

Tracked-On: #7508
Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>