### PR TITLE
config-tools: add validation and vm_name check for vuart widget

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -297,6 +297,17 @@ export default {
           }
         }
       }
+      if (hvdata.hasOwnProperty('vuart_connections')) {
+        for (let key in hvdata.vuart_connections.vuart_connection) {
+          let connection = hvdata.vuart_connections.vuart_connection[key]
+          for (let key1 in connection.endpoint) {
+            let ep = connection.endpoint[key1];
+            if (ep.vm_name === oldname) {
+              ep.vm_name = newname
+            }
+          }
+        }
+      }
     },
     assignVMID() {
       let vm_priority = {

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/VUART.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/VUART.vue
@@ -9,7 +9,10 @@
             <label>VM name: </label>
           </b-col>
           <b-col md="4">
-            <b-form-select v-model="VUARTConn.endpoint[0].vm_name" :options="vmNames"></b-form-select>
+            <b-form-select :state="validation(VUARTConn.endpoint[0].vm_name)" v-model="VUARTConn.endpoint[0].vm_name" :options="vmNames"></b-form-select>
+            <b-form-invalid-feedback>
+              must have value
+            </b-form-invalid-feedback>
           </b-col>
         </b-row>
 
@@ -24,7 +27,10 @@
             <label>VM name: </label>
           </b-col>
           <b-col md="4">
-            <b-form-select v-model="VUARTConn.endpoint[1].vm_name" :options="vmNames"></b-form-select>
+            <b-form-select :state="validation(VUARTConn.endpoint[1].vm_name)" v-model="VUARTConn.endpoint[1].vm_name" :options="vmNames"></b-form-select>
+            <b-form-invalid-feedback>
+              must have value
+            </b-form-invalid-feedback>
           </b-col>
         </b-row>
 
@@ -33,7 +39,10 @@
             <label>Type: </label>
           </b-col>
           <b-col md="4">
-            <b-form-select v-model="VUARTConn.type" :options="VuartType"></b-form-select>
+            <b-form-select :state="validation(VUARTConn.type)" v-model="VUARTConn.type" :options="VuartType"></b-form-select>
+            <b-form-invalid-feedback>
+              must have value
+            </b-form-invalid-feedback>
           </b-col>
         </b-row>
 
@@ -143,6 +152,9 @@ export default {
     }
   },
   methods: {
+    validation(value) {
+      return value.length != 0;
+    },
     removeVUARTConnection(index) {
       this.defaultVal.splice(index, 1);
     },


### PR DESCRIPTION
1. Add validation to vuart widget, to warn on empty line for required field.
2. Add vm_name check, so that when vm_name is edited in vm tab, the vuart enpoint field changes to the new name.
