### PR TITLE
config: restore FEATURES on the basic tab

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -256,7 +256,7 @@ These settings can only be changed at build time.</xs:documentation>
 <xs:complexType name="HVConfigType">
   <xs:all>
     <xs:element name="FEATURES" type="FeatureOptionsType">
-      <xs:annotation acrn:title="Hypervisor features" acrn:views="advanced">
+      <xs:annotation acrn:title="Hypervisor features" acrn:views="basic, advanced">
 	<xs:documentation>Enable hypervisor features.</xs:documentation>
       </xs:annotation>
     </xs:element>


### PR DESCRIPTION
A previous PR incorectly removed the hypervisor FEATURES options on the
basic tab because all options were advanced.  One wasn't (IVSHMEM).

Tracked-on: #7514

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>