### PR TITLE
config-tools: change name for board XML

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/lib/acrn.ts
+++ b/misc/config_tools/configurator/packages/configurator/src/lib/acrn.ts
@@ -22,8 +22,9 @@ class PythonObject {
         }
     }
 
-    loadBoard(boardXMLText) {
-        return this.api('loadBoard', 'json', boardXMLText)
+    loadBoard(boardXMLText, path) {
+        return this.api('loadBoard', 'json', boardXMLText, path)
+
     }
 
     loadScenario(scenarioXMLText) {
@@ -120,7 +121,7 @@ class Configurator {
                 if (syntactical_errors !== "") {
                     throw Error("The file has broken structure.");
                 }
-                return this.pythonObject.loadBoard(fileContent);
+                return this.pythonObject.loadBoard(fileContent, path);
             })
     }
 

--- a/misc/config_tools/configurator/pyodide/pyodide.py
+++ b/misc/config_tools/configurator/pyodide/pyodide.py
@@ -27,6 +27,7 @@ scenario_xml_schema_path = schema_dir / 'sliced.xsd'
 datachecks_xml_schema_path = schema_dir / 'allchecks.xsd'
 
 nuc11_folder = LazyPath(config_tools_dir / 'data' / 'nuc11tnbi5')
+nuc11_board_path = nuc11_folder / 'nuc11tnbi5.xml'
 
 # file define
 nuc11_board = file_text(nuc11_folder / 'nuc11tnbi5.xml')


### PR DESCRIPTION
Use file name as the board xml name instead of using the name in
'board' field in board XML.

e.g.

1. Initial filename is "my_potato.xml"
2. User imports my_potato.xml into the Configurator
3. Resulting file is my_potato.board.xml

Tracked-On: #7521
Signed-off-by: Conghui <conghui.chen@intel.com>