### PR TITLE
config_tools: fix option passing to device model in launch scripts

### DIFF
--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -98,7 +98,7 @@ class LaunchScript:
             self._deinit_commands.append(command)
 
     def add_plain_dm_parameter(self, opt):
-        full_opt = f"\"{opt}\""
+        full_opt = f"{opt}"
         if full_opt not in self._dm_parameters:
             self._dm_parameters.append(full_opt)
 
@@ -145,8 +145,8 @@ class LaunchScript:
             s += f"    {param}\n"
         s += ")\n\n"
 
-        s += "echo \"Launch device model with parameters: ${dm_params[*]}\"\n"
-        s += "acrn-dm ${dm_params[*]}\n\n"
+        s += "echo \"Launch device model with parameters: ${dm_params[@]}\"\n"
+        s += "acrn-dm \"${dm_params[@]}\"\n\n"
 
         s += "# Deinitializing\n"
         for command in self._deinit_commands:


### PR DESCRIPTION
Generated launch scripts tracks the options to ACRN device model in an
array `dm_params`. Those scripts use `${dm_params[*]}` to join all
elements in the array and pass the joined string to acrn-dm.

One tricky thing about `${dm_params[*]}` is that it joins the array
elements as one single unquoted string. This means an option as a string
with whitespaces will be split by the shell and passed to acrn-dm as
multiple options. This does not happen to the options generated today, but
prevents users from using, e.g., the -B option to pass the full command
line options for the guest kernel.

Rather than joining all elements as an unquoted string, it is more
preferrable to treat each element in `dm_params` as a quoted string. This
patch does this by:

  1. replacing `${dm_params[*]}` with `"{dm_params[@]}"`, and

  2. removing the quotes around plaintext options in `dm_params`.

Tracked-On: #6690
Signed-off-by: Junjie Mao <junjie.mao@intel.com>