### PR TITLE
config-tools: clean launch scripts before saving

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -349,6 +349,10 @@ export default {
       return errorFlag
     },
     saveScenario() {
+      if (_.isEmpty(this.scenario.vm)) {
+        alert("Please add at least one VM")
+        return
+      }
       let errorFlag = false
       errorFlag = this.confirmVmName()
       this.assignVMID()
@@ -408,7 +412,7 @@ export default {
             }
           })
           .then(() => {
-            alert(`${msg.slice(0,stepDone).join('')} \n All files successfully saved to your working folder ${this.WorkingFolder}`)
+            alert(`${msg.slice(0,stepDone).join('')} \nAll files successfully saved to your working folder ${this.WorkingFolder}`)
           })
         } catch(err) {
           console.log("error" + err)

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/NewBoard.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/NewBoard.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-modal title="Board XML overwrite!!" fade
+  <b-modal title="Board XML overwrite" fade
            v-model="showModal"
            @cancel="cancel"
            @abort="cancel"
@@ -8,8 +8,9 @@
            @submit="overWrite"
   >
   <div>
-    <p>If you continue, the board XML file in the working folder will be replaced:</p>
-    <p align="center">{{this.$parent.currentSelectedBoard}}</p>
+    <p><b>Are you sure you want to overwrite the board XML file in this working folder?</b></p>
+    <p>If you continue, the board XML file in the following working folder will be overwritten:</p>
+    <p>{{this.$parent.currentSelectedBoard}}</p>
     <p>(You may need to change your configuration settings to be compatible with the new board XML file.)</p>
   </div>
   </b-modal>


### PR DESCRIPTION
    1. Clean all launch scripts before click "Save" button, the new launch
    scripts will be created after that.
    2. Add a blank line to the warning dialog box.
    3, Change dialog box message when click "Use a Different Board" button.
