### PR TITLE
misc: fix the physical memory segmentation UI issue

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -393,7 +393,7 @@ Refer SDM 17.19.2 for details, and use with caution.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="memory" type="MemoryInfo" minOccurs="0">
-      <xs:annotation acrn:title="Memory allocation" acrn:views="basic, advanced" acrn:applicable-vms="pre-launched, post-launched">
+      <xs:annotation acrn:title="" acrn:views="basic, advanced" acrn:applicable-vms="pre-launched, post-launched">
       </xs:annotation>
     </xs:element>
     <xs:element name="priority" type="PriorityType"  default="PRIO_LOW">


### PR DESCRIPTION
Current physical memory segmentation UI have an redundant title when
user select the advance mode, so we set the MemoryInfo element title
to NULL to fix this issue.

Tracked-On: #8861
Signed-off-by: Chenli Wei <chenli.wei@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>