### PR TITLE
config-tools: add vsock option in configurator

### DIFF
--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -326,6 +326,9 @@ def generate_for_one_vm(board_etree, hv_scenario_etree, vm_scenario_etree, vm_id
         if virtio_gpu is not None:
             script.add_virtual_device("virtio-gpu", options=virtio_gpu)
 
+    for vsock in eval_xpath_all(vm_scenario_etree, ".//virtio_devices/vsock[text() != '']/text()"):
+        script.add_virtual_device("vhost-vsock", options="cid="+vsock)
+
     # Passthrough PCI devices
     bdf_regex = re.compile("([0-9a-f]{2}):([0-1][0-9a-f]).([0-7])")
     for passthru_device in eval_xpath_all(vm_scenario_etree, ".//pci_devs/*/text()"):

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -445,6 +445,22 @@ argument and memory.</xs:documentation>
 This feature enables you to view the VM's GPU output in the Service VM.</xs:documentation>
             </xs:annotation>
           </xs:element>
+          <xs:element name="vsock" minOccurs="0">
+            <xs:annotation acrn:title="Virtio vsock CID" acrn:views="basic"
+                          acrn:widget-options="'placeholder': '3 ~ (-2U)'">
+              <xs:documentation>vsock is the new socket address family for host/guest communication.
+CID is the identifier for this VM.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:annotation>
+                  <xs:documentation>Integer between 3 ~ (-2U).</xs:documentation>
+                </xs:annotation>
+                <xs:minInclusive value="3" />
+                <xs:maxInclusive value="4294967294" />
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:element>
           <xs:element name="console" type="VirtioConsoleConfiguration" minOccurs="0" maxOccurs="unbounded">
             <xs:annotation acrn:title="Virtio console device" acrn:views="basic">
               <xs:documentation>Virtio console device for data input and output.


### PR DESCRIPTION
vsock is the new socket address family for host/guest communication.
Configurator option for vsock CID is added in this patch.
Also vsock parameter is generated in script.

Tracked-On: #7535
Signed-off-by: Wu Zhou <wu.zhou@intel.com>