### PR TITLE
misc: Add applicable-vms to cpu_affinity

### DIFF
--- a/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
@@ -94,17 +94,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <cpu_affinity>
-      <pcpu>
-        <pcpu_id>0</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>1</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>2</pcpu_id>
-      </pcpu>
-    </cpu_affinity>
     <clos>
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>

--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -122,26 +122,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <cpu_affinity>
-      <pcpu>
-        <pcpu_id>0</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>1</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>2</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>3</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>4</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>5</pcpu_id>
-      </pcpu>
-    </cpu_affinity>
     <clos>
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>

--- a/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
@@ -95,17 +95,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <cpu_affinity>
-      <pcpu>
-        <pcpu_id>0</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>1</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>2</pcpu_id>
-      </pcpu>
-    </cpu_affinity>
     <clos>
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>

--- a/misc/config_tools/data/generic_board/hybrid_rt.xml
+++ b/misc/config_tools/data/generic_board/hybrid_rt.xml
@@ -116,14 +116,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <cpu_affinity>
-      <pcpu>
-        <pcpu_id>0</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>1</pcpu_id>
-      </pcpu>
-    </cpu_affinity>
     <clos>
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
@@ -95,17 +95,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <cpu_affinity>
-      <pcpu>
-        <pcpu_id>0</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>1</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>2</pcpu_id>
-      </pcpu>
-    </cpu_affinity>
     <clos>
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
@@ -95,17 +95,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <cpu_affinity>
-      <pcpu>
-        <pcpu_id>0</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>1</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>2</pcpu_id>
-      </pcpu>
-    </cpu_affinity>
     <clos>
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -93,17 +93,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <cpu_affinity>
-      <pcpu>
-        <pcpu_id>0</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>1</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>2</pcpu_id>
-      </pcpu>
-    </cpu_affinity>
     <clos>
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
@@ -122,14 +122,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <cpu_affinity>
-      <pcpu>
-        <pcpu_id>0</pcpu_id>
-      </pcpu>
-      <pcpu>
-        <pcpu_id>1</pcpu_id>
-      </pcpu>
-    </cpu_affinity>
     <clos>
       <vcpu_clos>0</vcpu_clos>
       <vcpu_clos>0</vcpu_clos>

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -385,7 +385,7 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="cpu_affinity" type="CPUAffinityConfigurations" minOccurs="0">
-      <xs:annotation acrn:title="Physical CPU affinity" acrn:views="basic">
+      <xs:annotation acrn:title="Physical CPU affinity" acrn:views="basic" acrn:applicable-vms="pre-launched, post-launched">
         <xs:documentation>Select a subset of physical CPUs that this VM can use. More than one can be selected.</xs:documentation>
       </xs:annotation>
     </xs:element>


### PR DESCRIPTION
Currently setting cpu_affinity for service vm has no effect. This patch
sets acrn:applicable-vms of cpu_affinity to pre-launched VMs and
post-launched VMs to restrict validation and UI display.

Tracked-On: #7538
Signed-off-by: Yifan Liu <yifan1.liu@intel.com>