### PR TITLE
config_tools: bugfix for the configurator

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/Virtio/Console.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/Virtio/Console.vue
@@ -96,7 +96,7 @@ export default {
   data() {
     return {
       ConsoleUseType: this.rootSchema.definitions['VirtioConsoleUseType']['enum'],
-      ConsoleBackendType: this.rootSchema.definitions['VirtioConsoleBackendType']['enum'],
+      ConsoleBackendType: this.rootSchema.definitions['BasicVirtioConsoleBackendType']['enum'],
       defaultVal: vueUtils.getPathVal(this.rootFormData, this.curNodePath)
     };
   },

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -362,7 +362,7 @@ The size is a subset of the VM's total memory size specified on the Basic tab.</
 </xs:simpleType>
 
 <xs:complexType name="VirtioConsoleConfiguration">
-  <xs:sequence>
+  <xs:all>
     <xs:element name="use_type" type="VirtioConsoleUseType" minOccurs="0">
       <xs:annotation acrn:title="Use type">
         <xs:documentation>Specify device type in guest, ether HVC console when user config it as virtio console or /dev/vportXpY
@@ -389,7 +389,7 @@ device file when user config it as virtio serial port, which can be read and wri
         <xs:documentation>The device path for the tty backend type.</xs:documentation>
       </xs:annotation>
     </xs:element>
-  </xs:sequence>
+  </xs:all>
 </xs:complexType>
 
 <xs:complexType name="VirtioInputConfiguration">

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -351,10 +351,18 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
         <xs:documentation>Enable nested virtualization for KVM.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="virtual_cat_number" type="xs:integer" default="0" minOccurs="0">
+    <xs:element name="virtual_cat_number" default="0" minOccurs="0">
       <xs:annotation acrn:title="Maximum virtual CLOS" acrn:applicable-vms="pre-launched, post-launched" acrn:views="advanced">
         <xs:documentation>Max number of virtual CLOS MASK</xs:documentation>
       </xs:annotation>
+      <xs:simpleType>
+        <xs:annotation>
+          <xs:documentation>Integer value is not below zero.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:integer">
+          <xs:minInclusive value="0" />
+        </xs:restriction>
+      </xs:simpleType>
     </xs:element>
     <xs:element name="virtual_cat_support" type="Boolean" default="n" minOccurs="0">
       <xs:annotation acrn:title="VM Virtual Cache Allocation Tech" acrn:applicable-vms="pre-launched, post-launched" acrn:views="advanced">


### PR DESCRIPTION
1. Add restriction for Maximum Virtual CLOS configuration that doesn't allow negative numbers in UI.
2. Hide tty and sock in UI.