### PR TITLE
config-tools: change the tooltip width to 60%

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
@@ -196,6 +196,6 @@ export default {
 }
 
 .n-popover {
-  max-width: 50%;
+  max-width: 60%;
 }
 </style>


### PR DESCRIPTION
Tooltip width was set to 50%. This could not just cut the line into
2 lines, for the line has to be cut by word. This would leave one
word on a new line, looks weird.

Set to 60% will solve this issue.

Tracked-On: #7541

Signed-off-by: Wu Zhou <wu.zhou@intel.com>