### PR TITLE
doc: GSG's python dependence

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -459,9 +459,7 @@ Configurator to generate a scenario configuration file and launch script.
 
    .. code-block:: bash
 
-      cd ~/acrn-work/acrn-hypervisor/misc/config_tools
-      python3 -m pip install -r requirements.txt
-      cd configurator
+      cd ~/acrn-work/acrn-hypervisor/misc/config_tools/configurator
       python3 -m pip install -r requirements.txt
       yarn
 

--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -154,7 +154,7 @@ To set up the ACRN build environment on the development computer:
 
    .. code-block:: bash
 
-      sudo pip3 install lxml xmlschema defusedxml
+      sudo pip3 install lxml xmlschema defusedxml tqbm
 
 #. Create a working directory:
 

--- a/misc/config_tools/configurator/README.md
+++ b/misc/config_tools/configurator/README.md
@@ -51,9 +51,7 @@ If your system doesn't have git and python, you can install it by
 
 ```bash
 git clone https://github.com/projectacrn/acrn-hypervisor
-cd acrn-hypervisor/misc/config_tools
-python3 -m pip install -r requirements.txt
-cd configurator
+cd acrn-hypervisor/misc/config_tools/configurator
 python3 -m pip install -r requirements.txt
 yarn
 ```

--- a/misc/config_tools/configurator/requirements.txt
+++ b/misc/config_tools/configurator/requirements.txt
@@ -1,7 +1,10 @@
+defusedxml
+lxml
+elementpath
+xmlschema
 build
 tqdm
 requests
-lxml
 xmltodict
 sphinx
 bs4

--- a/misc/config_tools/requirements.txt
+++ b/misc/config_tools/requirements.txt
@@ -1,4 +1,0 @@
-defusedxml
-lxml
-elementpath
-xmlschema

--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -240,7 +240,7 @@ def clean_configurator_deb(version, build_dir):
     add_cmd_list(cmd_list, 'bash -c "find -name "build" -prune -exec rm -rf {} \;"', config_tools_path)
     add_cmd_list(cmd_list, 'bash -c "find -name "target" -prune -exec rm -rf {} \;"', config_tools_path)
     add_cmd_list(cmd_list, 'bash -c "rm -rf dist"', config_tools_path)
-    add_cmd_list(cmd_list, 'bash -c "python ./configurator/packages/configurator/thirdLib/manager.py clean"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "python3 ./configurator/packages/configurator/thirdLib/manager.py clean"', config_tools_path)
     run_cmd_list(cmd_list)
     return
 


### PR DESCRIPTION
For config_tools use python to clear dirty files, add python dependence
while prepare development computer.

Tracked-On: #7508
Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>