### PR TITLE
misc: modify the non stand s5 vUART generate logic

### DIFF
--- a/misc/config_tools/service_vm_config/serial_config.py
+++ b/misc/config_tools/service_vm_config/serial_config.py
@@ -21,27 +21,18 @@ def find_non_standard_uart(vm, scenario_etree, allocation_etree):
     uart_list = []
     vmname = common.get_node("./name/text()", vm)
 
-    connection_list = scenario_etree.xpath(f"//vuart_connection[endpoint/vm_name = '{vmname}']")
-    for connection in connection_list:
+    connection_list0 = scenario_etree.xpath(f"//vuart_connection[endpoint/vm_name = '{vmname}']")
+    connection_list1 = allocation_etree.xpath(f"//vuart_connection[endpoint/vm_name = '{vmname}']")
+    for connection in (connection_list0 + connection_list1):
         type = common.get_node(f"./type/text()", connection)
 
         if (type != "legacy") :
             continue
-
         port = common.get_node(f".//endpoint[vm_name = '{vmname}']/io_port/text()", connection)
         if port not in stadard_uart_port:
             target_vm_name = common.get_node(f".//endpoint[vm_name != '{vmname}']/vm_name/text()", connection)
             target_vm_id = common.get_node(f"//vm[name = '{target_vm_name}']/@id", scenario_etree)
             uart_list.append({"io_port" : port, "target_vm_id" : target_vm_id})
-
-    legacy_uart_list = allocation_etree.xpath(f"//vm[load_order = 'SERVICE_VM']/legacy_vuart")
-    for legacy_uart in legacy_uart_list:
-        port = common.get_node(f"./addr.port_base/text()", legacy_uart)
-        if port is None:
-            continue
-        elif port not in stadard_uart_port:
-            uart_list.append({"io_port" : port, "target_vm_id": common.get_node(f"./t_vuart.vm_id/text()", legacy_uart)})
-
     return uart_list
 
 def main(args):

--- a/misc/config_tools/static_allocators/s5_vuart.py
+++ b/misc/config_tools/static_allocators/s5_vuart.py
@@ -22,7 +22,7 @@ def create_s5_vuart_connection(allocation_etree, service_vm_name, service_vm_por
 
     vuart_connection_node = common.append_node(f"./vuart_connection", None, vuart_connections_node)
     common.append_node(f"./name", connection_name, vuart_connection_node)
-    common.append_node(f"./type", "type", vuart_connection_node)
+    common.append_node(f"./type", "legacy", vuart_connection_node)
 
     service_vm_endpoint = common.append_node(f"./endpoint", None, vuart_connection_node)
     common.append_node(f"./vm_name", service_vm_name, service_vm_endpoint)
@@ -57,9 +57,11 @@ def alloc_free_port(scenario_etree, load_order, vm_name):
         for port in port_list:
             tmp_list.append(int(port, 16))
 
-        port_list = list(set(service_port_list) - set(tmp_list))
+        global service_port_list
+        service_port_list = list(set(service_port_list) - set(tmp_list))
+        service_port_list.sort()
         port = hex(service_port_list[0])
-        service_port_list.remove(port_list[0])
+        service_port_list.remove(service_port_list[0])
         return str(port).upper()
     else:
         tmp_list = list(set(standard_uart_port) - set(port_list))


### PR DESCRIPTION
The legacy code get all non-stand vUARTs from scenario_etree and generate
the serial.conf, now we need add more non-stand vUARTs which was config
by offline tool and record by allocation_etree.

This patch add allocation_etree to the list, then add all non-stand
vUART to serial.conf which will config by SERVICE VM.

Signed-off-by: Chenli Wei <chenli.wei@intel.com>