### PR TITLE
misc: hide RDT for basic mode

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -287,7 +287,7 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="CACHE_REGION" type="CacheRegionType" minOccurs="0">
-      <xs:annotation>
+      <xs:annotation acrn:views="advanced">
         <xs:documentation>Specify the cache setting.</xs:documentation>
       </xs:annotation>
     </xs:element>


### PR DESCRIPTION
The current RDT element display for basic and advance mode, it not
necessary, so this patch hide RDT for basic mode.

Signed-off-by: Chenli Wei chenli.wei@intel.com