### PR TITLE
misc: configurator: Add entry "None" to HV console selector

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -23,9 +23,9 @@
 These settings can only be changed at build time.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="SERIAL_CONSOLE" type="SerialConsoleOptions">
+    <xs:element name="SERIAL_CONSOLE" type="SerialConsoleType" default="None">
       <xs:annotation acrn:title="Serial console port" acrn:views="basic"
-		     acrn:options="//ttys/serial[type != '0']/dev_path/text()">
+		     acrn:options="//ttys/serial[type != '0']/dev_path/text(), 'None' ">
         <xs:documentation>Select the host serial device used for hypervisor debugging.</xs:documentation>
       </xs:annotation>
     </xs:element>

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -172,15 +172,8 @@ Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:docu
 
 <xs:simpleType name="SerialConsoleType">
   <xs:restriction base="xs:string">
-    <xs:pattern value=".*ttyS[\d]+" />
+    <xs:pattern value="(.*ttyS[\d]+)|None" />
   </xs:restriction>
-</xs:simpleType>
-
-<xs:simpleType name="SerialConsoleOptions">
-  <xs:annotation>
-    <xs:documentation>Either empty or a string, such as ``/dev/ttyS0``.</xs:documentation>
-  </xs:annotation>
-  <xs:union memberTypes="None SerialConsoleType" />
 </xs:simpleType>
 
 <xs:simpleType name="VMNameType">

--- a/misc/config_tools/static_allocators/lib/lib.py
+++ b/misc/config_tools/static_allocators/lib/lib.py
@@ -53,15 +53,16 @@ class BusDevFunc(namedtuple(
 
 def parse_hv_console(scenario_etree):
     """
-    There may be 3 types in the console item
+    There may be 4 types in the console item
     1. BDF:(00:18.2) seri:/dev/ttyS2
     2. /dev/ttyS2
     3. ttyS2
+    4. "None"
     """
     ttys_n = ''
     ttys = common.get_node("//SERIAL_CONSOLE/text()", scenario_etree)
 
-    if not ttys or ttys == None:
+    if not ttys or ttys == None or ttys == 'None':
         return ttys_n
 
     if ttys and 'BDF' in ttys or '/dev' in ttys:


### PR DESCRIPTION
Add an explicit "None" entry in HV console selector if user would like
to disable debug console or there is no serial console available.

Tracked-On: #7546
Signed-off-by: Calvin Zhang <calvinzhang.cool@gmail.com>