### PR TITLE
config-tools: Fix Enable SR-IOV build fail

### DIFF
--- a/misc/config_tools/static_allocators/bdf.py
+++ b/misc/config_tools/static_allocators/bdf.py
@@ -119,7 +119,7 @@ def create_igd_sbdf(board_etree, allocation_etree):
     doesn't exist.
     """
     bus = "0x0"
-    device_node = common.get_node(f"//bus[@type='pci' and @address='{bus}']/device[vendor='0x8086' and class='0x030000']", board_etree)
+    device_node = common.get_node(f"//bus[@type='pci' and @address='{bus}']/device[@address='0x20000' and vendor='0x8086' and class='0x030000']", board_etree)
     if device_node is None:
         common.append_node("/acrn-config/hv/MISC_CFG/IGD_SBDF", '0xFFFF', allocation_etree)
     else:


### PR DESCRIPTION
Because SR-IOV is enabled to obtain board xml,
the xpath address cannot resolve the @address='0x20000' address.
cause the build to fail. fix build issues

Tracked-On: #7371
Signed-off-by: zhongzhenx.liu <zhongzhenx.liu@intel.com>