### PR TITLE
Copyright year range in code headers is not up to date

### DIFF
--- a/hypervisor/acpi_parser/acpi_ext.c
+++ b/hypervisor/acpi_parser/acpi_ext.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
  *
  * Copyright (c) 2003 John Baldwin <jhb@FreeBSD.org>
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/boot/trampoline.S
+++ b/hypervisor/arch/x86/boot/trampoline.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/configs/vacpi.c
+++ b/hypervisor/arch/x86/configs/vacpi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/cpu_state_tbl.c
+++ b/hypervisor/arch/x86/cpu_state_tbl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/e820.c
+++ b/hypervisor/arch/x86/e820.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/gdt.c
+++ b/hypervisor/arch/x86/gdt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/guest_memory.c
+++ b/hypervisor/arch/x86/guest/guest_memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/hyperv.c
+++ b/hypervisor/arch/x86/guest/hyperv.c
@@ -2,7 +2,7 @@
  * Microsoft Hyper-V emulation. See Microsoft's
  * Hypervisor Top Level Functional Specification for more information.
  *
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -1,7 +1,7 @@
 /*-
  * Copyright (c) 2012 Sandvine, Inc.
  * Copyright (c) 2012 NetApp, Inc.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/trusty.c
+++ b/hypervisor/arch/x86/guest/trusty.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/ucode.c
+++ b/hypervisor/arch/x86/guest/ucode.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/ve820.c
+++ b/hypervisor/arch/x86/guest/ve820.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2019 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vm_reset.c
+++ b/hypervisor/arch/x86/guest/vm_reset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmtrr.c
+++ b/hypervisor/arch/x86/guest/vmtrr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) <2018-2020> Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/arch/x86/guest/vmx_asm.S
+++ b/hypervisor/arch/x86/guest/vmx_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmx_io.c
+++ b/hypervisor/arch/x86/guest/vmx_io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/idt.S
+++ b/hypervisor/arch/x86/idt.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/lib/memory.c
+++ b/hypervisor/arch/x86/lib/memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <types.h>

--- a/hypervisor/arch/x86/lib/retpoline-thunk.S
+++ b/hypervisor/arch/x86/lib/retpoline-thunk.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) <2018-2019> Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/arch/x86/security.c
+++ b/hypervisor/arch/x86/security.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed.c
+++ b/hypervisor/arch/x86/seed/seed.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed_abl.c
+++ b/hypervisor/arch/x86/seed/seed_abl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed_abl.h
+++ b/hypervisor/arch/x86/seed/seed_abl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed_sbl.c
+++ b/hypervisor/arch/x86/seed/seed_sbl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed_sbl.h
+++ b/hypervisor/arch/x86/seed/seed_sbl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/trampoline.c
+++ b/hypervisor/arch/x86/trampoline.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/wakeup.S
+++ b/hypervisor/arch/x86/wakeup.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) <2018-2019> Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/boot/acpi_base.c
+++ b/hypervisor/boot/acpi_base.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
  *
  * Copyright (c) 2003 John Baldwin <jhb@FreeBSD.org>
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/include/reloc.h
+++ b/hypervisor/boot/include/reloc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) <2018-2020> Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/event.c
+++ b/hypervisor/common/event.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/softirq.c
+++ b/hypervisor/common/softirq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/trusty_hypercall.c
+++ b/hypervisor/common/trusty_hypercall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/dbg_cmd.c
+++ b/hypervisor/debug/dbg_cmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/hypercall.c
+++ b/hypervisor/debug/hypercall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/debug/printf.c
+++ b/hypervisor/debug/printf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -1,7 +1,7 @@
 /*
  * SHARED BUFFER
  *
- * Copyright (C) 2017 Intel Corporation.
+ * Copyright (C) 2017-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/string.c
+++ b/hypervisor/debug/string.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/trace.c
+++ b/hypervisor/debug/trace.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/io_req.c
+++ b/hypervisor/dm/io_req.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -1,7 +1,7 @@
 /*-
  * Copyright (c) 2013 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vdev.c
+++ b/hypervisor/dm/vpci/vdev.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vpci_bridge.c
+++ b/hypervisor/dm/vpci/vpci_bridge.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vsriov.c
+++ b/hypervisor/dm/vpci/vsriov.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -1,7 +1,7 @@
 /*-
  * Copyright (c) 2012 NetApp, Inc.
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -2,7 +2,7 @@
  * Copyright (c) 1997, Stefan Esser <se@freebsd.org>
  * Copyright (c) 2000, Michael Smith <msmith@freebsd.org>
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/apicreg.h
+++ b/hypervisor/include/arch/x86/asm/apicreg.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 1996, by Peter Wemm and Steve Passe
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/board.h
+++ b/hypervisor/include/arch/x86/asm/board.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/boot/ld_sym.h
+++ b/hypervisor/include/arch/x86/asm/boot/ld_sym.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/cpu.h
+++ b/hypervisor/include/arch/x86/asm/cpu.h
@@ -1,7 +1,7 @@
 /*-
  * Copyright (c) 1989, 1990 William F. Jolitz
  * Copyright (c) 1990 The Regents of the University of California.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2020 Intel Corporation
  *
  * This code is derived from software contributed to Berkeley by
  * William Jolitz.

--- a/hypervisor/include/arch/x86/asm/cpu_caps.h
+++ b/hypervisor/include/arch/x86/asm/cpu_caps.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/cpufeatures.h
+++ b/hypervisor/include/arch/x86/asm/cpufeatures.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/cpuid.h
+++ b/hypervisor/include/arch/x86/asm/cpuid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/default_acpi_info.h
+++ b/hypervisor/include/arch/x86/asm/default_acpi_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/e820.h
+++ b/hypervisor/include/arch/x86/asm/e820.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/assign.h
+++ b/hypervisor/include/arch/x86/asm/guest/assign.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/ept.h
+++ b/hypervisor/include/arch/x86/asm/guest/ept.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/guest_memory.h
+++ b/hypervisor/include/arch/x86/asm/guest/guest_memory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/guest_pm.h
+++ b/hypervisor/include/arch/x86/asm/guest/guest_pm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/instr_emul.h
+++ b/hypervisor/include/arch/x86/asm/guest/instr_emul.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2012 NetApp, Inc.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/guest/trusty.h
+++ b/hypervisor/include/arch/x86/asm/guest/trusty.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vcpuid.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpuid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/virtual_cr.h
+++ b/hypervisor/include/arch/x86/asm/guest/virtual_cr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/asm/guest/vlapic.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/guest/vm.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vmcs.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmcs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vmexit.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmexit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vmtrr.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmtrr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) <2018-2020> Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 /**

--- a/hypervisor/include/arch/x86/asm/guest/vmx_io.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmx_io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/host_pm.h
+++ b/hypervisor/include/arch/x86/asm/host_pm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) <2018-2019> Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/include/arch/x86/asm/idt.h
+++ b/hypervisor/include/arch/x86/asm/idt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/init.h
+++ b/hypervisor/include/arch/x86/asm/init.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) <2018-2019> Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/include/arch/x86/asm/io.h
+++ b/hypervisor/include/arch/x86/asm/io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/ioapic.h
+++ b/hypervisor/include/arch/x86/asm/ioapic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/irq.h
+++ b/hypervisor/include/arch/x86/asm/irq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/lapic.h
+++ b/hypervisor/include/arch/x86/asm/lapic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/lib/atomic.h
+++ b/hypervisor/include/arch/x86/asm/lib/atomic.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 1998 Doug Rabson
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2019 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/lib/bits.h
+++ b/hypervisor/include/arch/x86/asm/lib/bits.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 1998 Doug Rabson
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2019 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/lib/spinlock.h
+++ b/hypervisor/include/arch/x86/asm/lib/spinlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/mmu.h
+++ b/hypervisor/include/arch/x86/asm/mmu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/msr.h
+++ b/hypervisor/include/arch/x86/asm/msr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/page.h
+++ b/hypervisor/include/arch/x86/asm/page.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/pci_dev.h
+++ b/hypervisor/include/arch/x86/asm/pci_dev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/per_cpu.h
+++ b/hypervisor/include/arch/x86/asm/per_cpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/pgtable.h
+++ b/hypervisor/include/arch/x86/asm/pgtable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/security.h
+++ b/hypervisor/include/arch/x86/asm/security.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/seed.h
+++ b/hypervisor/include/arch/x86/asm/seed.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/trampoline.h
+++ b/hypervisor/include/arch/x86/asm/trampoline.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) <2018-2019> Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/include/arch/x86/asm/vm_config.h
+++ b/hypervisor/include/arch/x86/asm/vm_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/vmx.h
+++ b/hypervisor/include/arch/x86/asm/vmx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/vtd.h
+++ b/hypervisor/include/arch/x86/asm/vtd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/zeropage.h
+++ b/hypervisor/include/arch/x86/asm/zeropage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/dbg_cmd.h
+++ b/hypervisor/include/debug/dbg_cmd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/profiling.h
+++ b/hypervisor/include/debug/profiling.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 int32_tel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 int32_tel Corporation. All rights reserved.
+ * Copyright (C) 2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/sbuf.h
+++ b/hypervisor/include/debug/sbuf.h
@@ -1,7 +1,7 @@
 /*
  * SHARED BUFFER
  *
- * Copyright (C) 2017 Intel Corporation.
+ * Copyright (C) 2017-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/include/debug/shell.h
+++ b/hypervisor/include/debug/shell.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/trace.h
+++ b/hypervisor/include/debug/trace.h
@@ -1,7 +1,7 @@
 /*
  * ACRN TRACE
  *
- * Copyright (C) 2017 Intel Corporation.
+ * Copyright (C) 2017-2018 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/include/debug/uart16550.h
+++ b/hypervisor/include/debug/uart16550.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/io_req.h
+++ b/hypervisor/include/dm/io_req.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/vacpi.h
+++ b/hypervisor/include/dm/vacpi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/vioapic.h
+++ b/hypervisor/include/dm/vioapic.h
@@ -1,7 +1,7 @@
 /*-
  * Copyright (c) 2013 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/dm/vpic.h
+++ b/hypervisor/include/dm/vpic.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/dm/vuart.h
+++ b/hypervisor/include/dm/vuart.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/lib/errno.h
+++ b/hypervisor/include/lib/errno.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/list.h
+++ b/hypervisor/include/lib/list.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (C) 2005-2011 HighPoint Technologies, Inc.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2020 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/types.h
+++ b/hypervisor/include/lib/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/util.h
+++ b/hypervisor/include/lib/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -1,7 +1,7 @@
 /*
  * common definition
  *
- * Copyright (C) 2017 Intel Corporation.
+ * Copyright (C) 2017-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -1,7 +1,7 @@
 /*
  * hypercall definition
  *
- * Copyright (C) 2017 Intel Corporation.
+ * Copyright (C) 2017-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/lib/crypto/mbedtls/md.c
+++ b/hypervisor/lib/crypto/mbedtls/md.c
@@ -6,7 +6,7 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation.
+ *  Copyright (C) 2018-2019, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/md.h
+++ b/hypervisor/lib/crypto/mbedtls/md.h
@@ -7,7 +7,7 @@
  */
 /*
  *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation.
+ *  Copyright (C) 2018-2019, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/md_internal.h
+++ b/hypervisor/lib/crypto/mbedtls/md_internal.h
@@ -9,7 +9,7 @@
  */
 /*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation.
+ *  Copyright (C) 2018-2019, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/md_wrap.c
+++ b/hypervisor/lib/crypto/mbedtls/md_wrap.c
@@ -6,7 +6,7 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation.
+ *  Copyright (C) 2018-2019, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/sha256.c
+++ b/hypervisor/lib/crypto/mbedtls/sha256.c
@@ -2,7 +2,7 @@
  *  FIPS-180-2 compliant SHA-256 implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation.
+ *  Copyright (C) 2018-2019, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/sha256.h
+++ b/hypervisor/lib/crypto/mbedtls/sha256.h
@@ -8,7 +8,7 @@
  */
 /*
  *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation.
+ *  Copyright (C) 2018-2019, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/lib/stack_protector.c
+++ b/hypervisor/lib/stack_protector.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/lib/string.c
+++ b/hypervisor/lib/string.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <types.h>

--- a/hypervisor/release/console.c
+++ b/hypervisor/release/console.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/dump.c
+++ b/hypervisor/release/dump.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/hypercall.c
+++ b/hypervisor/release/hypercall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/logmsg.c
+++ b/hypervisor/release/logmsg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/npk_log.c
+++ b/hypervisor/release/npk_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/profiling.c
+++ b/hypervisor/release/profiling.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/trace.c
+++ b/hypervisor/release/trace.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2019 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/uart16550.c
+++ b/hypervisor/release/uart16550.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2020 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */


### PR DESCRIPTION
Modified the copyright year range in code, and corrected "int32_el" into
"Intel Corporation" in two places.

Tracked-On: #7559
Signed-off-by: Ziheng Li <ziheng.li@intel.com>