### PR TITLE
config_tools: bugfix for launch script without uart parameters

### DIFF
--- a/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
@@ -54,18 +54,6 @@
           <io_port>0x3F</io_port>
         </endpoint>
       </vuart_connection>
-      <vuart_connection>
-        <name>Connection_2</name>
-        <type>pci</type>
-        <endpoint>
-          <vm_name>ACRN_Service_VM</vm_name>
-          <vbdf>00:10.0</vbdf>
-        </endpoint>
-        <endpoint>
-          <vm_name>POST_RT_VM1</vm_name>
-          <vbdf>00:10.0</vbdf>
-        </endpoint>
-      </vuart_connection>
     </vuart_connections>
   </hv>
   <vm id="0">

--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -263,8 +263,8 @@ def generate_for_one_vm(board_etree, hv_scenario_etree, vm_scenario_etree, vm_id
         script.add_virtual_device("uart", options="vuart_idx:0")
 
     for idx, conn in enumerate(eval_xpath_all(hv_scenario_etree, f".//vuart_connection[endpoint/vm_name = '{vm_name}']"), start=1):
-        if eval_xpath(conn, "./type") == "pci":
-            script.add_virtual_device("uart", options="vuart_idx:{idx}")
+        if eval_xpath(conn, "./type/text()") == "pci":
+            script.add_virtual_device("uart", options=f"vuart_idx:{idx}")
 
     # Mediated PCI devices, including virtio
     for usb_xhci in eval_xpath_all(vm_scenario_etree, ".//usb_xhci/usb_dev[text() != '']/text()"):


### PR DESCRIPTION
bugfix for the generated launch script without uart parameters
after VUART is configured to "pci"

Tracked-On: #7556
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>