### PR TITLE
config-tools: show enumNames in vuart select-form

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/VUART.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/VUART.vue
@@ -6,7 +6,7 @@
 
         <b-row class="align-items-center my-2 mt-4">
           <b-col md="2">
-            <label>VM name: </label>
+            <label>{{vmNameTitle}}: </label>
           </b-col>
           <b-col md="4">
             <b-form-select :state="validation(VUARTConn.endpoint[0].vm_name)" v-model="VUARTConn.endpoint[0].vm_name" :options="vmNames"></b-form-select>
@@ -24,7 +24,7 @@
 
         <b-row class="align-items-center my-2">
           <b-col md="2">
-            <label>VM name: </label>
+            <label>{{vmNameTitle}}: </label>
           </b-col>
           <b-col md="4">
             <b-form-select :state="validation(VUARTConn.endpoint[1].vm_name)" v-model="VUARTConn.endpoint[1].vm_name" :options="vmNames"></b-form-select>
@@ -36,7 +36,7 @@
 
         <b-row class="align-items-center my-2">
           <b-col md="2">
-            <label>Type: </label>
+            <label>{{vuartConnectionTypeTitle}}: </label>
           </b-col>
           <b-col md="4">
             <b-form-select :state="validation(VUARTConn.type)" v-model="VUARTConn.type" :options="VuartType"></b-form-select>
@@ -51,23 +51,23 @@
           <p></p>
           <b-row class="justify-content-sm-start">
             <b-col sm="4">
-              Virtual UART port:
+              {{vuartEndpointTitle}}:
             </b-col>
-            <b-col sm="4" v-if="VUARTConn.type === 'legacy'"> I/O address: </b-col>
-            <b-col sm="4" v-else-if="VUARTConn.type === 'pci'"> VBDF </b-col>
+            <b-col sm="4" v-if="VUARTConn.type === 'legacy'"> {{vuartVIoPortTitle}}: </b-col>
+            <b-col sm="4" v-else-if="VUARTConn.type === 'pci'"> {{vuartVBDFTitle}}: </b-col>
           </b-row>
           <b-row class="justify-content-sm-start align-items-center">
             <b-col sm="4"> Connection_{{ index + 1 }}-{{ VUARTConn.endpoint[0].vm_name }} </b-col>
             <b-col sm="4">
-              <b-form-input v-model="VUARTConn.endpoint[0].io_port" v-if="VUARTConn.type === 'legacy'" placeholder="An address in hexadecimal, e.g. 0x4000"/>
-              <b-form-input v-model="VUARTConn.endpoint[0].vbdf" v-else-if="VUARTConn.type === 'pci'" placeholder="00:[device].[function], e.g. 00:1c.0. All fields are in hexadecimal."/>
+              <b-form-input v-model="VUARTConn.endpoint[0].io_port" v-if="VUARTConn.type === 'legacy'" :placeholder="vIoPortPlaceholder"/>
+              <b-form-input v-model="VUARTConn.endpoint[0].vbdf" v-else-if="VUARTConn.type === 'pci'" :placeholder="vBDFPlaceholder"/>
             </b-col>
           </b-row>
           <b-row class="justify-content-sm-start align-items-center">
             <b-col sm="4"> Connection_{{ index + 1 }}-{{ VUARTConn.endpoint[1].vm_name }} </b-col>
             <b-col sm="4">
-              <b-form-input v-model="VUARTConn.endpoint[1].io_port" v-if="VUARTConn.type === 'legacy'" placeholder="An address in hexadecimal, e.g. 0x4000"/>
-              <b-form-input v-model="VUARTConn.endpoint[1].vbdf" v-else-if="VUARTConn.type === 'pci'" placeholder="00:[device].[function], e.g. 00:1c.0. All fields are in hexadecimal."/>
+              <b-form-input v-model="VUARTConn.endpoint[1].io_port" v-if="VUARTConn.type === 'legacy'" :placeholder="vIoPortPlaceholder"/>
+              <b-form-input v-model="VUARTConn.endpoint[1].vbdf" v-else-if="VUARTConn.type === 'pci'" :placeholder="vBDFPlaceholder"/>
             </b-col>
           </b-row>
         </div>
@@ -128,8 +128,23 @@ export default {
     }
   },
   data() {
+    let enumValue = this.rootSchema.definitions['VuartType']['enum']
+    let enumNames = this.rootSchema.definitions['VuartType']['enumNames']
+    let VuartType = []
+    enumValue.forEach((item, i) => {
+      VuartType.push({value:item, text:enumNames[i]})
+    })
+    let epTypeProp = this.rootSchema.definitions.VuartEndpointType.properties
+    let conTypeProp = this.rootSchema.definitions.VuartConnectionType.properties
     return {
-      VuartType: this.rootSchema.definitions['VuartType']['enum'],
+      vmNameTitle: epTypeProp.vm_name.title,
+      vuartConnectionTypeTitle: conTypeProp.type.title,
+      vuartEndpointTitle: conTypeProp.endpoint['title'],
+      vuartVIoPortTitle: epTypeProp.io_port.title,
+      vuartVBDFTitle: epTypeProp.vbdf.title,
+      vIoPortPlaceholder: epTypeProp.io_port['ui:options']['placeholder'],
+      vBDFPlaceholder: epTypeProp.vbdf['ui:options']['placeholder'],
+      VuartType,
       IOPortDefault: this.rootSchema.definitions['VuartEndpointType']['properties']['io_port']['default'],
       defaultVal: vueUtils.getPathVal(this.rootFormData, this.curNodePath)
     };

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -227,12 +227,12 @@ The size is a subset of the VM's total memory size specified on the Basic tab.</
       </xs:annotation>
     </xs:element>
     <xs:element name="io_port" type="HexFormat" default="0x3F">
-      <xs:annotation acrn:title="Virtual I/O address">
+      <xs:annotation acrn:title="Virtual I/O address" acrn:widget-options="'placeholder':'An address in hexadecimal, e.g. 0x4000'">
         <xs:documentation>Specify the COM base for each legacy virtual UART.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="vbdf" type="VBDFType">
-      <xs:annotation acrn:title="Virtual UART BDF" acrn:defaults="[f'00:{i:02x}.0' for i in range(16, 24)]" acrn:unique-among="//vuart_connection/endpoint[vm_name=$parent/vm_name]/vbdf/text()">
+      <xs:annotation acrn:title="Virtual UART BDF" acrn:defaults="[f'00:{i:02x}.0' for i in range(16, 24)]" acrn:unique-among="//vuart_connection/endpoint[vm_name=$parent/vm_name]/vbdf/text()" acrn:widget-options="'placeholder':'00:[device].[function], e.g. 00:1c.0. All fields are in hexadecimal.'">
         <xs:documentation>Specify the virtual Bus:Device.Function (BDF) for each PCI virtual UART. Virtual BDF is automatically assigned when the configuration is saved and can be changed if needed.</xs:documentation>
       </xs:annotation>
     </xs:element>
@@ -251,7 +251,10 @@ The size is a subset of the VM's total memory size specified on the Basic tab.</
         <xs:documentation>Select the communication virtual UART (vUART) type.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="endpoint" type="VuartEndpointType" minOccurs="2" maxOccurs="2" />
+    <xs:element name="endpoint" type="VuartEndpointType" minOccurs="2" maxOccurs="2">
+      <xs:annotation acrn:title="Virtual UART port">
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
 </xs:complexType>
 


### PR DESCRIPTION
The vuart widget was showing enum values in select-form as options.
The correct way is to show enumNames instead of values.
The widget uses b-form which need different data structure for
select-form. So this patch added a transformation.

Also changed the label 'VBDF' to 'Virtual BDF' as an UX improvement.

Tracked-On: #7562
Signed-off-by: Wu Zhou <wu.zhou@intel.com>