### PR TITLE
Refine clos and vCAT element

### DIFF
--- a/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
@@ -65,9 +65,6 @@
         <pcpu_id>3</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>
@@ -94,11 +91,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -118,9 +110,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -151,9 +140,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>

--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -87,10 +87,6 @@
         <real_time_vcpu>y</real_time_vcpu>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>
@@ -122,14 +118,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -153,11 +141,6 @@
         <pcpu_id>3</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -191,10 +174,6 @@
         <pcpu_id>5</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>

--- a/misc/config_tools/data/cfl-k700-i7/partitioned.xml
+++ b/misc/config_tools/data/cfl-k700-i7/partitioned.xml
@@ -68,10 +68,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>
@@ -110,10 +106,6 @@
         <pcpu_id>3</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>

--- a/misc/config_tools/data/cfl-k700-i7/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/shared_launch_6user_vm.xml
@@ -59,9 +59,6 @@
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -83,10 +80,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -123,10 +116,6 @@
         <real_time_vcpu>y</real_time_vcpu>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>1024</size>
     </memory>
@@ -160,10 +149,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>
@@ -197,10 +182,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>
@@ -234,10 +215,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>
@@ -271,10 +248,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>

--- a/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
@@ -65,9 +65,6 @@
         <pcpu_id>3</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>
@@ -95,11 +92,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -118,9 +110,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -151,9 +140,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>

--- a/misc/config_tools/data/generic_board/hybrid_rt.xml
+++ b/misc/config_tools/data/generic_board/hybrid_rt.xml
@@ -84,10 +84,6 @@
         <real_time_vcpu>y</real_time_vcpu>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>
@@ -116,10 +112,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -141,10 +133,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -175,9 +163,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>

--- a/misc/config_tools/data/generic_board/partitioned.xml
+++ b/misc/config_tools/data/generic_board/partitioned.xml
@@ -68,10 +68,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>
@@ -110,10 +106,6 @@
         <pcpu_id>3</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>

--- a/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
@@ -59,9 +59,6 @@
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -83,10 +80,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -123,10 +116,6 @@
         <real_time_vcpu>y</real_time_vcpu>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>1024</size>
     </memory>
@@ -160,10 +149,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>
@@ -197,10 +182,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>
@@ -234,10 +215,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>
@@ -271,10 +248,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
@@ -65,9 +65,6 @@
         <pcpu_id>3</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>
@@ -95,11 +92,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -118,9 +110,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -151,9 +140,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>

--- a/misc/config_tools/data/nuc11tnbi5/partitioned.xml
+++ b/misc/config_tools/data/nuc11tnbi5/partitioned.xml
@@ -68,10 +68,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>
@@ -110,10 +106,6 @@
         <pcpu_id>3</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>

--- a/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
@@ -59,9 +59,6 @@
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -83,10 +80,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -123,10 +116,6 @@
         <real_time_vcpu>y</real_time_vcpu>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>1024</size>
     </memory>
@@ -160,10 +149,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>
@@ -197,10 +182,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>
@@ -234,10 +215,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>
@@ -271,10 +248,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>

--- a/misc/config_tools/data/qemu/shared.xml
+++ b/misc/config_tools/data/qemu/shared.xml
@@ -60,9 +60,6 @@
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -81,9 +78,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>None</console_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
@@ -65,9 +65,6 @@
         <pcpu_id>3</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>
@@ -95,11 +92,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -119,9 +111,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -155,9 +144,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/partitioned.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/partitioned.xml
@@ -68,10 +68,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>
@@ -110,10 +106,6 @@
         <pcpu_id>3</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
@@ -71,9 +71,6 @@
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -96,10 +93,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -140,10 +133,6 @@
         <real_time_vcpu>y</real_time_vcpu>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>1024</size>
     </memory>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -65,9 +65,6 @@
         <pcpu_id>3</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>
@@ -93,11 +90,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -116,9 +108,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -149,9 +138,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
@@ -87,10 +87,6 @@
         <real_time_vcpu>y</real_time_vcpu>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>
@@ -122,10 +118,6 @@
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -147,10 +139,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -182,9 +170,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>

--- a/misc/config_tools/data/whl-ipc-i5/partitioned.xml
+++ b/misc/config_tools/data/whl-ipc-i5/partitioned.xml
@@ -68,10 +68,6 @@
         <pcpu_id>2</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>
@@ -112,10 +108,6 @@
         <pcpu_id>3</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <epc_section>
       <base>0</base>
       <size>0</size>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
@@ -59,9 +59,6 @@
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -83,10 +80,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
   </vm>
   <vm id="2">
@@ -104,10 +97,6 @@
         <real_time_vcpu>y</real_time_vcpu>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>1024</size>
     </memory>
@@ -141,10 +130,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -160,10 +145,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -179,10 +160,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -198,10 +175,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_vxworks.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_vxworks.xml
@@ -59,9 +59,6 @@
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -86,10 +83,6 @@
         <real_time_vcpu>y</real_time_vcpu>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>2048</size>
     </memory>
@@ -123,10 +116,6 @@
         <real_time_vcpu>y</real_time_vcpu>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -142,10 +131,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -161,10 +146,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -180,10 +161,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -199,10 +176,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
@@ -59,9 +59,6 @@
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -83,10 +80,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -123,10 +116,6 @@
         <real_time_vcpu>y</real_time_vcpu>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -142,10 +131,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -161,10 +146,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -180,10 +161,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -199,10 +176,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
@@ -59,9 +59,6 @@
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -83,10 +80,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -124,10 +117,6 @@
         <real_time_vcpu>y</real_time_vcpu>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>1024</size>
     </memory>
@@ -161,10 +150,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -180,10 +165,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -199,10 +180,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>
@@ -218,10 +195,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <console_vuart>COM Port 1</console_vuart>
     <PTM>n</PTM>
   </vm>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
@@ -59,9 +59,6 @@
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
     <name>ACRN_Service_VM</name>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>
       <kern_mod>Linux_bzImage</kern_mod>
@@ -83,10 +80,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>4096</size>
     </memory>
@@ -124,10 +117,6 @@
         <real_time_vcpu>y</real_time_vcpu>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>1024</size>
     </memory>
@@ -161,10 +150,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>
@@ -198,10 +183,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>
@@ -235,10 +216,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>
@@ -272,10 +249,6 @@
         <pcpu_id>1</pcpu_id>
       </pcpu>
     </cpu_affinity>
-    <clos>
-      <vcpu_clos>0</vcpu_clos>
-      <vcpu_clos>0</vcpu_clos>
-    </clos>
     <memory>
       <size>512</size>
     </memory>

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -68,23 +68,6 @@
   </xs:sequence>
 </xs:complexType>
 
-<xs:complexType name="CLOSConfiguration">
-  <xs:sequence>
-    <xs:element name="vcpu_clos" type="xs:integer" default="0" maxOccurs="unbounded">
-      <xs:annotation>
-        <xs:documentation>By default (``virtual_cat_support`` is not specified):
-vcpu_clos is per-CPU and it configures each CPU in VMs to a desired CLOS ID in the ``VM`` section of the
-scenario file. Follow :ref:`rdt_detection_capabilities` to identify the maximum supported CLOS ID that can be used.
-
-If ``virtual_cat_support`` is specified:
-vcpu_clos is not per-CPU anymore, just a list of physical CLOSIDs (minimum 2) that are assigned to VMs
-for vCAT use. Each vcpu_clos will be mapped to a virtual CLOSID, the first vcpu_clos is mapped to virtual
-CLOSID 0 and the second is mapped to virtual CLOSID 1, etc.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
-  </xs:sequence>
-</xs:complexType>
-
 <xs:complexType name="EPCSection">
   <xs:sequence>
     <xs:element name="base" type="HexFormat" default="0">

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -357,6 +357,11 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
         <xs:documentation>Enable nested virtualization for KVM.</xs:documentation>
       </xs:annotation>
     </xs:element>
+    <xs:element name="virtual_cat_support" type="Boolean" default="n" minOccurs="0">
+      <xs:annotation acrn:title="VM Virtual Cache Allocation Tech" acrn:applicable-vms="pre-launched, post-launched" acrn:views="advanced">
+        <xs:documentation>Enable virtualization of the Cache Allocation Technology (CAT) feature in RDT. CAT enables you to allocate cache to VMs, providing isolation to avoid performance interference from other VMs.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
     <xs:element name="virtual_cat_number" default="0" minOccurs="0">
       <xs:annotation acrn:title="Maximum virtual CLOS" acrn:applicable-vms="pre-launched, post-launched" acrn:views="advanced">
         <xs:documentation>Max number of virtual CLOS MASK</xs:documentation>
@@ -369,11 +374,6 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
           <xs:minInclusive value="0" />
         </xs:restriction>
       </xs:simpleType>
-    </xs:element>
-    <xs:element name="virtual_cat_support" type="Boolean" default="n" minOccurs="0">
-      <xs:annotation acrn:title="VM Virtual Cache Allocation Tech" acrn:applicable-vms="pre-launched, post-launched" acrn:views="advanced">
-        <xs:documentation>Enable virtualization of the Cache Allocation Technology (CAT) feature in RDT. CAT enables you to allocate cache to VMs, providing isolation to avoid performance interference from other VMs.</xs:documentation>
-      </xs:annotation>
     </xs:element>
     <xs:element name="secure_world_support" type="Boolean" default="n" minOccurs="0">
       <xs:annotation acrn:views="">
@@ -388,12 +388,6 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
     <xs:element name="security_vm" type="Boolean" default="n" minOccurs="0">
       <xs:annotation acrn:views="">
         <xs:documentation>Specify TPM2 FIXUP for VM.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
-    <xs:element name="clos" type="CLOSConfiguration">
-      <xs:annotation acrn:views="advanced">
-        <xs:documentation>Class of Service for Cache Allocation Technology.
-Refer SDM 17.19.2 for details, and use with caution.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="epc_section" type="EPCSection" minOccurs="0">

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -106,7 +106,7 @@
     <xsl:call-template name="guest_flags" />
 
     <xsl:if test="acrn:is-rdt-enabled()">
-      <xsl:apply-templates select="clos" />
+      <xsl:call-template name="clos" />
     </xsl:if>
 
     <xsl:call-template name="cpu_affinity" />
@@ -176,14 +176,14 @@
     <xsl:value-of select="acrn:initializer('guest_flags', concat('(', acrn:string-join(//allocation-data/acrn-config/vm[@id=$vm_id]/guest_flags/guest_flag, '|', '', ''),')'))" />
   </xsl:template>
 
-  <xsl:template match="clos">
+  <xsl:template name="clos">
     <xsl:value-of select="acrn:ifdef('CONFIG_RDT_ENABLED')" />
-    <xsl:value-of select="acrn:initializer('pclosids', concat('vm', ../@id, '_vcpu_clos'))" />
+    <xsl:value-of select="acrn:initializer('pclosids', concat('vm', @id, '_vcpu_clos'))" />
 
-    <xsl:variable name="vm_id" select="../@id" />
-    <xsl:variable name="vm_name" select="../name/text()" />
+    <xsl:variable name="vm_id" select="@id" />
+    <xsl:variable name="vm_name" select="name/text()" />
     <xsl:choose>
-      <xsl:when test="acrn:is-vcat-enabled() and ../virtual_cat_support[text() = 'y']">
+      <xsl:when test="acrn:is-vcat-enabled() and virtual_cat_support[text() = 'y']">
         <xsl:value-of select="acrn:initializer('num_pclosids', concat(count(//vm[@id=$vm_id]/virtual_cat_number), 'U'))" />
         <xsl:variable name="rdt_res_str" select="acrn:get-normalized-closinfo-rdt-res-str()" />
 


### PR DESCRIPTION
The current UI "Maximum virtual CLOS" above the "VM Virtual Cache  Allocation Tech", it's not user-friendly, and the clos element was not  used by vCAT feature.

This series move the "virtual_cat_number" element and remove the unused  node from schema, then remove clos node from XMLS to adapter these change.