### PR TITLE
[release_3.0 branch] hv: sched_event: Change nqueued from int8_t to int32_t

### DIFF
--- a/hypervisor/include/common/event.h
+++ b/hypervisor/include/common/event.h
@@ -4,7 +4,7 @@
 
 struct sched_event {
 	spinlock_t lock;
-	int8_t nqueued;
+	int32_t nqueued;
 	struct thread_object* waiting_thread;
 };
 


### PR DESCRIPTION
This patch changes the type of nqueued in struct sched_event from int8_t
to int32_t.

In commit d575edf79, the 1 bit flag in struct sched_event has been
changed to int8_t counter to resolve race condition. Signal_event
will decrease the counter and wait_event will increase it and loop if
the counter is greater than 0.

In most cases the uses of signal_event and wait_event are consistent,
except VCPU_EVENT_VIRTUAL_INTERRUPT. In our logic, we signal this event
whenever there is an virtual interrupt, but we wait on it only in
hlt_vmexit_handler, and we reset this event before VMEnter.

In most cases this worked fine. However it has been found that in
certain GPU stress testing scenario, the signaling of this event
happened too frequently to the point where this int8_t counter underflowed
(i.e., hit -128 and then became 127). Then in subsequent
hlt_vmexit_handler, hv waited on this event and stuck there as the
counter was too large.

This patch changes the type from int8_t to int32_t to avoid underflow.

Tracked-On: #7567
Signed-off-by: Yifan Liu <yifan1.liu@intel.com>