### PR TITLE
config-tools: fix board import bug

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/Board.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/Board.vue
@@ -157,7 +157,7 @@ export default {
       .then((res) => {
         let boardPath = ''
         res.map((filepath) => {
-          if (filepath.path.search('board') != -1) {
+          if (filepath.path.search('\\.board\\.xml') != -1) {
             boardPath = filepath.path
           }
         })


### PR DESCRIPTION
Only import board with special suffix: .board.xml

Tracked-On: #7571
Signed-off-by: Conghui <conghui.chen@intel.com>