### PR TITLE
[release_3.0] misc: deb: Enable "systemd-networkd" service

### DIFF
--- a/misc/packaging/acrn-hypervisor.postinst
+++ b/misc/packaging/acrn-hypervisor.postinst
@@ -125,4 +125,7 @@ sed -i '$a GRUB_TIMEOUT=20' ${filename}
 sync
 update-grub
 
+# Enable "systemd-networkd" service
+systemctl enable systemd-networkd
+
 exit 0


### PR DESCRIPTION
In ACRN, "systemd-networkd" service is a pre-requisite to use virtio-net.
This patch enables "systemd-networkd" service in the debian package.

Tracked-On: #7576
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>