### PR TITLE
[release_3.0] misc: configurator: bugfix: incorrect path split

### DIFF
--- a/misc/config_tools/configurator/pyodide/loadBoard.py
+++ b/misc/config_tools/configurator/pyodide/loadBoard.py
@@ -4,6 +4,7 @@ __package__ = 'configurator.pyodide'
 import json
 import logging
 import re
+import os
 from copy import deepcopy
 
 import elementpath
@@ -111,15 +112,20 @@ def get_cat_info(soup):
 
 def get_board_info(board, path):
     soup = BeautifulSoup(board, 'xml')
+    # Workaround: The pyodide thinks it runs under os.name == posix.
+    # So os.path.basename will not work on windows.
+    # Here we replace all '\' with '/' to make it work (most of the time).
     try:
-        board_name = re.split('[\\\\/.]', path)[-2]
-        if board_name == 'board':
-            board_name = re.split('[\\\\/.]', path)[-3]
-    except IndexError as e:
+        path = path.replace('\\', '/')
+        fname = os.path.basename(path)
+        basename, _ = os.path.splitext(fname)
+        board_name = basename + '.xml' if basename.endswith('.board') \
+            else basename + '.board.xml'
+    except Exception as e:
         logging.warning(e)
         board_name = 'default'
     result = {
-        'name': board_name + '.board.xml',
+        'name': board_name,
         'content': board,
         'CAT_INFO': get_cat_info(soup),
         'BIOS_INFO': soup.select_one('BIOS_INFO').text,


### PR DESCRIPTION
Board files with multiple dots in their name may be splitted
incorrectly, and os.path.basename assumes os.name == posix in pyodide
environment. This workaround partially fixes this problem whenever the
the board filename does not contain '\' character.

Tracked-On: #7582
Signed-off-by: Yifan Liu <yifan1.liu@intel.com>