### PR TITLE
misc: modify IVSHMEM virtual BDF validation check

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
@@ -51,7 +51,7 @@
               </b-form-invalid-feedback>
             </b-col>
             <b-col sm="3">
-              <b-form-input :state="validation(IVSHMEM_VM.VBDF)" v-model="IVSHMEM_VM.VBDF" placeholder="00:[device].[function], e.g. 00:0c.0. All fields are in hexadecimal."/>
+              <b-form-input :v-model="IVSHMEM_VM.VBDF" placeholder="00:[device].[function], e.g. 00:0c.0. All fields are in hexadecimal."/>
               <b-form-invalid-feedback>
                 must have value
               </b-form-invalid-feedback>


### PR DESCRIPTION
The current UI force user input BDF which could automatically fill it
in if it is blank, so it an optional.

This patch change the BDF to an optional.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@intel.com>