### PR TITLE
config_tools: bugs fix for configurator

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/Virtio/Console.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/Virtio/Console.vue
@@ -137,8 +137,8 @@ export default {
         this.defaultVal = []
       }
       this.defaultVal.push({
-        "use_type": this.ConsoleUseType,
-        "backend_type": this.ConsoleBackendType,
+        "use_type": "",
+        "backend_type": "",
         "output_file_path": "",
         "sock_file_path": "",
         "tty_device_path": "",

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/Virtio/Console.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/Virtio/Console.vue
@@ -8,7 +8,7 @@
             <label>Use type: </label>
           </b-col>
           <b-col md="4">
-            <b-form-select v-model="console.use_type" :options="ConsoleUseType"/>
+            <b-form-select v-model="console.use_type" :options="getUseTypes"/>
           </b-col>
         </b-row>
 
@@ -95,7 +95,8 @@ export default {
   },
   data() {
     return {
-      ConsoleUseType: this.rootSchema.definitions['VirtioConsoleUseType']['enum'],
+      enumNames: this.rootSchema.definitions['VirtioConsoleUseType']['enumNames'],
+      enum: this.rootSchema.definitions['VirtioConsoleUseType']['enum'],
       ConsoleBackendType: this.rootSchema.definitions['BasicVirtioConsoleBackendType']['enum'],
       defaultVal: vueUtils.getPathVal(this.rootFormData, this.curNodePath)
     };
@@ -116,6 +117,16 @@ export default {
       },
       deep: true
     }
+  },
+  computed: {
+    getUseTypes() {
+      let enumOptions = []
+      for (let i = 0; i < this.enumNames.length; i++) {
+        let enumOption = {text: this.enumNames[i], value: this.enum[i]}
+        enumOptions.push(enumOption)
+      }
+      return enumOptions
+    },
   },
   methods: {
     removeVirtioConsole(index) {

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -339,8 +339,12 @@ The size is a subset of the VM's total memory size specified on the Basic tab.</
        <xs:documentation>A string with value: ``Virtio console`` or ``Virtio serial port``</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
-    <xs:enumeration value="Virtio console" />
-    <xs:enumeration value="Virtio serial port" />
+    <xs:enumeration value="Virtio console" >
+      <xs:annotation acrn:title="virtio serial port (as console)" />
+    </xs:enumeration>
+    <xs:enumeration value="Virtio serial port" >
+      <xs:annotation acrn:title="virtio serial port" />
+    </xs:enumeration>
   </xs:restriction>
 </xs:simpleType>
 

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -201,7 +201,9 @@ The size is a subset of the VM's total memory size specified on the Basic tab.</
     <xs:enumeration value="COM Port 2" />
     <xs:enumeration value="COM Port 3" />
     <xs:enumeration value="COM Port 4" />
-    <xs:enumeration value="PCI" />
+    <xs:enumeration value="PCI" >
+      <xs:annotation acrn:views="" />
+    </xs:enumeration>
   </xs:restriction>
 </xs:simpleType>
 


### PR DESCRIPTION
1. virtio serial port and virtio console are all based on virito serial port. but virtio serial port functionally can not be used as 
console, which may lead to user confusion, so explicitly specify the point by changing the item name as follows:
Virtio console -> virtio serial port (as console)
3. fix the issue that saves all enum values are saved in the scenario XML file if the user doesn't select any value in the configurator.
4. It's unexpected to show the "PCI" option for Console virtual UART type currently, so this patch hides it in the configurator.