### PR TITLE
misc: configurator: Delete old .board.xml after reselect a new one

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/Board.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/Board.vue
@@ -132,6 +132,10 @@ export default {
       let filepath = ''
       if (useNewFile) {
         filepath = this.newFilePath
+        if (filepath != this.currentSelectedBoard) {
+          configurator.removeFile(this.currentSelectedBoard)
+          .catch((err) => alert(`${err}`))
+        }
       } else {
         filepath = this.currentSelectedBoard
       }


### PR DESCRIPTION
Delete old .board.xml after reselect a new one so that there will be
only one working .board.xml in working directory

Tracked-On: #7597
Signed-off-by: Calvin Zhang <calvinzhang.cool@gmail.com>