### PR TITLE
misc: config_tool: Add udmabuf.list_limit=8192 to ServiceVM bootargs

### DIFF
--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -98,6 +98,7 @@
   </xsl:variable>
   <xsl:value-of select="acrn:define('SERVICE_VM_ROOTFS', concat($quot, $sos_rootfs, ' ', $quot), '')" />
   <xsl:value-of select="acrn:define('SERVICE_VM_BOOTARGS_DIFF', concat($quot, $sos_bootargs, ' ', $maxcpus, ' ', $hugepage_kernelstring, ' ', $quot), '')" />
+  <xsl:value-of select="acrn:define('SERVICE_VM_BOOTARGS_MISC', concat($quot, 'udmabuf.list_limit=8192 ', $quot), '')" />
 </xsl:template>
 
 <xsl:template name="cpu_affinity">

--- a/misc/config_tools/xforms/vm_configurations.h.xsl
+++ b/misc/config_tools/xforms/vm_configurations.h.xsl
@@ -64,7 +64,7 @@
     <xsl:if test="count(vm[load_order='SERVICE_VM'])">
       <xsl:value-of select="acrn:comment(concat('SERVICE_VM == VM', vm[load_order='SERVICE_VM']/@id))" />
       <xsl:value-of select="$newline" />
-      <xsl:value-of select="acrn:define('SERVICE_VM_OS_BOOTARGS', 'SERVICE_VM_ROOTFS SERVICE_VM_IDLE SERVICE_VM_BOOTARGS_DIFF', '')" />
+      <xsl:value-of select="acrn:define('SERVICE_VM_OS_BOOTARGS', 'SERVICE_VM_ROOTFS SERVICE_VM_IDLE SERVICE_VM_BOOTARGS_DIFF SERVICE_VM_BOOTARGS_MISC', '')" />
     </xsl:if>
   </xsl:template>
 


### PR DESCRIPTION
Add udmabuf.list_limit=8192 to ServiceVM bootargs for virtio gpu. It's
harmless if not used.

Tracked-On: #7581
Signed-off-by: Calvin Zhang <calvinzhang.cool@gmail.com>