### PR TITLE
move buildtype above debugoptions in the scenario schema

### DIFF
--- a/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/cfl-k700-i7/partitioned.xml
+++ b/misc/config_tools/data/cfl-k700-i7/partitioned.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/cfl-k700-i7/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/shared_launch_6user_vm.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/generic_board/hybrid_rt.xml
+++ b/misc/config_tools/data/generic_board/hybrid_rt.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/generic_board/partitioned.xml
+++ b/misc/config_tools/data/generic_board/partitioned.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/nuc11tnbi5/partitioned.xml
+++ b/misc/config_tools/data/nuc11tnbi5/partitioned.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/qemu/shared.xml
+++ b/misc/config_tools/data/qemu/shared.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/partitioned.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/partitioned.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/whl-ipc-i5/partitioned.xml
+++ b/misc/config_tools/data/whl-ipc-i5/partitioned.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_vxworks.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_vxworks.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
@@ -1,7 +1,7 @@
 <acrn-config>
   <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
     <DEBUG_OPTIONS>
-      <BUILD_TYPE>debug</BUILD_TYPE>
       <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
       <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
       <NPK_LOGLEVEL>5</NPK_LOGLEVEL>

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -13,16 +13,6 @@
   </xs:annotation>
 
   <xs:all>
-    <xs:element name="BUILD_TYPE" type="BuildType" default="debug">
-      <xs:annotation acrn:title="Build type" acrn:views="basic">
-        <xs:documentation>Select the build type:
-
-* ``Debug`` enables the debug shell, prints, and logs.
-* ``Release`` optimizes the ACRN binary for deployment and turns off all debug infrastructure.
-
-These settings can only be changed at build time.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
     <xs:element name="SERIAL_CONSOLE" type="SerialConsoleType" default="None">
       <xs:annotation acrn:title="Serial console port" acrn:views="basic"
 		     acrn:options="//ttys/serial[type != '0']/dev_path/text(), 'None' ">
@@ -255,6 +245,16 @@ These settings can only be changed at build time.</xs:documentation>
 
 <xs:complexType name="HVConfigType">
   <xs:all>
+    <xs:element name="BUILD_TYPE" type="BuildType" default="debug">
+      <xs:annotation acrn:title="Build type" acrn:views="basic">
+        <xs:documentation>Select the build type:
+
+* ``Debug`` enables the debug shell, prints, and logs.
+* ``Release`` optimizes the ACRN binary for deployment and turns off all debug infrastructure.
+
+These settings can only be changed at build time.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
     <xs:element name="FEATURES" type="FeatureOptionsType">
       <xs:annotation acrn:title="Hypervisor features" acrn:views="basic, advanced">
       </xs:annotation>


### PR DESCRIPTION
(adding to release_3.0 branch)

DX/UI recommendation is to move the build type parameter outside of the
debugoptions section. This breaks existing schema files, so also update
scenario XML files in the code tree to match.

Update the xforms xsl script with the same change to the buildtype
option location in schema XML files.

Tracked-on: #5692

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>