### PR TITLE
[release_3.0] config-tools: remove empty cache_region entry

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/CAT.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/CAT.vue
@@ -597,6 +597,12 @@ export default {
           //   return a['@id'] - b['@id']
           // });
         })
+
+        for (let i = 0; i < board_cat_info.length; i++) {
+          if (board_cat_info[i].data.POLICY.length == 0) {
+            board_cat_info.splice(i--, 1)
+          }
+        }
         return board_cat_info;
       }
 


### PR DESCRIPTION
Currently the empty cache_regions are saved to scenario file. It is
useless, and unable to pass the load/build validation check, causing
build fail.

This patch add a filter to the empty cache_region entry, so that the
load/build validation check may pass.

Tracked-On: #7609
Signed-off-by: Wu Zhou <wu.zhou@intel.com>