### PR TITLE
config-tools: remove empty cache_region entry

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/CAT.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/CAT.vue
@@ -425,8 +425,13 @@ export default {
           addPolicy(cpu_policies)
         }
       })
-
-      this.CAT_INFO = board_cat_info;
+      this.CAT_INFO = _.cloneDeep(board_cat_info);
+      // remove cache entries that has no policy
+      for (let i = 0; i < this.CAT_INFO.length; i++) {
+        if (this.CAT_INFO[i].data.POLICY.length == 0) {
+          this.CAT_INFO.splice(i--, 1)
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Currently the empty cache_regions are saved to scenario file. It is
useless, and unable to pass the load/build validation check, causing
build fail.

This patch add a filter to the empty cache_region entry, so that the
load/build validation check may pass.

Tracked-On: #7609
Signed-off-by: Wu Zhou <wu.zhou@intel.com>