### PR TITLE
config_tools: fix move_enablement in the upgrader

### DIFF
--- a/misc/config_tools/scenario_config/upgrader.py
+++ b/misc/config_tools/scenario_config/upgrader.py
@@ -594,13 +594,13 @@ class ScenarioUpgrader(ScenarioTransformer):
 
         return False
 
-    def move_enablement(self, xpath, xsd_element_node, xml_parent_node, new_nodes, values_as_enabled = ["y"], values_as_disabled = ["n"]):
+    def move_enablement(self, xpath, xsd_element_node, xml_parent_node, new_nodes, values_as_enabled = ["Enable"], values_as_disabled = ["Disable"]):
         ret = self.move_data_by_xpath(xpath, xsd_element_node, xml_parent_node, new_nodes)
         for n in new_nodes:
             if n.text in values_as_enabled:
-                n.text = "Enable"
+                n.text = "y"
             elif n.text in values_as_disabled:
-                n.text = "Disable"
+                n.text = "n"
         return ret
 
     def move_data_by_xpath(self, xpath, xsd_element_node, xml_parent_node, new_nodes, scenario_xml_only = False, launch_xml_only = False):

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -13,16 +13,6 @@
   </xs:restriction>
 </xs:simpleType>
 
-<xs:simpleType name="EnablementType">
-  <xs:annotation>
-    <xs:documentation>A string with value: ``Enable`` or ``Disable``.</xs:documentation>
-  </xs:annotation>
-  <xs:restriction base="xs:string">
-    <xs:enumeration value="Enable" />
-    <xs:enumeration value="Disable" />
-  </xs:restriction>
-</xs:simpleType>
-
 <xs:simpleType name="HexFormat">
   <xs:annotation acrn:widget-options="'placeholder': 'A hexadecimal number with a leading 0x, e.g. 0x1000.'"
                  acrn:errormsg="'pattern': 'Must be a hexadecimal integer (case-insensitive).'">


### PR DESCRIPTION
The EnablementType is now obsolete and config items having this type have
been updated to use the Boolean type. However, the upgrader is not changed
accordingly and it still converts "y" or "n" of certain config items to
"Enable" or "Disable".

This patch drops the EnablementType in the schema and updates the upgrader
to respect the latest definitions.

Tracked-On: #6690
Signed-off-by: Junjie Mao <junjie.mao@intel.com>