### PR TITLE
config_tools: hide vm_type for Service VM

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -205,6 +205,9 @@ export default {
           this.currentFormData = this.scenario.vm[i]
         }
       }
+      if (this.currentFormData['load_order'] === 'SERVICE_VM') {
+        delete this.currentFormSchema.BasicConfigType.properties.vm_type
+      }
     },
     switchTab(tabVMID) {
       this.activeVMID = tabVMID;


### PR DESCRIPTION
For Service OS, 'vm_type' should not be modified.
Delete it from 'ServiceVMBasicConfigType' to forbid unexpected error.

Tracked-On: #7528
Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>