### PR TITLE
misc: configurator: Fix vUART and IVSHMEM select box missing problem

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
@@ -155,7 +155,7 @@ export default {
   },
   methods: {
     validation(value) {
-      return value.length != 0;
+      return (value != null) && (value.length != 0);
     },
     addSharedVM(vms, index) {
       // add new item after current item

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/VUART.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/VUART.vue
@@ -153,7 +153,7 @@ export default {
   },
   methods: {
     validation(value) {
-      return value.length != 0;
+      return (value != null) && (value.length != 0);
     },
     removeVUARTConnection(index) {
       this.defaultVal.splice(index, 1);


### PR DESCRIPTION
When user adds a vUART or IVSHMEM region and select VMs in selection
list, deleting the selected VM could break the selection box.

This patch adds a state check against null and undefined value.

Tracked-On: #7624
Signed-off-by: Yifan Liu <yifan1.liu@intel.com>