### PR TITLE
config_tools: add default values to I/O ports of vUART

### DIFF
--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -215,8 +215,8 @@ The size is a subset of the VM's total memory size specified on the Basic tab.</
         <xs:documentation>Virtual UART port</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="io_port" type="HexFormat" default="0x3F">
-      <xs:annotation acrn:title="Virtual I/O address">
+    <xs:element name="io_port" type="HexFormat">
+      <xs:annotation acrn:title="Virtual I/O address" acrn:defaults="[hex(i) for i in range(0x9200, 0x9280, 8)]" acrn:unique-among="//vuart_connection/endpoint[vm_name=$parent/vm_name]/io_port/text()">
         <xs:documentation>Specify the COM base for each legacy virtual UART.</xs:documentation>
       </xs:annotation>
     </xs:element>


### PR DESCRIPTION
Similar to 5bd3e9642 ("config_tools: add default values to vBDF of vUART
and IVSHMEM"), this patch adds default values to the I/O ports of vUART
which shall also keep unique among all vUART endpoints of the same VM.

In order not to overlap with the (potentially used) COM ports, a different
range starting from 0x9200 is selected as defaults. Users are still free to
customize them to COM ports if intended.

Tracked-On: #7330
Signed-off-by: Junjie Mao <junjie.mao@intel.com>