### PR TITLE
ACRN: DM: Fix the vsock Guest Cid overflow issue

### DIFF
--- a/devicemodel/hw/pci/virtio/vhost_vsock.c
+++ b/devicemodel/hw/pci/virtio/vhost_vsock.c
@@ -238,7 +238,8 @@ static int
 virtio_vhost_vsock_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 {
 	struct virtio_vsock *vsock;
-	int rc, cid;
+	int rc;
+	uint64_t cid;
 	pthread_mutexattr_t attr;
 	char *devopts = NULL;
 	char *tmp = NULL;
@@ -254,7 +255,7 @@ virtio_vhost_vsock_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	}
 	if (!strncmp(tmp, "cid=", 4)) {
 		strsep(&tmp, "=");
-		dm_strtoi(tmp, NULL, 10, &cid);
+		dm_strtoul(tmp, NULL, 10, &cid);
 	}
 	free(devopts);
 

--- a/devicemodel/include/vhost_vsock.h
+++ b/devicemodel/include/vhost_vsock.h
@@ -29,7 +29,7 @@
 	(1ULL << VIRTIO_RING_F_EVENT_IDX) | (1ULL << VHOST_F_LOG_ALL) | \
 	(1ULL << VIRTIO_F_ANY_LAYOUT) | (1ULL << VIRTIO_F_VERSION_1)
 
-#define U32_MAX                 65535
+#define U32_MAX                 ((uint32_t)~0U)
 #define VMADDR_CID_HOST         2
 
 struct virtio_vsock_config {


### PR DESCRIPTION
Vsock guest cid should be u32 type, redefined the cid type and
fix the MAX value of the cid.

Tracked-On: #7456
Signed-off-by: Liu Long <long.liu@linux.intel.com>