### PR TITLE
ACRN: DM: Fix the vsock cid overflow issue.

### DIFF
--- a/devicemodel/hw/pci/virtio/vhost_vsock.c
+++ b/devicemodel/hw/pci/virtio/vhost_vsock.c
@@ -238,7 +238,8 @@ static int
 virtio_vhost_vsock_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 {
 	struct virtio_vsock *vsock;
-	int rc, cid;
+	int rc;
+	uint64_t cid;
 	pthread_mutexattr_t attr;
 	char *devopts = NULL;
 	char *tmp = NULL;
@@ -254,7 +255,7 @@ virtio_vhost_vsock_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	}
 	if (!strncmp(tmp, "cid=", 4)) {
 		strsep(&tmp, "=");
-		dm_strtoi(tmp, NULL, 10, &cid);
+		dm_strtoul(tmp, NULL, 10, &cid);
 	}
 	free(devopts);
 


### PR DESCRIPTION
The vsock cid type is u32, redefine the cid type to u32, and use
dm_strtoui API replace dm_strtoi.

Tracked-On: #7456
Signed-off-by: Liu Long <long.liu@linux.intel.com>