### PR TITLE
config-tools: refine vsock UI

### DIFF
--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -411,6 +411,14 @@ device file when user config it as virtio serial port, which can be read and wri
   </xs:sequence>
 </xs:complexType>
 
+<xs:simpleType name="vsockCIDType">
+    <xs:annotation acrn:widget-options="'placeholder': 'integer greater than 2'" />
+    <xs:restriction base="xs:integer">
+      <xs:minInclusive value="3" />
+      <xs:maxInclusive value="4294967294" />
+    </xs:restriction>
+</xs:simpleType>
+
 <xs:simpleType name="OSType">
   <xs:annotation>
     <xs:documentation>A string with either ``Non-Windows OS`` or  ``Windows OS``.</xs:documentation>

--- a/misc/config_tools/schema/checks/virtio_devices.xsd
+++ b/misc/config_tools/schema/checks/virtio_devices.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2022 Intel Corporation. -->
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<xs:schema xml:id="root"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:acrn="https://projectacrn.org">
+
+  <xs:assert test="every $vm in /acrn-config/vm satisfies
+                   every $vsock in $vm/virtio_devices/vsock satisfies
+                   count(//virtio_devices/vsock[text()=$vsock]) = 1
+                   ">
+    <xs:annotation acrn:severity="error" acrn:report-on="$vm">
+      <xs:documentation>"{$vm/name}" repeats a vsock CID assignment: {$vsock}, either with this VM or with other VMs. Remove the duplicates.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+</xs:schema>

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -444,22 +444,6 @@ argument and memory.</xs:documentation>
 This feature enables you to view the VM's GPU output in the Service VM.</xs:documentation>
             </xs:annotation>
           </xs:element>
-          <xs:element name="vsock" minOccurs="0">
-            <xs:annotation acrn:title="Virtio vsock CID" acrn:views="basic"
-                          acrn:widget-options="'placeholder': '3 ~ (-2U)'">
-              <xs:documentation>vsock is the new socket address family for host/guest communication.
-CID is the identifier for this VM.</xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-              <xs:restriction base="xs:integer">
-                <xs:annotation>
-                  <xs:documentation>Integer between 3 ~ (-2U).</xs:documentation>
-                </xs:annotation>
-                <xs:minInclusive value="3" />
-                <xs:maxInclusive value="4294967294" />
-              </xs:restriction>
-            </xs:simpleType>
-          </xs:element>
           <xs:element name="console" type="VirtioConsoleConfiguration" minOccurs="0" maxOccurs="unbounded">
             <xs:annotation acrn:title="Virtio console device" acrn:views="basic">
               <xs:documentation>Virtio console device for data input and output.
@@ -490,6 +474,13 @@ mouse, and tablet.  It sends Linux input layer events over virtio.</xs:documenta
                                acrn:errormsg="'required': 'Path to a disk image required.'"/>
                 <xs:restriction base="xs:string" />
               </xs:simpleType>
+          </xs:element>
+          <xs:element name="vsock" type="vsockCIDType" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation acrn:title="Virtio vsock Context ID (CID)" acrn:views="basic">
+              <xs:documentation>Specify the post-launched VM's unique Context ID (CID) used by vsock (integer greater than 2).
+vsock provides a way for the host system and applications running in a user VM to communicate with each other using the standard socket interface.
+vsock uses a (context id, port) pair of integers for identifying processes. The host system CID is always 2. The port is hardcoded in our implementation.</xs:documentation>
+            </xs:annotation>
           </xs:element>
         </xs:all>
       </xs:complexType>

--- a/misc/config_tools/schema/datachecks.xsd
+++ b/misc/config_tools/schema/datachecks.xsd
@@ -14,6 +14,7 @@
       <xi:include href="checks/vbdf_assignment.xsd" xpointer="xpointer(id('root')/*)" />
       <xi:include href="checks/vm_types.xsd" xpointer="xpointer(id('root')/*)" />
       <xi:include href="checks/passthrough_devices.xsd" xpointer="xpointer(id('root')/*)" />
+      <xi:include href="checks/virtio_devices.xsd" xpointer="xpointer(id('root')/*)" />
       <xi:include href="checks/vuart_config.xsd" xpointer="xpointer(id('root')/*)" />
 
     </xs:complexType>


### PR DESCRIPTION
1. One VM can have multi vsock. Changed vsock UI to multi line.
2. Add verification that no repeated CID is allowed.
3. Refine the tooltip text.

Tracked-On: #7637
Signed-off-by: Wu Zhou <wu.zhou@intel.com>