### PR TITLE
hv: compile out unused function if CONFIG_MULTIBOOT2 is disabled

### DIFF
--- a/hypervisor/boot/guest/bzimage_loader.c
+++ b/hypervisor/boot/guest/bzimage_loader.c
@@ -182,6 +182,7 @@ static void *get_bzimage_kernel_load_addr(struct acrn_vm *vm)
 	return load_addr;
 }
 
+#ifdef CONFIG_MULTIBOOT2
 /**
  * @pre vm != NULL && efi_mmap_desc != NULL
  */
@@ -234,6 +235,7 @@ static uint16_t create_service_vm_efi_mmap_desc(struct acrn_vm *vm, struct efi_m
 
 	return desc_idx;
 }
+#endif
 
 /**
  * @pre zp != NULL && vm != NULL


### PR DESCRIPTION
When CONFIG_MULTIBOOT2 is disabled, 'create_service_vm_efi_mmap_desc' is
unused and build fails because [-Werror=unused-function] is set.

boot/guest/bzimage_loader.c:188:17: error: 'create_service_vm_efi_mmap_desc' defined but not used [-Werror=unused-function]
  188 | static uint16_t create_service_vm_efi_mmap_desc(struct acrn_vm *vm, struct efi_memory_desc *efi_mmap_desc)
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

Tracked-On: #7634
Signed-off-by: Calvin Zhang <calvinzhang.cool@gmail.com>