### PR TITLE
misc: configurator: fix IVSHMEM size missing bug

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
@@ -163,6 +163,7 @@ export default {
   data() {
     return {
       providerType: this.rootSchema.definitions['ProviderType']['enum'],
+      IVSHMEMSize: this.rootSchema.definitions['IVSHMEMSize']['enum'],
       IVSHMEMRegionType: this.rootSchema.definitions['IVSHMEMRegionType'],
       IVSHMEMVM: this.rootSchema.definitions['IVSHMEMVM'],
       VMConfigType: this.rootSchema.definitions['VMConfigType'],


### PR DESCRIPTION
Fix IVSHMEM size selection options missing bug due to data provider
being deleted by mistake.

Tracked-On: #7650
Signed-off-by: Yifan Liu <yifan1.liu@intel.com>