### PR TITLE
[release_3.0] config-tools: refine the vuart widget's text

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/VUART.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/VUART.vue
@@ -12,7 +12,7 @@
                     <IconInfo/>
                 </template>
                 <span v-html="this.VMConfigType.properties.name.description"></span>
-              </n-popover>VM name:
+              </n-popover>{{vmNameTitle}}
             </label>
           </b-col>
           <b-col md="4">
@@ -37,7 +37,7 @@
                     <IconInfo/>
                 </template>
                 <span v-html="this.VMConfigType.properties.name.description"></span>
-              </n-popover>VM name:
+              </n-popover>{{vmNameTitle}}:
             </label>
           </b-col>
           <b-col md="4">
@@ -56,7 +56,7 @@
                     <IconInfo/>
                 </template>
                 <span v-html="this.VuartConnectionType.properties.type.description"></span>
-              </n-popover>Type: 
+              </n-popover>{{vuartConnectionTypeTitle}}:
             </label>
           </b-col>
           <b-col md="4">
@@ -72,7 +72,7 @@
           <p></p>
           <b-row class="justify-content-sm-start">
             <b-col sm="4">
-              Virtual UART port:
+              {{vuartEndpointTitle}}:
             </b-col>
             <b-col sm="4" v-if="VUARTConn.type === 'legacy'">
               <n-popover trigger="hover" placement="top-start">
@@ -81,7 +81,7 @@
                 </template>
                 <span v-html="this.VuartEndpointType.io_port.description"></span>
               </n-popover>
-              I/O address:
+              {{vuartVIoPortTitle}}:
             </b-col>
             <b-col sm="4" v-else-if="VUARTConn.type === 'pci'">
               <n-popover trigger="hover" placement="top-start">
@@ -89,21 +89,21 @@
                       <IconInfo/>
                   </template>
                   <span>{{this.VuartEndpointType.vbdf.description}}</span>
-                </n-popover>VBDF
+                </n-popover>{{vuartVBDFTitle}}
             </b-col>
           </b-row>
           <b-row class="justify-content-sm-start align-items-center">
             <b-col sm="4"> Connection_{{ index + 1 }}-{{ VUARTConn.endpoint[0].vm_name }} </b-col>
             <b-col sm="4">
-              <b-form-input v-model="VUARTConn.endpoint[0].io_port" v-if="VUARTConn.type === 'legacy'" placeholder="An address in hexadecimal, e.g. 0x4000"/>
-              <b-form-input v-model="VUARTConn.endpoint[0].vbdf" v-else-if="VUARTConn.type === 'pci'" placeholder="00:[device].[function], e.g. 00:1c.0. All fields are in hexadecimal."/>
+              <b-form-input v-model="VUARTConn.endpoint[0].io_port" v-if="VUARTConn.type === 'legacy'" :placeholder="vIoPortPlaceholder"/>
+              <b-form-input v-model="VUARTConn.endpoint[0].vbdf" v-else-if="VUARTConn.type === 'pci'" :placeholder="vBDFPlaceholder"/>
             </b-col>
           </b-row>
           <b-row class="justify-content-sm-start align-items-center">
             <b-col sm="4"> Connection_{{ index + 1 }}-{{ VUARTConn.endpoint[1].vm_name }} </b-col>
             <b-col sm="4">
-              <b-form-input v-model="VUARTConn.endpoint[1].io_port" v-if="VUARTConn.type === 'legacy'" placeholder="An address in hexadecimal, e.g. 0x4000"/>
-              <b-form-input v-model="VUARTConn.endpoint[1].vbdf" v-else-if="VUARTConn.type === 'pci'" placeholder="00:[device].[function], e.g. 00:1c.0. All fields are in hexadecimal."/>
+              <b-form-input v-model="VUARTConn.endpoint[1].io_port" v-if="VUARTConn.type === 'legacy'" :placeholder="vIoPortPlaceholder"/>
+              <b-form-input v-model="VUARTConn.endpoint[1].vbdf" v-else-if="VUARTConn.type === 'pci'" :placeholder="vBDFPlaceholder"/>
             </b-col>
           </b-row>
         </div>
@@ -165,9 +165,24 @@ export default {
     }
   },
   data() {
+    let enumValue = this.rootSchema.definitions['VuartType']['enum']
+    let enumNames = this.rootSchema.definitions['VuartType']['enumNames']
+    let VuartType = []
+    enumValue.forEach((item, i) => {
+      VuartType.push({value:item, text:enumNames[i]})
+    })
+    let epTypeProp = this.rootSchema.definitions.VuartEndpointType.properties
+    let conTypeProp = this.rootSchema.definitions.VuartConnectionType.properties
     return {
-      VuartType: this.rootSchema.definitions['VuartType']['enum'],
       VuartEndpointType: this.rootSchema.definitions['VuartEndpointType']['properties'],
+      vmNameTitle: epTypeProp.vm_name.title,
+      vuartConnectionTypeTitle: conTypeProp.type.title,
+      vuartEndpointTitle: conTypeProp.endpoint['title'],
+      vuartVIoPortTitle: epTypeProp.io_port.title,
+      vuartVBDFTitle: epTypeProp.vbdf.title,
+      vIoPortPlaceholder: epTypeProp.io_port['ui:options']['placeholder'],
+      vBDFPlaceholder: epTypeProp.vbdf['ui:options']['placeholder'],
+      VuartType,
       IOPortDefault: this.rootSchema.definitions['VuartEndpointType']['properties']['io_port']['default'],
       VMConfigType: this.rootSchema.definitions['VMConfigType'],
       VuartConnectionType: this.rootSchema.definitions['VuartConnectionType'],

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -216,12 +216,12 @@ The size is a subset of the VM's total memory size specified on the Basic tab.</
       </xs:annotation>
     </xs:element>
     <xs:element name="io_port" type="HexFormat">
-      <xs:annotation acrn:title="Virtual I/O address" acrn:defaults="[hex(i) for i in range(0x9200, 0x9280, 8)]" acrn:unique-among="//vuart_connection/endpoint[vm_name=$parent/vm_name]/io_port/text()">
+      <xs:annotation acrn:title="Virtual I/O address" acrn:defaults="[hex(i) for i in range(0x9200, 0x9280, 8)]" acrn:unique-among="//vuart_connection/endpoint[vm_name=$parent/vm_name]/io_port/text()" acrn:widget-options="'placeholder':'An address in hexadecimal, e.g. 0x4000'">
         <xs:documentation>Specify the COM base for each legacy virtual UART.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="vbdf" type="VBDFType">
-      <xs:annotation acrn:title="Virtual UART BDF" acrn:defaults="[f'00:{i:02x}.0' for i in range(16, 24)]" acrn:unique-among="//vuart_connection/endpoint[vm_name=$parent/vm_name]/vbdf/text()">
+      <xs:annotation acrn:title="Virtual UART BDF" acrn:defaults="[f'00:{i:02x}.0' for i in range(16, 24)]" acrn:unique-among="//vuart_connection/endpoint[vm_name=$parent/vm_name]/vbdf/text()" acrn:widget-options="'placeholder':'00:[device].[function], e.g. 00:1c.0. All fields are in hexadecimal.'">
         <xs:documentation>Specify the virtual Bus:Device.Function (BDF) for each PCI virtual UART. Virtual BDF is automatically assigned when the configuration is saved and can be changed if needed.</xs:documentation>
       </xs:annotation>
     </xs:element>
@@ -240,7 +240,10 @@ The size is a subset of the VM's total memory size specified on the Basic tab.</
         <xs:documentation>Select the communication virtual UART (vUART) type.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="endpoint" type="VuartEndpointType" minOccurs="2" maxOccurs="2" />
+    <xs:element name="endpoint" type="VuartEndpointType" minOccurs="2" maxOccurs="2">
+      <xs:annotation acrn:title="Virtual UART port">
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
 </xs:complexType>
 


### PR DESCRIPTION
The labels and titles in vuart widget are hard-coded in the .vue file
rather than exposing the text from XSD file. This patch fixed it.

Tracked-On: #7562

Signed-off-by: Wu Zhou <wu.zhou@intel.com>