### PR TITLE
misc: config_tools: fix make deadloop on release build with debug sce…

### DIFF
--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -34,6 +34,11 @@
       <xsl:with-param name="value" select="@scenario" />
     </xsl:call-template>
 
+    <xsl:call-template name="boolean-by-key-value">
+      <xsl:with-param name="key" select="'RELEASE'" />
+	  <xsl:with-param name="value" select="hv/BUILD_TYPE = 'release'" />
+    </xsl:call-template>
+
     <xsl:apply-templates select="hv/DEBUG_OPTIONS" />
     <xsl:apply-templates select="hv/FEATURES" />
     <xsl:apply-templates select="hv/MEMORY" />
@@ -43,11 +48,6 @@
   </xsl:template>
 
   <xsl:template match="DEBUG_OPTIONS">
-    <xsl:call-template name="boolean-by-key-value">
-      <xsl:with-param name="key" select="'RELEASE'" />
-      <xsl:with-param name="value" select="BUILD_TYPE = 'release'" />
-    </xsl:call-template>
-
     <xsl:call-template name="integer-by-key-value">
       <xsl:with-param name="key" select="'MEM_LOGLEVEL_DEFAULT'" />
       <xsl:with-param name="value" select="MEM_LOGLEVEL" />


### PR DESCRIPTION
…nario

When I build a release acrn with a debug scenario like this:
$ BOARD=nuc11tnbi5 SCENARIO=shared make -j1 RELEASE=y

Following logs are repeated endlessly.

/home/abc/workspace/mainline/acrn-hypervisor/build/hypervisor/configs/allocation.xml generated
/home/abc/workspace/mainline/acrn-hypervisor/build/hypervisor/configs/unified.xml generated
/home/abc/workspace/mainline/acrn-hypervisor/build/hypervisor/configs/config.mk generated
scripts/makefile/config.mk:191: The command line sets RELEASE to be 'y', but an existing build is configured with 'n'
scripts/makefile/config.mk:191: The configuration will be modified for RELEASE=y

Because "BUILD_TYPE" was moved out of "DEBUG_OPTIONS" in scenario file,
outdated transform script fails to extract information there and it always
set 'CONFIG_RELEASE=n'.

If a makefile is included with a rule for it, the rule will be executed
first to generated new makefile. If it's updated, the make process will
be reexecuted with new makefile.

In the case above, build/hypervisor/configs/config.mk rule is executed every
time make tries to include it. Unhandled different between `RELEASE` and
`CONFIG_RELEASE` causes determine_build_type to update .scenario.xml which
is a dependency of hypervisor/scripts/makefile/config.mk.

Tracked-On: #7657
Signed-off-by: Qiang Zhang <qiang4.zhang@intel.com>