### PR TITLE
config_tools: schema of 'VM_NAME' for 'IVSHMEMVM'

### DIFF
--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -198,7 +198,7 @@ Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:docu
 
 <xs:complexType name="IVSHMEMVM">
   <xs:sequence>
-   <xs:element name="VM_NAME" type="VMNameType">
+   <xs:element name="VM_NAME" type="VMNameType" minOccurs="1">
      <xs:annotation acrn:title="Shared VMs">
        <xs:documentation>Name of the VM that uses this shared memory region.</xs:documentation>
      </xs:annotation>


### PR DESCRIPTION
Set VM_NAME' for 'IVSHMEMVM' as required property in schema.

Tracked-On: #7662
Signed-off-by: Zhao <yuanyuan.zhao@intel.com>