### PR TITLE
Change sense of some schema config options

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -59,13 +59,13 @@
       </xs:annotation>
     </xs:element>
     <xs:element name="ENFORCE_TURNOFF_AC" type="Boolean" default="y">
-      <xs:annotation acrn:title="Split lock detection" acrn:views="advanced">
-        <xs:documentation>Enable detection of split locks. A split lock can negatively affect an application's real-time performance. If a lock is detected, an alignment check exception #AC occurs.</xs:documentation>
+      <xs:annotation acrn:title="Disable Split lock detection" acrn:views="advanced">
+        <xs:documentation>Disable detection of split locks. A split lock can negatively affect an application's real-time performance. If a lock is detected, an alignment check exception #AC occurs.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="ENFORCE_TURNOFF_GP" type="Boolean" default="n">
-      <xs:annotation acrn:title="UC lock detection" acrn:views="advanced">
-        <xs:documentation>Enable detection of uncacheable-memory (UC) locks. A UC lock can negatively affect an application's real-time performance. If a lock is detected, a general-protection exception #GP occurs.</xs:documentation>
+      <xs:annotation acrn:title="Disable UC lock detection" acrn:views="advanced">
+        <xs:documentation>Disable detection of uncacheable-memory (UC) locks. A UC lock can negatively affect an application's real-time performance. If a lock is detected, a general-protection exception #GP occurs.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="SECURITY_VM_FIXUP" type="Boolean" default="n">
@@ -99,8 +99,8 @@
       </xs:annotation>
     </xs:element>
     <xs:element name="MCE_ON_PSC_DISABLED" type="Boolean" default="y">
-      <xs:annotation acrn:title="MCE workaround" acrn:views="advanced">
-        <xs:documentation>Enable the software workaround for Machine Check Error on Page Size Change (erratum in some processor families).</xs:documentation>
+      <xs:annotation acrn:title="Disable MCE workaround" acrn:views="advanced">
+        <xs:documentation>Disable the software workaround for Machine Check Error on Page Size Change (erratum in some processor families).</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="RDT" type="RDTType">


### PR DESCRIPTION
(Duplicating change on master branch to release_3.0 branch)

The MCE, split lock, and UC lock checkboxes have a unique behavior.
Selecting the checkbox disables the feature. We proposed changing the
behavior, so that the checkbox enables the feature, but the fix is
postponed to v3.1. Change the sense of these option's tooltip and title
to reflect their current behavior (Disabling vs. normal Enabling).

Tracked-On: #7661

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>