### PR TITLE
config-tools: fix vBDF issue for IVSHMEM

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
@@ -6,12 +6,14 @@
 
         <b-row class="align-items-center my-2 mt-4">
           <b-col md="2">
-            <n-popover trigger="hover" placement="top-start">
+            <label>
+              <n-popover trigger="hover" placement="top-start">
               <template #trigger>
                   <IconInfo/>
               </template>
               <span v-html="this.IVSHMEMRegionType.properties.NAME.description"></span>
             </n-popover>Region name:
+            </label>
           </b-col>
           <b-col md="4">
               <b-form-input v-model="IVSHMEM_VMO.NAME" placeholder="Any string with no white spaces."/>
@@ -59,7 +61,7 @@
                 <template #trigger>
                     <IconInfo/>
                 </template>
-                <span v-html="this.IVSHMEMVM.properties.VBDF.description"></span>
+                <span v-html="this.IVSHMEM_VM.properties.VBDF.description"></span>
               </n-popover>Virtual BDF:
             </b-col>
           </b-row>
@@ -71,7 +73,7 @@
                   <template #trigger>
                       <IconInfo/>
                   </template>
-                  <span v-html="this.VMConfigType.properties.name.description"></span>
+                  <span v-html="this.IVSHMEM_VM.properties.VM_NAME.description"></span>
                 </n-popover>VM name:
               </label>
             </b-col>
@@ -82,7 +84,7 @@
               </b-form-invalid-feedback>
             </b-col>
             <b-col sm="3">
-              <b-form-input :v-model="IVSHMEM_VM.VBDF" placeholder="00:[device].[function], e.g. 00:0c.0. All fields are in hexadecimal."/>
+              <b-form-input v-model="IVSHMEM_VM.VBDF" placeholder="00:[device].[function], e.g. 00:0c.0. All fields are in hexadecimal."/>
               <b-form-invalid-feedback>
                 must have value
               </b-form-invalid-feedback>
@@ -165,8 +167,7 @@ export default {
       providerType: this.rootSchema.definitions['ProviderType']['enum'],
       IVSHMEMSize: this.rootSchema.definitions['IVSHMEMSize']['enum'],
       IVSHMEMRegionType: this.rootSchema.definitions['IVSHMEMRegionType'],
-      IVSHMEMVM: this.rootSchema.definitions['IVSHMEMVM'],
-      VMConfigType: this.rootSchema.definitions['VMConfigType'],
+      IVSHMEM_VM: this.rootSchema.definitions['IVSHMEMVM'],
       defaultVal: vueUtils.getPathVal(this.rootFormData, this.curNodePath)
     };
   },

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -243,7 +243,7 @@ Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:docu
 
 <xs:complexType name="IVSHMEMRegionType">
   <xs:all>
-    <xs:element name="NAME">
+    <xs:element name="NAME" minOccurs="1">
       <xs:annotation acrn:title="Region Name">
         <xs:documentation>Name of the shared memory region.</xs:documentation>
       </xs:annotation>


### PR DESCRIPTION
1. Fix the issue that when saving the configuration, the vBDF does not
display automatically in IVSHMEM region.
2. Chagne 'Region name' in IVSHMEM from optional to required.
3. Fix the wrong tooltip content for 'VM name'.

Tracked-On: #7673
Signed-off-by: Conghui <conghui.chen@intel.com>