### PR TITLE
dm: vdisplay: terminate acrn-dm process when SDL init failed

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -1045,7 +1045,10 @@ main(int argc, char *argv[])
 	}
 
 	if (gfx_ui) {
-		gfx_ui_init();
+		if(gfx_ui_init()) {
+			pr_err("gfx ui initialize failed\n");
+			exit(1);
+		}
 	}
 
 	for (;;) {

--- a/devicemodel/hw/vdisplay_sdl.c
+++ b/devicemodel/hw/vdisplay_sdl.c
@@ -1128,7 +1128,7 @@ vdpy_deinit(int handle)
 	return 0;
 }
 
-void
+int
 gfx_ui_init()
 {
 	SDL_SysWMinfo info;
@@ -1141,6 +1141,7 @@ gfx_ui_init()
 
 	if (SDL_Init(SDL_INIT_VIDEO)) {
 		pr_err("Failed to Init SDL2 system");
+		return -1;
 	}
 
 	SDL_GetDisplayBounds(0, &disp_rect);
@@ -1150,6 +1151,7 @@ gfx_ui_init()
 		pr_err("Too small resolutions. Please check the "
 		       " graphics system\n");
 		SDL_Quit();
+		return -1;
 	}
 
 	SDL_SetHint(SDL_HINT_GRAB_KEYBOARD, "1");
@@ -1170,6 +1172,8 @@ gfx_ui_init()
 	SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
 
 	vdpy.s.is_ui_realized = true;
+
+	return 0;
 }
 
 void

--- a/devicemodel/include/vdisplay.h
+++ b/devicemodel/include/vdisplay.h
@@ -84,7 +84,7 @@ struct cursor {
 };
 
 int vdpy_parse_cmd_option(const char *opts);
-void gfx_ui_init();
+int gfx_ui_init();
 int vdpy_init();
 void vdpy_get_display_info(int handle, struct display_info *info);
 void vdpy_surface_set(int handle, struct surface *surf);


### PR DESCRIPTION
Virtual display is component which based on native window system.
This feature depended phisical monitor connected and graphic driver in
SOS running correctly. If these dependencies fail, it is a fatal error
for virtual display. We have to terminate the device model to let user
fix runtime environment issue for graphics.

Tracked-On: #7672
Signed-off-by: Sun Peng <peng.p.sun@linux.intel.com>