### PR TITLE
dm: Fix uninitialized variable in AHCI

### DIFF
--- a/devicemodel/hw/pci/ahci.c
+++ b/devicemodel/hw/pci/ahci.c
@@ -1468,7 +1468,7 @@ static void
 atapi_start_stop_unit(struct ahci_port *p, int slot, uint8_t *cfis)
 {
 	uint8_t *acmd = cfis + 0x40;
-	uint32_t tfd;
+	uint32_t tfd = ATA_S_ERROR;
 
 	switch (acmd[4] & 3) {
 	case 0:


### PR DESCRIPTION
tfd is one data field of FIS for AHCI, it is unacceptable if it is
random value, could cause AHCI data transport failure.

Acturally there is no chance the switch statement has the value other
than 0~3, since there is only 2 bit to deduce.

Add the initial value for tfd as ATA_S_ERROR, which is checked by function 
ahci_write_fis_d2h afterwards, so guest driver could handle it well.

Tracked-On: #7679

Signed-off-by: hangliu1 <hang1.liu@linux.intel.com>