### PR TITLE
misc: add assert to check ivsh memory region name

### DIFF
--- a/misc/config_tools/schema/checks/ivsh_memory.xsd
+++ b/misc/config_tools/schema/checks/ivsh_memory.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2022 Intel Corporation. -->
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+
+<xs:schema xml:id="root"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:acrn="https://projectacrn.org">
+
+  <xs:assert test="every $VM_NAME in /acrn-config//IVSHMEM//VM_NAME satisfies
+                  every $REGION_NAME in /acrn-config//IVSHMEM_REGION[IVSHMEM_VMS/IVSHMEM_VM/VM_NAME=$VM_NAME]/NAME satisfies
+                  count(/acrn-config//IVSHMEM_REGION[NAME=$REGION_NAME]/IVSHMEM_VMS/IVSHMEM_VM[VM_NAME=$VM_NAME]) = 1">
+    <xs:annotation acrn:severity="error" acrn:report-on="$REGION_NAME">
+      <xs:documentation>InterVM shared memory region name "{$REGION_NAME}" should be different for the same VM "{$VM_NAME}"</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+</xs:schema>

--- a/misc/config_tools/schema/datachecks.xsd
+++ b/misc/config_tools/schema/datachecks.xsd
@@ -16,6 +16,7 @@
       <xi:include href="checks/passthrough_devices.xsd" xpointer="xpointer(id('root')/*)" />
       <xi:include href="checks/virtio_devices.xsd" xpointer="xpointer(id('root')/*)" />
       <xi:include href="checks/vuart_config.xsd" xpointer="xpointer(id('root')/*)" />
+      <xi:include href="checks/ivsh_memory.xsd" xpointer="xpointer(id('root')/*)" />
 
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
The current code allow the same region name for same VM, it's an issue

This patch add an assert to check the above issue and report it.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@intel.com>