### PR TITLE
misc: config_tool: allow cpu sharing among standard VMs

### DIFF
--- a/misc/config_tools/schema/checks/cpu_assignment.xsd
+++ b/misc/config_tools/schema/checks/cpu_assignment.xsd
@@ -24,13 +24,6 @@
     </xs:annotation>
   </xs:assert>
 
-  <xs:assert test="every $pcpu in /acrn-config/vm[load_order = 'PRE_LAUNCHED_VM']//cpu_affinity//pcpu_id satisfies
-                   count(/acrn-config/vm[@id != $pcpu/ancestor::vm//companion_vmid ]//cpu_affinity[.//pcpu_id = $pcpu]) &lt;= 1">
-    <xs:annotation acrn:severity="error" acrn:report-on="//vm//cpu_affinity[.//pcpu_id = $pcpu]">
-      <xs:documentation>Physical CPU {$pcpu} is assigned to Pre-launched VM [{$pcpu/ancestor::vm/name}] and thus cannot be shared among multiple VMs. Look for, and probably remove, any affinity assignments to {$pcpu} in this VM's settings: {//vm[cpu_affinity//pcpu_id = $pcpu]/name}.</xs:documentation>
-    </xs:annotation>
-  </xs:assert>
-
   <xs:assert test="every $pcpu in /acrn-config/vm[vm_type = 'RTVM']//cpu_affinity//pcpu_id satisfies
                    count(/acrn-config/vm[@id != $pcpu/ancestor::vm//companion_vmid ]//cpu_affinity[.//pcpu_id = $pcpu]) &lt;= 1">
     <xs:annotation acrn:severity="error" acrn:report-on="//vm//cpu_affinity[.//pcpu_id = $pcpu]">


### PR DESCRIPTION
CPU sharing among standard Pre-launched VMs and Post-launched VMs are
allowed by design. Revert 4e2abfb4730 ('misc: configurator: add check
for uniqueness of cpus in Pre-launched VM')

Tracked-On: #7688
Signed-off-by: Qiang Zhang <qiang4.zhang@intel.com>