### PR TITLE
[release_3.0]ACRN: xHCI: Check the value of Ring Segment Size

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -1836,6 +1836,11 @@ pci_xhci_insert_event(struct pci_xhci_vdev *xdev,
 
 	erdp = rts->intrreg.erdp & ~0xF;
 	erst = &rts->erstba_p[rts->er_enq_seg];
+	if (erst->dwRingSegSize < 16 || erst->dwRingSegSize > 4096) {
+		UPRINTF(LDBG, "xHCI: ERSTSZ is not valiad: %u\n",
+				erst->dwRingSegSize);
+		return -EINVAL;
+	}
 	erdp_idx = (erdp - erst->qwRingSegBase) / sizeof(struct xhci_trb);
 
 	UPRINTF(LDBG, "insert event 0[%lx] 2[%x] 3[%x]\r\n"


### PR DESCRIPTION
Flow Table 6-95 from xHCI spec, Ring Segment Size defines
the number of TRBs supported by the ring segment, valid
values for this field are 16 to 4096.

Tracked-On: #6981
Signed-off-by: Liu Long <long.liu@intel.com>