### PR TITLE
misc: fix the conflict between S5 and LPC

### DIFF
--- a/misc/config_tools/static_allocators/intx.py
+++ b/misc/config_tools/static_allocators/intx.py
@@ -76,7 +76,7 @@ def alloc_vuart_connection_irqs(board_etree, scenario_etree, allocation_etree):
         # Allocate irq for S5 vuart
         if load_order != "SERVICE_VM":
             legacy_vuart_irq = alloc_irq(irq_list)
-            create_vuart_irq_node(allocation_etree, common.get_node("./@id", vm_node), load_order, str(vuart_id), legacy_vuart_irq)
+            create_vuart_irq_node(allocation_etree, common.get_node("./@id", vm_node), load_order, str(vuart_id), "0")
             vuart_id = vuart_id + 1
 
         vuart_connections = scenario_etree.xpath("//vuart_connection")

--- a/misc/config_tools/static_allocators/s5_vuart.py
+++ b/misc/config_tools/static_allocators/s5_vuart.py
@@ -8,7 +8,7 @@
 import sys
 import common, lib.error
 
-standard_uart_port = ['0x3F8', '0x2F8', '0x3E8', '0x2E8']
+standard_uart_port = ['0x3E8', '0x2E8']
 
 # The COM1 was used for console vUART, so we alloc io_port frome COM2~COM4
 service_port_list = list(range(0x9000, 0x9100, 8))


### PR DESCRIPTION
The current code use COM1 or COM2 for LPC and there is an conflict with
S5 feature.

This patch filter these COM Ports and fix the above issue.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@intel.com>