### PR TITLE
config tool:add schema check for UI name validation

### DIFF
--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -211,8 +211,8 @@ The size is a subset of the VM's total memory size specified on the Basic tab.</
 <xs:complexType name="VuartEndpointType">
   <xs:sequence>
     <xs:element name="vm_name" type="xs:string">
-      <xs:annotation acrn:title="Virtual UART port">
-        <xs:documentation>Virtual UART port</xs:documentation>
+      <xs:annotation acrn:title="vUART connection VM name">
+        <xs:documentation>vUART connection VM name</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="io_port" type="HexFormat">

--- a/misc/config_tools/schema/checks/ivsh_memory.xsd
+++ b/misc/config_tools/schema/checks/ivsh_memory.xsd
@@ -14,4 +14,11 @@
     </xs:annotation>
   </xs:assert>
 
+  <xs:assert test="every $NAME in /acrn-config//IVSHMEM_REGION//NAME satisfies
+                  not(/acrn-config//IVSHMEM_REGION//NAME = '')">
+    <xs:annotation acrn:severity="error" acrn:report-on="$NAME">
+      <xs:documentation>InterVM shared memory region name must be set </xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
 </xs:schema>

--- a/misc/config_tools/schema/checks/vuart_config.xsd
+++ b/misc/config_tools/schema/checks/vuart_config.xsd
@@ -36,4 +36,11 @@
     </xs:annotation>
   </xs:assert>
 
+  <xs:assert test="every $NAME in /acrn-config//vuart_connection//endpoint//vm_name satisfies
+                  not(/acrn-config//vuart_connection//endpoint//vm_name = '')">
+    <xs:annotation acrn:severity="error" acrn:report-on="$NAME">
+      <xs:documentation>VM name in "{$NAME/ancestor::vuart_connection/name}" must be set </xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
 </xs:schema>


### PR DESCRIPTION
ivshmem name and vuart connection vm name are required in UI, so
add the check in case user miss setting them.

Tracked-On: #7700
Signed-off-by: hangliu1 <hang1.liu@linux.intel.com>