### PR TITLE
config_tools: CAT is no longer unchecked when VCAT is unchecked

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/CAT.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/CAT.vue
@@ -289,8 +289,8 @@ export default {
               break;
             case 'VCAT_ENABLED':
               this.formDataProxy('SSRAM_ENABLED', 'n');
-              this.formDataProxy('RDT_ENABLED', data);
               if (data === 'y') {
+                this.formDataProxy('RDT_ENABLED', 'y');
                 this.formDataProxy('CDP_ENABLED', 'n');
               }
               break;


### PR DESCRIPTION
CAT is no longer unchecked when VCAT is unchecked

Tracked-On: #6691
Signed-off-by: Weiyi Feng <weiyix.feng@intel.com>