### PR TITLE
misc: fix the schema check error

### DIFF
--- a/misc/config_tools/schema/checks/rdt_support.xsd
+++ b/misc/config_tools/schema/checks/rdt_support.xsd
@@ -81,7 +81,11 @@
     </xs:annotation>
   </xs:assert>
 
-  <xs:assert test="not (//hv//RDT/RDT_ENABLED = 'y' and //hv//SSRAM/SSRAM_ENABLED = 'y')"/>
+  <xs:assert test="not (//hv//RDT/RDT_ENABLED = 'y' and //hv//SSRAM/SSRAM_ENABLED = 'y')">
+    <xs:annotation>
+      <xs:documentation>RDT_ENABLED and SSRAM_ENABLED can't both be enabled</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
 
   <xs:assert test="hv//SSRAM_ENABLED = 'n' or empty(vm[load_order ='PRE_LAUNCHED_VM' and vm_type='RTVM']) or
 		   every $cap in caches/cache[@level=3]/capability[@id='Software SRAM'] satisfies


### PR DESCRIPTION
The current code have not add annotation for RDT_ENABLED and
SSRAM_ENABLED check which cause a schema check error.

This patch add annotation and documentation to remind users.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@intel.com>