### PR TITLE
misc: configurator: Switch to basic form after switching VM or HV tabs

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -76,6 +76,7 @@
               :currentActiveVMID="activeVMID"
               :currentFormSchema="currentFormSchema"
               :currentFormData="currentFormData"
+              ref="ConfigForm"
 
               @deleteVM="deleteVM"
               @scenarioConfigFormDataUpdate="scenarioConfigFormDataUpdate"
@@ -215,6 +216,7 @@ export default {
     },
     switchTab(tabVMID) {
       this.activeVMID = tabVMID;
+      this.$refs.ConfigForm.currentFormMode = 'BasicConfigType'
       this.updateCurrentFormSchema()
       this.updateCurrentFormData()
     },


### PR DESCRIPTION
Switch to basic form after switching VM or HV tabs to make the basic
form default view.

Tracked-On: #7712
Signed-off-by: Qiang Zhang <qiang4.zhang@intel.com>