### PR TITLE
config_tools: clear schema files

### DIFF
--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -240,6 +240,8 @@ def clean_configurator_deb(version, build_dir):
     add_cmd_list(cmd_list, 'bash -c "find -name "build" -prune -exec rm -rf {} \;"', config_tools_path)
     add_cmd_list(cmd_list, 'bash -c "find -name "target" -prune -exec rm -rf {} \;"', config_tools_path)
     add_cmd_list(cmd_list, 'bash -c "rm -rf dist"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "rm -rf schema/sliced.xsd"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "rm -rf schema/allchecks.xsd"', config_tools_path)
     add_cmd_list(cmd_list, 'bash -c "python3 ./configurator/packages/configurator/thirdLib/manager.py clean"', config_tools_path)
     run_cmd_list(cmd_list)
     return


### PR DESCRIPTION
Clear schema files of config tools when 'make clean'.

Tracked-On: #7508
Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>