### PR TITLE
doc: parameterize hidden config option doc generation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,7 +13,10 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = "Project ACRN"
 BUILDDIR      ?= _build
 SOURCEDIR     = $(BUILDDIR)/rst
-LATEXMKOPTS   = "-silent -interaction=nonstopmode -f"
+LATEXMKOPTS   = -silent
+
+# should the config option doc show hidden config options?
+XSLTPARAM     ?= --stringparam showHidden 'n'
 
 # document publication assumes the folder structure is setup
 # with the acrn-hypervisor and projectacrn.github.io repos as
@@ -54,7 +57,7 @@ content:
 	$(Q)scripts/extract_content.py $(SOURCEDIR) misc
 	$(Q)mkdir -p $(SOURCEDIR)/misc/config_tools/schema
 	$(Q)rsync -rt ../misc/config_tools/schema/*.xsd $(SOURCEDIR)/misc/config_tools/schema
-	$(Q)xsltproc -xinclude ./scripts/configdoc.xsl $(SOURCEDIR)/misc/config_tools/schema/config.xsd > $(SOURCEDIR)/reference/configdoc.txt
+	$(Q)xsltproc $(XSLTPARAM) -xinclude ./scripts/configdoc.xsl $(SOURCEDIR)/misc/config_tools/schema/config.xsd > $(SOURCEDIR)/reference/configdoc.txt
 
 
 html: content doxy

--- a/doc/scripts/configdoc.xsl
+++ b/doc/scripts/configdoc.xsl
@@ -5,6 +5,8 @@
   <xsl:variable name="section_adornment" select="'#*=-%+@`'"/>
   <xsl:variable name="vLower" select="'abcdefghijklmnopqrstuvwxyz'"/>
   <xsl:variable name="vUpper" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+  <!-- Default is to not show hidden options (acrn:views='') overridded by passing - -paramstring showHidden 'y' to xsltproc -->
+  <xsl:param name="showHidden" select="n" />
   <!-- xslt script to autogenerate config option documentation -->
   <!-- Get things started with the ACRNConfigType element -->
   <xsl:template match="/xs:schema">
@@ -56,9 +58,9 @@
     <!-- Only visit elements having complex types. Those having simple types are
          described as an option -->
     <xsl:choose>
-      <xsl:when test="xs:annotation/@acrn:views=''">
         <!-- don't document elements if not viewable -->
-      </xsl:when>
+        <xsl:when test="xs:annotation/@acrn:views='' and $showHidden='n'">
+        </xsl:when>
       <xsl:when test="//xs:complexType[@name=$ty]">
         <!-- The section header -->
           <xsl:if test="$level &lt;= 4">
@@ -134,6 +136,9 @@
               <xsl:text>|icon-basic| |icon-advanced|</xsl:text>
             </xsl:when>
             <xsl:when test="xs:annotation/@acrn:views=''">
+              <xsl:text>|icon-not-available| </xsl:text>
+            </xsl:when>
+            <xsl:when test="$parent/xs:annotation/@acrn:views=''">
               <xsl:text>|icon-not-available| </xsl:text>
             </xsl:when>
             <xsl:otherwise>


### PR DESCRIPTION
Add a configuration parameter for the xsltproc processing to decide
whether to include hidden options.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>