### PR TITLE
misc: configurator: fix minor bug of IVSHMEM region name

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
@@ -194,7 +194,7 @@ export default {
   methods: {
     validateIvshrgName(value) {
       var regexp = new RegExp(this.IVSHMEMRegionType.properties.NAME.pattern);
-      return regexp.test(value);
+      return (value != null) && regexp.test(value);
     },
     validation(value) {
       return (value != null) && (value.length != 0);


### PR DESCRIPTION
IVSHMEM region name input value may be null after saving the scenario.
Add a null check to avoid marking empty input as correct.

Tracked-On: #7707
Signed-off-by: Yifan Liu <yifan1.liu@intel.com>