### PR TITLE
config tool: change vm_type to required field and hide in service vm UI

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -211,7 +211,14 @@ export default {
         }
       }
       if (this.currentFormData['load_order'] === 'SERVICE_VM') {
-        delete this.currentFormSchema.BasicConfigType.properties.vm_type
+        if (this.currentFormData.hasOwnProperty('vm_type')) {
+          delete this.schemas.ServiceVM.BasicConfigType.properties.vm_type
+        } else {
+          if (this.schemas.ServiceVM.BasicConfigType.properties.hasOwnProperty('vm_type') === false) {
+            this.schemas.ServiceVM.BasicConfigType.properties.vm_type =
+              {$ref: '#/definitions/BasicVMType', title: 'VM type', description: '<p>Select the VM type. A standard VM (<span class=…ial features for time-sensitive applications.</p>'}
+          }
+        }
       }
     },
     switchTab(tabVMID) {

--- a/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_launch_2user_vm.xml
@@ -90,6 +90,7 @@
   </vm>
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -117,6 +117,7 @@
   </vm>
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/cfl-k700-i7/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/cfl-k700-i7/shared_launch_6user_vm.xml
@@ -58,6 +58,7 @@
   </hv>
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/generic_board/hybrid_launch_2user_vm.xml
@@ -91,6 +91,7 @@
   </vm>
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/generic_board/hybrid_rt.xml
+++ b/misc/config_tools/data/generic_board/hybrid_rt.xml
@@ -111,6 +111,7 @@
   </vm>
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/generic_board/shared_launch_6user_vm.xml
@@ -58,6 +58,7 @@
   </hv>
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/hybrid_launch_2user_vm.xml
@@ -91,6 +91,7 @@
   </vm>
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/nuc11tnbi5/shared_launch_6user_vm.xml
@@ -58,6 +58,7 @@
   </hv>
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/qemu/shared.xml
+++ b/misc/config_tools/data/qemu/shared.xml
@@ -59,6 +59,7 @@
   </hv>
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/hybrid.xml
@@ -91,6 +91,7 @@
   </vm>
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/tgl-vecow-spc-7100-Corei7/shared_launch_2user_vm.xml
@@ -70,6 +70,7 @@
   </hv>
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -89,6 +89,7 @@
   </vm>
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1user_vm_waag.xml
@@ -117,6 +117,7 @@
   </vm>
   <vm id="1">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_hardrt.xml
@@ -58,6 +58,7 @@
   </hv>
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_vxworks.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_vxworks.xml
@@ -58,6 +58,7 @@
   </hv>
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_1user_vm_waag.xml
@@ -58,6 +58,7 @@
   </hv>
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_2user_vm.xml
@@ -58,6 +58,7 @@
   </hv>
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
+++ b/misc/config_tools/data/whl-ipc-i5/shared_launch_6user_vm.xml
@@ -58,6 +58,7 @@
   </hv>
   <vm id="0">
     <load_order>SERVICE_VM</load_order>
+    <vm_type>STANDARD_VM</vm_type>
     <name>ACRN_Service_VM</name>
     <os_config>
       <kern_type>KERNEL_BZIMAGE</kern_type>

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -305,7 +305,7 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
         <xs:documentation>Specify the name used to identify this VM. The VM name will be shown in the hypervisor console vm_list command.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="vm_type" type="VMType" minOccurs="0">
+    <xs:element name="vm_type" type="VMType">
       <xs:annotation acrn:title="VM type" acrn:views="basic">
         <xs:documentation>Select the VM type. A standard VM (``STANDARD_VM``) is for general-purpose applications, such as human-machine interface (HMI). A real-time VM (``RTVM``) offers special features for time-sensitive applications.</xs:documentation>
       </xs:annotation>


### PR DESCRIPTION
hide vm_type in UI for service vm, and change it to
required field, since lack of it in xml may lead to
wrong inference for vm severity.