### PR TITLE
doc: update VM types description to use DX-friendly title

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -307,7 +307,7 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
     </xs:element>
     <xs:element name="vm_type" type="VMType">
       <xs:annotation acrn:title="VM type" acrn:views="basic">
-        <xs:documentation>Select the VM type. A standard VM (``STANDARD_VM``) is for general-purpose applications, such as human-machine interface (HMI). A real-time VM (``RTVM``) offers special features for time-sensitive applications.</xs:documentation>
+        <xs:documentation>Select the VM type. A Standard VM is for general-purpose applications, such as human-machine interface (HMI). A Real-time VM offers special features for time-sensitive applications.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="console_vuart" type="ConsoleVuartConfiguration" default="None">


### PR DESCRIPTION
Missed a use of the XML element name instead of the DX-friendly title in
the option description.  (For those paying attention, the default value
shown in the description also uses the XML element name, but we don't
have a convenient way to turn that string into the corresponding
acrn:title value.

Tracked-On: #5692

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>