### PR TITLE
config_tools: add default value to 'vm_type'

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -305,7 +305,7 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
         <xs:documentation>Specify the name used to identify this VM. The VM name will be shown in the hypervisor console vm_list command.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="vm_type" type="VMType">
+    <xs:element name="vm_type" type="VMType" default="STANDARD_VM">
       <xs:annotation acrn:title="VM type" acrn:views="basic">
         <xs:documentation>Select the VM type. A Standard VM is for general-purpose applications, such as human-machine interface (HMI). A Real-time VM offers special features for time-sensitive applications.</xs:documentation>
       </xs:annotation>


### PR DESCRIPTION
Set 'STANDARD_VM' as default value for 'vm_type'.

Tracked-On: #7726
Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>