### PR TITLE
doc: add doc for required systemd services

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -695,6 +695,12 @@ The ACRN hypervisor boots the Ubuntu Service VM automatically.
 
       [  0.000000] Hypervisor detected: ACRN
 
+#. Start systemd service required by device model:
+
+   .. code-block:: bash
+
+      systemctl enable --now systemd-networkd
+
 .. _gsg-user-vm:
 
 .. rst-class:: numbered-step


### PR DESCRIPTION
"systemd-networkd" is required for acrn-dm to create bridge device.
Document it in GSG before acrn network deb package is ready.

Signed-off-by: Qiang Zhang <qiang4.zhang@intel.com>