### PR TITLE
Tweak scenario validation in the configurator

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/lib/acrn.ts
+++ b/misc/config_tools/configurator/packages/configurator/src/lib/acrn.ts
@@ -129,7 +129,8 @@ class Configurator {
         return this.readFile(path).then((fileContent) => {
             let syntactical_errors = this.pythonObject.validateScenarioStructure(fileContent);
             if (syntactical_errors !== "") {
-                throw Error("The file has broken structure.\n" + syntactical_errors);
+                throw Error("The loaded file does not look like a valid ACRN scenario XML.\n\n" +
+                    "If that file is used with ACRN 2.x, try upgrading it following the instructions at https://projectacrn.github.io/latest/tutorials/upgrading_configuration.html.\n");
             }
             return this.pythonObject.loadScenario(fileContent)
         })

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -183,7 +183,8 @@ export default {
     },
     scenarioUpdate(scenarioData) {
       let scenarioXMLData = this.scenarioToXML(scenarioData)
-      this.errors = configurator.pythonObject.validateScenario(this.board.content, scenarioXMLData)
+      let all_errors = configurator.pythonObject.validateScenario(this.board.content, scenarioXMLData)
+      this.errors = all_errors.semantic_errors
       this.scenario = scenarioData;
       this.showFlag = false;
       this.updateCurrentFormSchema()
@@ -428,9 +429,10 @@ export default {
           .then(() => {
             stepDone = 1
             console.log("validate settings...")
-            this.errors = configurator.pythonObject.validateScenario(this.board.content, scenarioXMLData)
+            let all_errors = configurator.pythonObject.validateScenario(this.board.content, scenarioXMLData)
+            this.errors = all_errors.semantic_errors
             // noinspection ExceptionCaughtLocallyJS
-            if (this.errors.length !== 0) {
+            if (all_errors.syntactic_errors.length !== 0 || all_errors.semantic_errors.length !== 0) {
               throw new Error("validation failed")
             }
             console.log("validation ok")

--- a/misc/config_tools/configurator/pyodide/validateScenario.py
+++ b/misc/config_tools/configurator/pyodide/validateScenario.py
@@ -27,11 +27,9 @@ def main(board, scenario):
         XMLLoadStage("board"),
         XMLLoadStage("scenario"),
         DefaultValuePopulatingStage(),
+        SyntacticValidationStage(), 
         SemanticValidationStage(),
     ]
-    #
-    # if is_debug:
-    #     stages.append(SyntacticValidationStage())
 
     pipeline.add_stages(stages)
     with TemporaryDirectory() as tmpdir:
@@ -50,8 +48,9 @@ def main(board, scenario):
         )
         pipeline.run(obj)
 
-        validate_result = obj.get("semantic_errors")
-        return convert_result(validate_result)
+        syntactic_errors = obj.get("syntactic_errors")
+        semantic_errors = obj.get("semantic_errors")
+        return convert_result({"syntactic_errors": syntactic_errors, "semantic_errors": semantic_errors})
 
 
 def test():

--- a/misc/config_tools/configurator/pyodide/validateScenarioStructure.py
+++ b/misc/config_tools/configurator/pyodide/validateScenarioStructure.py
@@ -11,7 +11,7 @@ from scenario_config.xml_loader import XMLLoadStage
 
 from .pyodide import (
     convert_result, write_temp_file,
-    nuc11_scenario, scenario_xml_schema_path, datachecks_xml_schema_path
+    nuc11_scenario, schema_dir
 )
 
 
@@ -34,7 +34,7 @@ def main(scenario):
 
             obj = PipelineObject(
                 scenario_path=scenario_file_path,
-                schema_path=scenario_xml_schema_path,
+                schema_path=schema_dir / 'scenario_structure.xsd',
                 datachecks_path=None
             )
             pipeline.run(obj)

--- a/misc/config_tools/schema/scenario_structure.xsd
+++ b/misc/config_tools/schema/scenario_structure.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <!-- This is a tailored version of the schema of scenario XML files and is used by the configurator to ensure files
+       from users have the basic structure of a valid scenario XML. We do not use the full-fledged schema here because
+       users are allowed to save a scenario XML with some data inconsistencies. -->
+  <xs:element name="acrn-config">
+    <xs:complexType>
+      <xs:all>
+        <xs:element name="hv">
+          <xs:complexType>
+            <xs:all>
+              <xs:any maxOccurs="unbounded" processContents="skip" />
+            </xs:all>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="vm" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:all>
+              <xs:element name="load_order" type="xs:string" />
+              <xs:any maxOccurs="unbounded" processContents="skip" />
+            </xs:all>
+            <xs:attribute name="id" type="xs:integer" />
+          </xs:complexType>
+        </xs:element>
+      </xs:all>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
This patch series makes the following changes to the scenario validation in the configurator.

* Validation of scenario XML on load is relaxed to check only the essential structure assumed by the configurator.
* Validation of scenario XML on save is strengthened to check both syntactic and semantic issues.