### PR TITLE
config_tools: update the hugepage algorithm

### DIFF
--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -93,7 +93,7 @@
   </xsl:variable>
   <xsl:variable name="hugepage_kernelstring">
     <xsl:if test="//board-data//processors//capability[@id='gbyte_pages']">
-      <xsl:value-of select="concat('hugepagesz=1G hugepages=', //allocation-data//vm[acrn:is-service-vm(load_order)]/hugepages/gb, ' hugepagesz=2M hugepages=', //allocation-data//vm[acrn:is-service-vm(load_order)]/hugepages/mb)" />
+      <xsl:value-of select="concat('hugepagesz=1G hugepages=', //allocation-data//vm[acrn:is-service-vm(load_order)]/hugepages/gb)" />
     </xsl:if>
   </xsl:variable>
   <xsl:value-of select="acrn:define('SERVICE_VM_ROOTFS', concat($quot, $sos_rootfs, ' ', $quot), '')" />


### PR DESCRIPTION
update the hugepages algorithm as the following steps.
1. calculate the total hugepages of service vm using the formula.
"total memory*0.98 - the memory consumed by pre-launched VMs - 5G
-300M*num(number of virtio gpu instance)".
2. calculate hugepage 1G based post-launched vm memory setting.
3. check if the memory configured in post launch VMs is not larger than
the total hugepages.

Compared with the previous version, this patch removes the 2M hugepage
and the correction value, also update the formula of total hugepage.

Tracked-On: #7301
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>