### PR TITLE
config_tools: fix a module resolving issue in elementpath overlay

### DIFF
--- a/misc/config_tools/configurator/pyodide/validateScenario.py
+++ b/misc/config_tools/configurator/pyodide/validateScenario.py
@@ -8,7 +8,7 @@ from scenario_config.default_populator import DefaultValuePopulatingStage
 from scenario_config.pipeline import PipelineObject, PipelineEngine
 from scenario_config.validator import ValidatorConstructionByFileStage, SemanticValidationStage, \
     SyntacticValidationStage
-from scenario_config.xml_loader import XMLLoadStage
+from scenario_config.xml_loader import LXMLLoadStage
 
 from .pyodide import (
     convert_result, write_temp_file,
@@ -22,12 +22,12 @@ def main(board, scenario):
     pipeline = PipelineEngine(["board_path", "scenario_path", "schema_path", "datachecks_path"])
     stages = [
         ValidatorConstructionByFileStage(),
-        XMLLoadStage("schema"),
+        LXMLLoadStage("schema"),
 
-        XMLLoadStage("board"),
-        XMLLoadStage("scenario"),
+        LXMLLoadStage("board"),
+        LXMLLoadStage("scenario"),
         DefaultValuePopulatingStage(),
-        SyntacticValidationStage(), 
+        SyntacticValidationStage(),
         SemanticValidationStage(),
     ]
 

--- a/misc/config_tools/library/__init__.py
+++ b/misc/config_tools/library/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2022 Intel Corporation.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Do Not Delete
+# This file be used in configurator's wasm python env

--- a/misc/config_tools/scenario_config/elementpath_overlay.py
+++ b/misc/config_tools/scenario_config/elementpath_overlay.py
@@ -6,11 +6,17 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+import sys, os
 from decimal import Decimal
 from copy import copy
 import operator
-import rdt
 import elementpath
+
+# Allow this script to find the library module at misc/config_tools/library.
+#
+# TODO: Reshuffle the module structure of the configuration toolset for clearer imports.
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+import library.rdt as rdt
 
 BaseParser = elementpath.XPath2Parser
 

--- a/misc/config_tools/scenario_config/validator.py
+++ b/misc/config_tools/scenario_config/validator.py
@@ -262,7 +262,6 @@ def validate_all(validation_pipeline, pipeline_obj, data_dir):
     return nr_all_errors
 
 def main(args):
-    from xml_loader import XMLLoadStage
     from lxml_loader import LXMLLoadStage
 
     validator_construction_pipeline = PipelineEngine(["schema_path", "datachecks_path"])
@@ -275,8 +274,8 @@ def main(args):
 
     validation_pipeline = PipelineEngine(["board_path", "scenario_path", "schema_etree", "validator"])
     validation_pipeline.add_stages([
-        XMLLoadStage("board"),
-        XMLLoadStage("scenario"),
+        LXMLLoadStage("board"),
+        LXMLLoadStage("scenario"),
         DefaultValuePopulatingStage(),
         SyntacticValidationStage(),
         SemanticValidationStage(),

--- a/misc/config_tools/schema/checks/rdt_support.xsd
+++ b/misc/config_tools/schema/checks/rdt_support.xsd
@@ -91,7 +91,7 @@ This error cannot be fixed by adjusting the configuration. Report a `GitHub issu
 
   <xs:assert test="every $needed in number-of-clos-id-needed(/acrn-config) satisfies
                    every $capacity in min(//caches/cache/capability[@id='CAT']/clos_number) satisfies
-                   $needed &lt; 0">
+                   $needed &lt; $capacity">
     <xs:annotation acrn:severity="error" acrn:report-on="/acrn-config/hv/CACHE_REGION">
       <xs:documentation>The current CAT configuration requires {string($needed)} CLOS IDs, which exceeds the capacity of the platform which supports {string($capacity)} at most.</xs:documentation>
     </xs:annotation>


### PR DESCRIPTION
The library module introduced by commit 2cd13026e ("misc: move the RDT
interface to common library") was put under the library/ directory which is
not by default searchable from elementpath_overlay. This patch works around
the issue by adding that path to sys.path.

Also fix a typo in the RDT checking assertion.

Tracked-On: #6690
Signed-off-by: Junjie Mao <junjie.mao@intel.com>