### PR TITLE
config_tools: fix the issue that fail to import scenario

### DIFF
--- a/misc/config_tools/configurator/pyodide/validateScenario.py
+++ b/misc/config_tools/configurator/pyodide/validateScenario.py
@@ -8,7 +8,7 @@ from scenario_config.default_populator import DefaultValuePopulatingStage
 from scenario_config.pipeline import PipelineObject, PipelineEngine
 from scenario_config.validator import ValidatorConstructionByFileStage, SemanticValidationStage, \
     SyntacticValidationStage
-from scenario_config.xml_loader import LXMLLoadStage
+from scenario_config.lxml_loader import LXMLLoadStage
 
 from .pyodide import (
     convert_result, write_temp_file,


### PR DESCRIPTION
fix the typo in validateScenario.py because it leads to
fail to import scenario xml.

Tracked-On: #6690
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>