### PR TITLE
misc: fix the secure coding style violations of tpm

### DIFF
--- a/devicemodel/hw/mmio/core.c
+++ b/devicemodel/hw/mmio/core.c
@@ -115,11 +115,11 @@ int create_pt_acpidev(char *opt)
  *
  * @pre (name != NULL) && (strlen(name) > 0)
  */
-int get_mmio_hpa_resource(char *name, uint64_t *res_start, uint64_t *res_size)
+bool get_mmio_hpa_resource(char *name, uint64_t *res_start, uint64_t *res_size)
 {
 	FILE *fp;
 	uint64_t start, end;
-	int found = false;
+	bool found = false;
 	char line[128];
 	char *cp;
 

--- a/devicemodel/hw/platform/tpm/tpm.c
+++ b/devicemodel/hw/platform/tpm/tpm.c
@@ -119,9 +119,10 @@ static int init_tpm2_pt(char *opts, struct mmio_dev *tpm2dev)
 	}
 
 	devopts = strdup(opts);
-	if (devopts != NULL) {
-		vtopts = strstr(devopts,",");
+	if (devopts == NULL) {
+		return -ENODEV;
 	}
+	vtopts = strstr(devopts,",");
 
 	/* Check whether user set the uid to identify same hid devices for
 	 * several instances.
@@ -131,7 +132,7 @@ static int init_tpm2_pt(char *opts, struct mmio_dev *tpm2dev)
 	}
 
 	/* parse /proc/iomem to find the address and size of tpm buffer */
-	if ((devopts != NULL) && (!get_mmio_hpa_resource(devopts, &tpm2_buffer_hpa, &tpm2_buffer_size))) {
+	if (!get_mmio_hpa_resource(devopts, &tpm2_buffer_hpa, &tpm2_buffer_size)) {
 		free(devopts);
 		return -ENODEV;
 	}

--- a/devicemodel/include/mmio_dev.h
+++ b/devicemodel/include/mmio_dev.h
@@ -27,7 +27,7 @@ struct acpi_dev_pt_ops {
 #define DEFINE_ACPI_PT_DEV(x) DATA_SET(acpi_dev_pt_ops_set, x);
 
 struct mmio_dev *get_mmiodev(char *name);
-int get_mmio_hpa_resource(char *name, uint64_t *res_start, uint64_t *res_size);
+bool get_mmio_hpa_resource(char *name, uint64_t *res_start, uint64_t *res_size);
 int get_more_acpi_dev_info(char *hid, uint32_t instance, struct acpi_dev_pt_ops *ops);
 void acpi_dev_write_dsdt(struct vmctx *ctx);
 


### PR DESCRIPTION
There is an secure coding style violations of tmp, this patch add some
NULL check to fix these violations.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>