### PR TITLE
config_tools: remove VMX and VT-d invalid BIOS check in acrn-board-inspector

### DIFF
--- a/debian/acrn-board-inspector/acrn-board-inspector
+++ b/debian/acrn-board-inspector/acrn-board-inspector
@@ -2,16 +2,4 @@
 # wrapper to call board_inspector.py
 
 modprobe msr
-IA32_FEATURE_CONTROL=0x3A
-
-if [ "$(($(rdmsr ${IA32_FEATURE_CONTROL}) & 0x6))" = "0" ]; then
-   echo "VMX is not enabled, update your BIOS settings" >&2
-   exit 1
-fi
-
-if [ ! -f /sys/firmware/acpi/tables/DMAR ]; then
-   echo "Cannot find ACPI DMAR table. Is VT-d enabled/supported?" >&2
-   exit 1
-fi
-
 python3 -m acrn_board_inspector.board_inspector "$@"


### PR DESCRIPTION
this patch removes VMX and VT-d invalid BIOS setting check in
acrn-board-inspector because the board inspector tool also adds
these checks (please refer to PR #7216) and may it's possible for user
to get the wrong information by these two check in acrn-board-inspector.

so we remove the repeated check in acrn-board-inspector.

Tracked-On: #6689
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>