### PR TITLE
config_tools: fix the issue Service VM type is updated by UI automatically

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -211,16 +211,6 @@ export default {
           this.currentFormData = this.scenario.vm[i]
         }
       }
-      if (this.currentFormData['load_order'] === 'SERVICE_VM') {
-        if (this.currentFormData.hasOwnProperty('vm_type')) {
-          delete this.schemas.ServiceVM.BasicConfigType.properties.vm_type
-        } else {
-          if (this.schemas.ServiceVM.BasicConfigType.properties.hasOwnProperty('vm_type') === false) {
-            this.schemas.ServiceVM.BasicConfigType.properties.vm_type =
-              {$ref: '#/definitions/BasicVMType', title: 'VM type', description: '<p>Select the VM type. A standard VM (<span class=…ial features for time-sensitive applications.</p>'}
-          }
-        }
-      }
     },
     switchTab(tabVMID) {
       this.activeVMID = tabVMID;

--- a/misc/config_tools/scenario_config/jsonschema/converter.py
+++ b/misc/config_tools/scenario_config/jsonschema/converter.py
@@ -189,15 +189,19 @@ class XS2JS:
             if 'xs:enumeration' in restriction:
                 type_func = {"string": str, "integer": int}.get(js_st['type'], str)
                 # enum
+                enum_elements = restriction['xs:enumeration']
+                if not isinstance(enum_elements, list):
+                    enum_elements = [enum_elements]
+
                 enum = []
-                for enum_element in restriction['xs:enumeration']:
+                for enum_element in enum_elements:
                     enum.append(type_func(enum_element['@value']))
                 js_st["enum"] = enum
 
                 # enumNames
-                if enum and '@acrn:title' in restriction['xs:enumeration'][0].get('xs:annotation', {}):
+                if enum and '@acrn:title' in enum_elements[0].get('xs:annotation', {}):
                     enum_names = []
-                    for enum_element in restriction['xs:enumeration']:
+                    for enum_element in enum_elements:
                         if 'xs:annotation' in enum_element and '@acrn:title' in enum_element.get('xs:annotation', {}):
                             enum_names.append(enum_element['xs:annotation']['@acrn:title'])
                         else:

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -22,13 +22,13 @@
   <xs:annotation>
     <xs:documentation>Current supported VM types are:
 
-- ``Real-time`` for time-sensitive applications.
+- ``Real-time`` for time-sensitive applications (not applicable to the service VM).
 - ``Standard`` for general-purpose applications, such as human-machine interface (HMI).
 </xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
-    <xs:enumeration value="RTVM">
-      <xs:annotation acrn:title="Real-time" />
+    <xs:enumeration value="RTVM" >
+      <xs:annotation acrn:title="Real-time" acrn:applicable-vms="pre-launched, post-launched" />
     </xs:enumeration>
     <xs:enumeration value="STANDARD_VM">
       <xs:annotation acrn:title="Standard" />


### PR DESCRIPTION
Currently, if I update Pre-Launched VM type to real-time, select PCPU ID and
enable Real-time vCPU, then we update the name of sevice VM, finally, click the save button.
we will see the type of service vm is updated to RTVM. It is unexpected.

So this patch removes the logic of hiding service VM type, and only allows user
selecting Standard VM type to fix the issue that the service vm type is updated
by UI automatically.

Tracked-On: #6690
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>