### PR TITLE
doc: Fix typo in getting-started guide

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -154,7 +154,7 @@ To set up the ACRN build environment on the development computer:
 
    .. code-block:: bash
 
-      sudo pip3 install lxml xmlschema defusedxml tqbm
+      sudo pip3 install lxml xmlschema defusedxml tqdm
 
 #. Create a working directory:
 


### PR DESCRIPTION
Fix the typo (tqbm -> tqdm) in the getting-started guide.

Tracked-On: #7508
Signed-off-by: Ameya Palande <2ameya@gmail.com>