### PR TITLE
doc: update GSG to use sudo with systemctl command

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -695,13 +695,13 @@ The ACRN hypervisor boots the Ubuntu Service VM automatically.
 
       [  0.000000] Hypervisor detected: ACRN
 
-#. Start the ServiceVM's system daemon for managing network configurations,
-   so the Device Model can create a bridge device that provides User VMs with
+#. Enable and start the Service VM's system daemon for managing network configurations,
+   so the Device Model can create a bridge device (acrn-br0) that provides User VMs with
    wired network access:
 
    .. code-block:: bash
 
-      systemctl enable --now systemd-networkd
+      sudo systemctl enable --now systemd-networkd
 
 .. _gsg-user-vm:
 


### PR DESCRIPTION
systemctl won't run as a normal Linux user, requires sudo

Also augment the description information

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>