### PR TITLE
FIXME: packaging: generate a grub entry for shared scenario by default

### DIFF
--- a/misc/packaging/acrn-hypervisor.postinst
+++ b/misc/packaging/acrn-hypervisor.postinst
@@ -33,23 +33,7 @@ else
 fi
 kernelimg="module2 $service_vm_kernel Linux_bzImage"
 
-if [ $SCENARIO == shared ];then
-    cat>"${filename}"<<EOF
-#!/bin/sh
-exec tail -n +3 \$0
-menuentry 'ACRN multiboot2 ' --id ACRN_deb_multiboot2 {
-    load_video
-    insmod gzio
-    insmod part_gpt
-    insmod ext2
-    search --no-floppy --fs-uuid  --set $uuid
-multiboot2 $ACRNBIN root=PARTUUID=$partuuid
-$kernelimg
-
-}
-
-EOF
-elif [ $SCENARIO == hybrid ];then
+if [ $SCENARIO == hybrid ];then
     echo -e "\E[32m Please put zephyr64.elf in the /boot/ directory"
     tput sgr0
     cat>"${filename}"<<EOF
@@ -102,6 +86,22 @@ multiboot2 $ACRNBIN root=PARTUUID=$partuuid
 $kernelimg
 module2 /boot/ACPI_VM0.bin ACPI_VM0
 module2 /boot/ACPI_VM1.bin ACPI_VM1
+}
+
+EOF
+else
+    cat>"${filename}"<<EOF
+#!/bin/sh
+exec tail -n +3 \$0
+menuentry 'ACRN multiboot2 ' --id ACRN_deb_multiboot2 {
+    load_video
+    insmod gzio
+    insmod part_gpt
+    insmod ext2
+    search --no-floppy --fs-uuid  --set $uuid
+multiboot2 $ACRNBIN root=PARTUUID=$partuuid
+$kernelimg
+
 }
 
 EOF


### PR DESCRIPTION
The debian package created by misc/packaging today is supposed to add an
entry into grub.cfg for the installed hypervisor. Unfortunately, that is
done only when the given scenario XML is named shared, partitioned, hybrid
or hybrid_rt. In the rest of the cases, no entry is added while the default
boot option is still changed to ACRN_deb_multiboot2 which does not exist.

As a short-term workaround, this patch adjusts the branching structure of
the postinst script so that a grub entry is always generated. The entry for
shared scenario is chosen as the default if the scenario XML has a name
other than partitioned, hybrid or hybrid_rt.

This is a workaround only for release 3.0. In future releases we should
migrate to the dpkg-buildpackage using the scripts under debian/.

Tracked-On: #7778
Signed-off-by: Junjie Mao <junjie.mao@intel.com>