### PR TITLE
misc: set the communication vUART default type to PCI

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/VUART.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/VUART.vue
@@ -219,7 +219,7 @@ export default {
       }
       this.defaultVal.splice(index + 1, 0, {
         "name": "Connection_" + this.defaultVal.length,
-        "type": "legacy",
+        "type": "pci",
         "endpoint": [
           {
             "vm_name": "",

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -235,7 +235,7 @@ The size is a subset of the VM's total memory size specified on the Basic tab.</
         <xs:documentation>Specify the vUART name.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="type" type="VuartType" default="legacy">
+    <xs:element name="type" type="VuartType" default="pci">
       <xs:annotation acrn:title="vUART Type">
         <xs:documentation>Select the communication virtual UART (vUART) type.</xs:documentation>
       </xs:annotation>


### PR DESCRIPTION
The current code use the legacy as the default type of communication
vUART, these were only 4 standard vUART ports, others should config by
the /etc/serial.conf, so this patch change the default type to PCI
which could be used without config files.

Tracked-On: #6690
Signed-off-by: Chenli Wei chenli.wei@linux.intel.com