### PR TITLE
Mark CACHE_REGION as hidden (views="")

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -285,7 +285,7 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="CACHE_REGION" type="CacheRegionType" minOccurs="0">
-      <xs:annotation acrn:views="advanced">
+      <xs:annotation acrn:views="">
         <xs:documentation>Specify the cache setting.</xs:documentation>
       </xs:annotation>
     </xs:element>


### PR DESCRIPTION
CACHE_REGION is removed from the configurator interface but is still
showing in the generated documentation because the views="advanced" was
there.  Make that views="" to remove it from the UI and documentation.

Tracked-On: #5692

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>