### PR TITLE
misc: add assert to check the missing of CLOS MASK

### DIFF
--- a/misc/config_tools/schema/checks/rdt_support.xsd
+++ b/misc/config_tools/schema/checks/rdt_support.xsd
@@ -53,4 +53,13 @@ This error cannot be fixed by adjusting the configuration. Report a `GitHub issu
     </xs:annotation>
   </xs:assert>
 
+  <xs:assert test="every $vm_name in //vm/name satisfies
+                  if (//RDT_ENABLED = 'y')
+                  then count(//POLICY/VM[text() = $vm_name]) > 0
+                  else true()">
+    <xs:annotation acrn:severity="error" acrn:report-on="/acrn-config/hv/CACHE_REGION">
+      <xs:documentation>Need config the CLOS MASK for VM '{$vm_name}''.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
 </xs:schema>


### PR DESCRIPTION
The current UI there is an issue which have not sync and save the VMs
to RDT element, these issue will cause the missing of num_pclosids and
the HV can't start.

This patch add assert to check the the missing of CLOS MASK.
The UI issue will be fix by another patch.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>