### PR TITLE
config-tools: fix assertions against scenario XML

### DIFF
--- a/misc/config_tools/schema/checks/cpu_assignment.xsd
+++ b/misc/config_tools/schema/checks/cpu_assignment.xsd
@@ -26,8 +26,8 @@
   </xs:assert>
 
   <xs:assert test="every $vm in /acrn-config/vm[load_order != 'SERVICE_VM'] satisfies
-	  count(/acrn-config/vm/cpu_affinity/pcpu/pcpu_id) > 0">
-  <xs:annotation acrn:severity="error" acrn:report-on="//vm//cpu_affinity/pcpu">
+                   count($vm/cpu_affinity/pcpu[pcpu_id != '']) > 0">
+  <xs:annotation acrn:severity="error" acrn:report-on="$vm/cpu_affinity">
       <xs:documentation>Assign at least one physical CPU affinity (pCPU ID) for VM "{$vm/name}".</xs:documentation>
     </xs:annotation>
   </xs:assert>

--- a/misc/config_tools/schema/checks/rdt_support.xsd
+++ b/misc/config_tools/schema/checks/rdt_support.xsd
@@ -53,13 +53,4 @@ This error cannot be fixed by adjusting the configuration. Report a `GitHub issu
     </xs:annotation>
   </xs:assert>
 
-  <xs:assert test="every $vm_name in //vm/name satisfies
-                  if (//RDT_ENABLED = 'y')
-                  then count(//POLICY/VM[text() = $vm_name]) > 0
-                  else true()">
-    <xs:annotation acrn:severity="error" acrn:report-on="/acrn-config/hv/CACHE_REGION">
-      <xs:documentation>Need config the CLOS MASK for VM '{$vm_name}''.</xs:documentation>
-    </xs:annotation>
-  </xs:assert>
-
 </xs:schema>


### PR DESCRIPTION
This patch fixes the following issues in the existing scenario schema
assertions:

  1. The assertion that ensures the existence of pCPU affinity in all
     pre- and post-launched VMs does not count the pCPU settings under a
     VM properly.

  2. The assertion that ensures the presence of CAT settings of a defined
     VM is no longer needed as it was originally designed to capture
     configurator issues.

Tracked-On: #6690
Signed-off-by: Junjie Mao <junjie.mao@intel.com>