### PR TITLE
ACRN:DM: Free virtio_vsock struct resource in deinit function

### DIFF
--- a/devicemodel/hw/pci/virtio/vhost_vsock.c
+++ b/devicemodel/hw/pci/virtio/vhost_vsock.c
@@ -322,6 +322,7 @@ virtio_vhost_vsock_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		if (vsock->vhost_vsock)
 			vhost_vsock_deinit(vsock->vhost_vsock);
 		pr_dbg("%s: done\n", __func__);
+		free(vsock);
 	} else
 		pr_err("%s: NULL.\n", __func__);
 }


### PR DESCRIPTION
Free the virtio_vsock struct resource in virtio vsock deinit function
in case memory leak.

Tracked-On: #7759
Signed-off-by: Liu Long <long.liu@linux.intel.com>