### PR TITLE
Update Debian control file to add missing dependencies.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,9 @@ Build-Depends:
    python3-lxml,
    python3-defusedxml,
    python3-xmlschema (>= 1.10.0),
-   python3-elementpath (>= 2.5.0)
+   python3-elementpath (>= 2.5.0),
+   python3-requests,
+   python3-tqdm 
 Standards-Version: 4.3.0
 Homepage: https://projectacrn.org/
 Vcs-Browser: https://github.com/projectacrn/acrn-hypervisor
@@ -144,6 +146,7 @@ Depends:
    cpuid,
    msr-tools,
    pciutils,
+   usbutils,
    dmidecode,
    ${misc:Depends},
    ${python3:Depends},


### PR DESCRIPTION
Tracked-On:https://github.com/projectacrn/acrn-hypervisor/issues/6688
Some Debian dependencies are currently missing in the `/debian/control` file.  This change adds these missing dependencies:

**Source: acrn-hypervisor**
**Build-Depends:**
- python3-requests
- python3-tqdm
 
**Package: python3-acrn-board-inspector**
**Depends:**
- usbutils


Note: These changes should be part of the ACRN 3.0 release. Should I open a similar PR to the `release_3.0` branch?
