### PR TITLE
acrn_config: update text when loading the Configurator

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/index.html
+++ b/misc/config_tools/configurator/packages/configurator/index.html
@@ -18,7 +18,7 @@
                      style="height: 49px;padding-right: 1.5rem;cursor: pointer"/>
                 Loading...
             </text>
-            <text style="font-size:24px;display: block">Please wait for 5 seconds~</text>
+            <text style="font-size:24px;display: block">Loading the configurator can take a few seconds.</text>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Update the text that shows up when loading the ACRN Configurator.

Tracked-On: #6690
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>
Co-authored-by: David Kinder <david.b.kinder@intel.com>