### PR TITLE
Release_3.0:Update Debian control file to add missing dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,6 +35,8 @@ Build-Depends:
    python3-defusedxml,
    python3-xmlschema (>= 1.10.0),
    python3-elementpath (>= 2.5.0)
+   python3-requests,
+   python3-tqdm
 Standards-Version: 4.3.0
 Homepage: https://projectacrn.org/
 Vcs-Browser: https://github.com/projectacrn/acrn-hypervisor
@@ -144,6 +146,7 @@ Depends:
    cpuid,
    msr-tools,
    pciutils,
+   usbutils,
    dmidecode,
    ${misc:Depends},
    ${python3:Depends},


### PR DESCRIPTION
Some Debian dependencies are currently missing in the /debian/control file. This change adds these missing dependencies:

Source: acrn-hypervisor
Build-Depends:

python3-requests
python3-tqdm
Package: python3-acrn-board-inspector
Depends:

usbutils

Signed-off-by: wenlingz <wenling.zhang@intel.com>