### PR TITLE
config_tools: mark os_config item as required in scenario XML

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -406,7 +406,7 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
         <xs:documentation>Specify the companion VM id of this VM.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="os_config" type="OSConfigurations" minOccurs="0">
+    <xs:element name="os_config" type="OSConfigurations">
       <xs:annotation acrn:title="OS Configuration" acrn:applicable-vms="pre-launched, service-vm" acrn:views="basic">
         <xs:documentation>General information for host kernel, boot
 argument and memory.</xs:documentation>


### PR DESCRIPTION
Following the same logic of commit 59c7077e2 ("config_tools: remove
minOccurs from items that have default values"), this patch marks the
config item os_config, which is a collection of guest OS settings, as
required since subitems of it either have default values or are optional.

Tracked-On: #6690
Signed-off-by: Junjie Mao <junjie.mao@intel.com>