### PR TITLE
Remove "All Rights Reserved" string from license header

### DIFF
--- a/misc/config_tools/board_inspector/extractors/95-usb.py
+++ b/misc/config_tools/board_inspector/extractors/95-usb.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Intel Corporation. All rights reserved.
+# Copyright (C) 2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #


### PR DESCRIPTION
One had escaped from the global cleaning that commit 8b16be918 did.

Tracked-On: #7254
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>