### PR TITLE
doc: update acrn-kernel repo tag

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -155,9 +155,7 @@ To set up the ACRN build environment on the development computer:
       make clean && make iasl
       sudo cp ./generate/unix/bin/iasl /usr/sbin
 
-#. Get the ACRN hypervisor and kernel source code. (Because the ``acrn-kernel`` repo
-   has a lot of Linux kernel history, you can clone the relevant release branch
-   with minimal history, as shown here.)
+#. Get the ACRN hypervisor and kernel source code.
 
    .. code-block:: bash
 
@@ -167,7 +165,9 @@ To set up the ACRN build environment on the development computer:
       git checkout v3.0
 
       cd ..
-      git clone --depth 1 --branch release_3.0 https://github.com/projectacrn/acrn-kernel.git
+      git clone https://github.com/projectacrn/acrn-kernel.git
+      cd acrn-kernel
+      git checkout acrn-v3.0
 
 .. _gsg-board-setup:
 

--- a/doc/tutorials/acrn_on_qemu.rst
+++ b/doc/tutorials/acrn_on_qemu.rst
@@ -12,7 +12,7 @@ configuration.
 This setup was tested with the following configuration:
 
 - ACRN hypervisor: ``v3.0`` tag
-- ACRN kernel: ``v3.0`` tag
+- ACRN kernel: ``acrn-v3.0`` tag
 - QEMU emulator version: 4.2.1
 - Host OS: Ubuntu 20.04
 - Service VM/User VM OS: Ubuntu 20.04
@@ -175,9 +175,9 @@ Install ACRN Hypervisor
       sudo cp build/hypervisor/acrn.32.out /boot
 
 #. Clone and configure the Service VM kernel repository following the
-   instructions in the :ref:`gsg` and using the ``v3.0`` tag. The User VM (L2
+   instructions in the :ref:`gsg` and using the ``acrn-v3.0`` tag. The User VM (L2
    guest) uses the ``virtio-blk`` driver to mount the rootfs. This driver is
-   included in the default kernel configuration as of the ``v3.0`` tag.
+   included in the default kernel configuration as of the ``acrn-v3.0`` tag.
 
 #. Update GRUB to boot the ACRN hypervisor and load the Service VM kernel.
    Append the following configuration to the :file:`/etc/grub.d/40_custom`.


### PR DESCRIPTION
acrn-kernel tag (for v3.0 hypervisor) should be acrn-v3.0

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>