### PR TITLE
dm: virtio-console: change STDIO BE attribute

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -746,6 +746,7 @@ virtio_console_config_backend(struct virtio_console_backend *be)
 		saved_tio = tio;
 		cfmakeraw(&tio);
 		tio.c_cflag |= CLOCAL;
+		tio.c_oflag |= OPOST;
 		tcsetattr(fd, TCSANOW, &tio);
 
 		if (be->be_type == VIRTIO_CONSOLE_BE_STDIO) {


### PR DESCRIPTION
Fix the log format problem in devicemodel when using virtio-console with
'stdio' configuration.
In virtio-console, it will change the STDIO's attributes, and will case
the log message after that not align.
e.g:
	for (i=0; i<3; i++)
		printf('test\n');

	The original output would be like this:

	test
	    test
	        test

	After add 'OPOST' to oflag of STDIO, the output would be like this:

	test
	test
	test

	(OPOST - Enable implementation-defined output processing)

Tracked-On: #7860
Signed-off-by: Conghui <conghui.chen@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>