### PR TITLE
config_tools: hide required checkbox's label

### DIFF
--- a/misc/config_tools/configurator/packages/vue-json-schema-form/vue3/vue3-core/src/components/Widget.js
+++ b/misc/config_tools/configurator/packages/vue-json-schema-form/vue3/vue3-core/src/components/Widget.js
@@ -291,7 +291,7 @@ export default {
                         label: () => h('span', {
                             class: {
                                 genFormLabel: true,
-                                genFormItemRequired: props.required,
+                                genFormItemRequired: props.required && props.schema['ui:widget'] !== 'b-form-checkbox' && !props.uiProps.enumOptions,
                             },
                         }, [
                             ...miniDescriptionVNode ? [miniDescriptionVNode] : [],


### PR DESCRIPTION
Required fields with a checkbox will potentially cause confusion.
So hide the label when display a checkbox.

Tracked-On: #7864
Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>