### PR TITLE
misc: refine the assert of duplicate IO port

### DIFF
--- a/misc/config_tools/schema/checks/vuart_config.xsd
+++ b/misc/config_tools/schema/checks/vuart_config.xsd
@@ -14,7 +14,7 @@
     </xs:annotation>
   </xs:assert>
 
-  <xs:assert test="every $io_port in /acrn-config//endpoint/io_port satisfies
+  <xs:assert test="every $io_port in /acrn-config//endpoint[vm_name != '']/io_port satisfies
                    count(//endpoint[./vm_name=$io_port/ancestor::endpoint/vm_name and io_port=$io_port]) = 1">
     <xs:annotation acrn:severity="error" acrn:report-on="$io_port">
       <xs:documentation>VM "{$io_port/ancestor::endpoint/vm_name}" may not duplicate use of port "{$io_port}."</xs:documentation>


### PR DESCRIPTION
The current code judges an empty vm_name as a normal vm_name and assert
two endpoints with null name use the same IO port.

There was another which check wether the vm_name of endpoint is null, so
this patch break the assert if get null vm_name.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>