### PR TITLE
doc: elementpath version must be 2.5.0 in the GSG

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -135,7 +135,7 @@ To set up the ACRN build environment on the development computer:
 
    .. code-block:: bash
 
-      sudo pip3 install "elementpath<=2.5.0" lxml xmlschema defusedxml tqdm
+      sudo pip3 install "elementpath==2.5.0" lxml xmlschema defusedxml tqdm
 
 #. Create a working directory:
 


### PR DESCRIPTION
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>