### PR TITLE
config-tools: refine memory allocation for pre-launch vm

### DIFF
--- a/misc/config_tools/static_allocators/memory_allocator.py
+++ b/misc/config_tools/static_allocators/memory_allocator.py
@@ -84,7 +84,7 @@ def alloc_hpa_region(ram_range_info, mem_info_list, vm_node_index_list):
                 if hpa_start != 0:
                     if mem_start < hpa_start and mem_start + mem_size > hpa_start + hpa_size:
                         ram_range_info[mem_start] = hpa_start - mem_start
-                        ram_range_info[hpa_start - mem_start] = mem_start + mem_size - hpa_start - hpa_size
+                        ram_range_info[hpa_start + hpa_size] = mem_start + mem_size - hpa_start - hpa_size
                     elif mem_start == hpa_start and mem_start + mem_size > hpa_start + hpa_size:
                         del ram_range_info[mem_start]
                         ram_range_info[hpa_start + hpa_size] = mem_start + mem_size - hpa_start - hpa_size


### PR DESCRIPTION
Fixed a logic error in one line of code in
misc/config_tools/static_allocators/memory_allocator.py.

Tracked-On: #7838
Signed-off-by: Ziheng Li <ziheng.li@intel.com>