### PR TITLE
hv: Change sched_event back to boolean-based implementation

### DIFF
--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -133,12 +133,6 @@ void vcpu_make_request(struct acrn_vcpu *vcpu, uint16_t eventid)
 	kick_vcpu(vcpu);
 }
 
-/* Return true if an unhandled request is cancelled, false otherwise. */
-bool vcpu_try_cancel_request(struct acrn_vcpu *vcpu, uint16_t eventid)
-{
-	return bitmap_test_and_clear_lock(eventid, &vcpu->arch.pending_req);
-}
-
 /*
  * @retval true when INT is injected to guest.
  * @retval false when otherwise

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -438,6 +438,7 @@ static int32_t wbinvd_vmexit_handler(struct acrn_vcpu *vcpu)
 		if (is_rt_vm(vcpu->vm)) {
 			walk_ept_table(vcpu->vm, ept_flush_leaf_page);
 		} else {
+			spinlock_obtain(&vcpu->vm->wbinvd_lock);
 			/* Pause other vcpus and let them wait for the wbinvd completion */
 			foreach_vcpu(i, vcpu->vm, other) {
 				if (other != vcpu) {
@@ -452,6 +453,7 @@ static int32_t wbinvd_vmexit_handler(struct acrn_vcpu *vcpu)
 					signal_event(&other->events[VCPU_EVENT_SYNC_WBINVD]);
 				}
 			}
+			spinlock_release(&vcpu->vm->wbinvd_lock);
 		}
 	}
 

--- a/hypervisor/include/arch/x86/asm/guest/virq.h
+++ b/hypervisor/include/arch/x86/asm/guest/virq.h
@@ -103,7 +103,6 @@ void vcpu_inject_ud(struct acrn_vcpu *vcpu);
  */
 void vcpu_inject_ss(struct acrn_vcpu *vcpu);
 void vcpu_make_request(struct acrn_vcpu *vcpu, uint16_t eventid);
-bool vcpu_try_cancel_request(struct acrn_vcpu *vcpu, uint16_t eventid);
 
 /*
  * @pre vcpu != NULL

--- a/hypervisor/include/arch/x86/asm/guest/vm.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm.h
@@ -149,6 +149,7 @@ struct acrn_vm {
 	 * the initialization depends on the clear BSS section
 	 */
 	spinlock_t vm_state_lock;
+	spinlock_t wbinvd_lock;		/* Spin-lock used to serialize wbinvd emulation */
 	spinlock_t vlapic_mode_lock;	/* Spin-lock used to protect vlapic_mode modifications for a VM */
 	spinlock_t ept_lock;	/* Spin-lock used to protect ept add/modify/remove for a VM */
 	spinlock_t emul_mmio_lock;	/* Used to protect emulation mmio_node concurrent access for a VM */

--- a/hypervisor/include/common/event.h
+++ b/hypervisor/include/common/event.h
@@ -4,7 +4,7 @@
 
 struct sched_event {
 	spinlock_t lock;
-	int8_t nqueued;
+	bool set;
 	struct thread_object* waiting_thread;
 };
 


### PR DESCRIPTION
    Commit d575edf79a9b8dcde16574e28c213be7013470c7 changes the internal
    implementation of wait_event and signal_event to use a counter instead
    of a boolean value.
    
    The background was:
    ACRN utilizes vcpu_make_request and signal_event pair to shoot down
    other vcpus and let them wait for signals. vcpu_make_request eventually
    leads to target vcpu calling wait_event.
    
    However vcpu_make_request/signal_event pair was not thread-safe,
    and concurrent calls of this pair of API could lead to problems.
    One such example is the concurrent wbinvd emulation, where vcpus may
    concurrently issue vcpu_make_request/signal_event to synchronize wbinvd
    emulation.
    
    d575edf commit uses a counter in internal implementation of
    wait_event/signal_event to avoid data races.
    
    However by using a counter, the wait/signal pair now carries semantics of
    semaphores instead of events. Semaphores require caller to carefully
    plan their calls instead of multiply signaling any number of times to the same
    event, which deviates from the original "event" semantics.
    
    This patch changes the API implementation back to boolean-based, and
    re-resolve the issue of concurrent wbinvd in next patch.
    
    This also partially reverts commit 10963b04d127c3a321b30467b986f13cbd09db66,
    which was introduced because of the d575edf.