### PR TITLE
Update copyright year range in code headers

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: acrn-hypervisor
 Source: https://github.com/projectacrn/acrn-hypervisor
 
 Files: *
-Copyright: 2017-2018, Project ACRN
+Copyright: 2017-2022, Project ACRN
 License: BSD-3-Clause
 
 Files: debian/*

--- a/devicemodel/arch/x86/power_button.c
+++ b/devicemodel/arch/x86/power_button.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/core/cmd_monitor/cmd_monitor.c
+++ b/devicemodel/core/cmd_monitor/cmd_monitor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Intel Corporation
+ * Copyright (C) 2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/devicemodel/core/cmd_monitor/command.c
+++ b/devicemodel/core/cmd_monitor/command.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Intel Corporation
+ * Copyright (C) 2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/devicemodel/core/cmd_monitor/command.h
+++ b/devicemodel/core/cmd_monitor/command.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Intel Corporation
+ * Copyright (C) 2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _COMMAND_H_

--- a/devicemodel/core/cmd_monitor/command_handler.c
+++ b/devicemodel/core/cmd_monitor/command_handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Intel Corporation
+ * Copyright (C) 2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <stdio.h>

--- a/devicemodel/core/cmd_monitor/command_handler.h
+++ b/devicemodel/core/cmd_monitor/command_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Intel Corporation
+ * Copyright (C) 2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _COMMAND_HANDLER_H_

--- a/devicemodel/core/cmd_monitor/socket.c
+++ b/devicemodel/core/cmd_monitor/socket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Intel Corporation
+ * Copyright (C) 2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/devicemodel/core/cmd_monitor/socket.h
+++ b/devicemodel/core/cmd_monitor/socket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Intel Corporation
+ * Copyright (C) 2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _SOCKET_H_

--- a/devicemodel/core/hugetlb.c
+++ b/devicemodel/core/hugetlb.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/core/monitor.c
+++ b/devicemodel/core/monitor.c
@@ -2,7 +2,7 @@
  * Project Acrn
  * Acrn-dm-monitor
  *
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/core/pm.c
+++ b/devicemodel/core/pm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/devicemodel/core/pm_vuart.c
+++ b/devicemodel/core/pm_vuart.c
@@ -2,7 +2,7 @@
  * Project Acrn
  * Acrn-dm: pm-vuart
  *
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/core/sw_load_bzimage.c
+++ b/devicemodel/core/sw_load_bzimage.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/core/sw_load_elf.c
+++ b/devicemodel/core/sw_load_elf.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/core/sw_load_ovmf.c
+++ b/devicemodel/core/sw_load_ovmf.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/core/sw_load_vsbl.c
+++ b/devicemodel/core/sw_load_vsbl.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/core/timer.c
+++ b/devicemodel/core/timer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/devicemodel/core/vrpmb.c
+++ b/devicemodel/core/vrpmb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/mmio/core.c
+++ b/devicemodel/hw/mmio/core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/pci/gsi_sharing.c
+++ b/devicemodel/hw/pci/gsi_sharing.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/pci/gvt.c
+++ b/devicemodel/hw/pci/gvt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/ivshmem.c
+++ b/devicemodel/hw/pci/ivshmem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/pci/npk.c
+++ b/devicemodel/hw/pci/npk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/devicemodel/hw/pci/pci_util.c
+++ b/devicemodel/hw/pci/pci_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/platform_gsi_info.c
+++ b/devicemodel/hw/pci/platform_gsi_info.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/pci/ptm.c
+++ b/devicemodel/hw/pci/ptm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/vhost.c
+++ b/devicemodel/hw/pci/virtio/vhost.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_audio.c
+++ b/devicemodel/hw/pci/virtio/virtio_audio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_coreu.c
+++ b/devicemodel/hw/pci/virtio/virtio_coreu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_gpio.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_hdcp.c
+++ b/devicemodel/hw/pci/virtio/virtio_hdcp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_hyper_dmabuf.c
+++ b/devicemodel/hw/pci/virtio/virtio_hyper_dmabuf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_i2c.c
+++ b/devicemodel/hw/pci/virtio/virtio_i2c.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_input.c
+++ b/devicemodel/hw/pci/virtio/virtio_input.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_ipu.c
+++ b/devicemodel/hw/pci/virtio/virtio_ipu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_kernel.c
+++ b/devicemodel/hw/pci/virtio/virtio_kernel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_mei.c
+++ b/devicemodel/hw/pci/virtio/virtio_mei.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/pci/virtio/virtio_rpmb.c
+++ b/devicemodel/hw/pci/virtio/virtio_rpmb.c
@@ -1,7 +1,7 @@
 /*
  * Virtio Rpmb backend.
  *
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/pci/wdt_i6300esb.c
+++ b/devicemodel/hw/pci/wdt_i6300esb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/platform/acpi/acpi_parser.c
+++ b/devicemodel/hw/platform/acpi/acpi_parser.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2003 John Baldwin <jhb@FreeBSD.org>
- * Copyright (c) 2022 Intel Corporation
+ * Copyright (c) 2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/platform/acpi/acpi_pm.c
+++ b/devicemodel/hw/platform/acpi/acpi_pm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/platform/cmos_io.c
+++ b/devicemodel/hw/platform/cmos_io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/platform/debugexit.c
+++ b/devicemodel/hw/platform/debugexit.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2018 Intel
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/platform/hpet.c
+++ b/devicemodel/hw/platform/hpet.c
@@ -1,7 +1,7 @@
 /*-
  * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
  *
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019-2022 Intel Corporation.
  * Copyright (c) 2013 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
  * All rights reserved.

--- a/devicemodel/hw/platform/ioc.c
+++ b/devicemodel/hw/platform/ioc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/platform/ioc_cbc.c
+++ b/devicemodel/hw/platform/ioc_cbc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/platform/pit.c
+++ b/devicemodel/hw/platform/pit.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2011 NetApp, Inc.
  * All rights reserved.

--- a/devicemodel/hw/platform/pty_vuart.c
+++ b/devicemodel/hw/platform/pty_vuart.c
@@ -2,7 +2,7 @@
  * Project Acrn
  * Acrn-dm-pty
  *
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/platform/rpmb/att_keybox.c
+++ b/devicemodel/hw/platform/rpmb/att_keybox.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/platform/rpmb/rpmb_backend.c
+++ b/devicemodel/hw/platform/rpmb/rpmb_backend.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/platform/rpmb/rpmb_sim.c
+++ b/devicemodel/hw/platform/rpmb/rpmb_sim.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/hw/platform/tpm/tpm.c
+++ b/devicemodel/hw/platform/tpm/tpm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/platform/tpm/tpm_crb.c
+++ b/devicemodel/hw/platform/tpm/tpm_crb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/platform/tpm/tpm_emulator.c
+++ b/devicemodel/hw/platform/tpm/tpm_emulator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * Copyright (C) 2014, 2015 IBM Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/devicemodel/hw/platform/tpm/tpm_internal.h
+++ b/devicemodel/hw/platform/tpm/tpm_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/hw/platform/vssram/vssram.c
+++ b/devicemodel/hw/platform/vssram/vssram.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/atomic.h
+++ b/devicemodel/include/atomic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/include/att_keybox.h
+++ b/devicemodel/include/att_keybox.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Intel Corporation
+ * Copyright (c) 2019-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/cmd_monitor.h
+++ b/devicemodel/include/cmd_monitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Intel Corporation
+ * Copyright (C) 2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _CMD_MONITOR_H_

--- a/devicemodel/include/dm_string.h
+++ b/devicemodel/include/dm_string.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/gpio_dm.h
+++ b/devicemodel/include/gpio_dm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/hpet.h
+++ b/devicemodel/include/hpet.h
@@ -1,7 +1,7 @@
 /*-
  * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
  *
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019-2022 Intel Corporation.
  * Copyright (c) 2013 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
  * All rights reserved.

--- a/devicemodel/include/ioc.h
+++ b/devicemodel/include/ioc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/log.h
+++ b/devicemodel/include/log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/include/macros.h
+++ b/devicemodel/include/macros.h
@@ -1,7 +1,7 @@
 /*-
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * Copyright (c) 2018 Intel Corporation.
+ * Copyright (c) 2018-2022 Intel Corporation.
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/devicemodel/include/mei.h
+++ b/devicemodel/include/mei.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/mmio_dev.h
+++ b/devicemodel/include/mmio_dev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/include/monitor.h
+++ b/devicemodel/include/monitor.h
@@ -2,7 +2,7 @@
  * Project Acrn
  * Acrn-dm-monitor
  *
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/pci_util.h
+++ b/devicemodel/include/pci_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/pit.h
+++ b/devicemodel/include/pit.h
@@ -1,7 +1,7 @@
 /*-
  * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
  *
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2011 NetApp, Inc.
  * All rights reserved.

--- a/devicemodel/include/pm.h
+++ b/devicemodel/include/pm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef	_DM_INCLUDE_PM_

--- a/devicemodel/include/pm_vuart.h
+++ b/devicemodel/include/pm_vuart.h
@@ -2,7 +2,7 @@
  * Project Acrn
  * Acrn-dm: pm-vuart
  *
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/pty_vuart.h
+++ b/devicemodel/include/pty_vuart.h
@@ -2,7 +2,7 @@
  * Project Acrn
  * Acrn-dm-pty
  *
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/public/hsm_ioctl_defs.h
+++ b/devicemodel/include/public/hsm_ioctl_defs.h
@@ -4,7 +4,7 @@
  *
  * GPL LICENSE SUMMARY
  *
- * Copyright (c) 2017 Intel Corporation.
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of version 2 of the GNU General Public License as
@@ -17,7 +17,7 @@
  *
  * BSD LICENSE
  *
- * Copyright (C) 2017 Intel Corporation.
+ * Copyright (C) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/rpmb.h
+++ b/devicemodel/include/rpmb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/rpmb_backend.h
+++ b/devicemodel/include/rpmb_backend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/rpmb_sim.h
+++ b/devicemodel/include/rpmb_sim.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/timer.h
+++ b/devicemodel/include/timer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/devicemodel/include/tpm.h
+++ b/devicemodel/include/tpm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/vbs_common_if.h
+++ b/devicemodel/include/vbs_common_if.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/vhost.h
+++ b/devicemodel/include/vhost.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/vhost_vsock.h
+++ b/devicemodel/include/vhost_vsock.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
- * Copyright (C) 2022 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/virtio_kernel.h
+++ b/devicemodel/include/virtio_kernel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/include/vrpmb.h
+++ b/devicemodel/include/vrpmb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/devicemodel/include/vssram.h
+++ b/devicemodel/include/vssram.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/lib/dm_string.c
+++ b/devicemodel/lib/dm_string.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/devicemodel/log/disk_logger.c
+++ b/devicemodel/log/disk_logger.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/log/kmsg_logger.c
+++ b/devicemodel/log/kmsg_logger.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/devicemodel/log/log.c
+++ b/devicemodel/log/log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/doc/developer-guides/asm_coding_guidelines.rst
+++ b/doc/developer-guides/asm_coding_guidelines.rst
@@ -720,7 +720,7 @@ Compliant example::
     -------------File Contents Start After This Line------------
 
     /*
-     * Copyright (C) 2019 Intel Corporation.
+     * Copyright (C) 2019-2022 Intel Corporation.
      *
      * SPDX-License-Identifier: BSD-3-Clause
      */

--- a/doc/developer-guides/c_coding_guidelines.rst
+++ b/doc/developer-guides/c_coding_guidelines.rst
@@ -3386,7 +3386,7 @@ Compliant example::
     -------------File Contents Start After This Line------------
 
     /*
-     * Copyright (C) 2019 Intel Corporation.
+     * Copyright (C) 2019-2022 Intel Corporation.
      *
      * SPDX-License-Identifier: BSD-3-Clause
      */

--- a/doc/extensions/kerneldoc.py
+++ b/doc/extensions/kerneldoc.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright © 2016 Intel Corporation
+# Copyright © 2016-2022 Intel Corporation.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/doc/extensions/link_roles.py
+++ b/doc/extensions/link_roles.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Intel Corporation
+# Copyright (c) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/doc/scorer.js
+++ b/doc/scorer.js
@@ -2,7 +2,7 @@
  * Simple search result scoring code.
  *
  * Copyright 2007-2018 by the Sphinx team
- * Copyright (c) 2019, Intel
+ * Copyright (c) 2019-2022, Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/doc/scripts/extract_content.py
+++ b/doc/scripts/extract_content.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2018, Nordic Semiconductor ASA
-# Copyright (c) 2017, Intel Corporation
+# Copyright (c) 2017-2022, Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/doc/scripts/filter-doc-log.sh
+++ b/doc/scripts/filter-doc-log.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # run the filter-known-issues.py script to remove "expected" warning

--- a/doc/scripts/filter-known-issues.py
+++ b/doc/scripts/filter-known-issues.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-# Copyright (c) 2017, Intel Corporation
+# Copyright (c) 2017-2022, Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 """
 Filters a file, classifying output in errors, warnings and discarding

--- a/doc/scripts/show-versions.py
+++ b/doc/scripts/show-versions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2018, Intel Corporation
+# Copyright (c) 2018-2022, Intel Corporation
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/doc/tutorials/acrn_on_qemu.rst
+++ b/doc/tutorials/acrn_on_qemu.rst
@@ -267,7 +267,7 @@ Bring Up User VM (L2 Guest)
    .. code-block:: none
 
       #!/bin/bash
-      # Copyright (C) 2020 Intel Corporation.
+      # Copyright (C) 2020-2022 Intel Corporation.
       # SPDX-License-Identifier: BSD-3-Clause
       function launch_ubuntu()
       {

--- a/doc/tutorials/create-up2-images.sh
+++ b/doc/tutorials/create-up2-images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2018 Intel Corporation.
+# Copyright (C) 2018-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/doc/tutorials/gpt_ini2bin.py
+++ b/doc/tutorials/gpt_ini2bin.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (C) 2018 Intel Corporation.
+# Copyright (C) 2018-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import ConfigParser

--- a/doc/tutorials/launch_uos.sh
+++ b/doc/tutorials/launch_uos.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-# Copyright (C) 2018 Intel Corporation.
+# Copyright (C) 2018-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/hypervisor/acpi_parser/acpi_ext.c
+++ b/hypervisor/acpi_parser/acpi_ext.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
  *
  * Copyright (c) 2003 John Baldwin <jhb@FreeBSD.org>
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/boot/trampoline.S
+++ b/hypervisor/arch/x86/boot/trampoline.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/configs/vacpi.c
+++ b/hypervisor/arch/x86/configs/vacpi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/cpu_state_tbl.c
+++ b/hypervisor/arch/x86/cpu_state_tbl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/e820.c
+++ b/hypervisor/arch/x86/e820.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/exception.c
+++ b/hypervisor/arch/x86/exception.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/gdt.c
+++ b/hypervisor/arch/x86/gdt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/guest_memory.c
+++ b/hypervisor/arch/x86/guest/guest_memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/hyperv.c
+++ b/hypervisor/arch/x86/guest/hyperv.c
@@ -2,7 +2,7 @@
  * Microsoft Hyper-V emulation. See Microsoft's
  * Hypervisor Top Level Functional Specification for more information.
  *
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -1,7 +1,7 @@
 /*-
  * Copyright (c) 2012 Sandvine, Inc.
  * Copyright (c) 2012 NetApp, Inc.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/arch/x86/guest/lock_instr_emul.c
+++ b/hypervisor/arch/x86/guest/lock_instr_emul.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/nested.c
+++ b/hypervisor/arch/x86/guest/nested.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/optee.c
+++ b/hypervisor/arch/x86/guest/optee.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/trusty.c
+++ b/hypervisor/arch/x86/guest/trusty.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/ucode.c
+++ b/hypervisor/arch/x86/guest/ucode.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vcat.c
+++ b/hypervisor/arch/x86/guest/vcat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/ve820.c
+++ b/hypervisor/arch/x86/guest/ve820.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vept.c
+++ b/hypervisor/arch/x86/guest/vept.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vm_reset.c
+++ b/hypervisor/arch/x86/guest/vm_reset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmtrr.c
+++ b/hypervisor/arch/x86/guest/vmtrr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/arch/x86/guest/vmx_asm.S
+++ b/hypervisor/arch/x86/guest/vmx_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/guest/vmx_io.c
+++ b/hypervisor/arch/x86/guest/vmx_io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/idt.S
+++ b/hypervisor/arch/x86/idt.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/lib/memory.c
+++ b/hypervisor/arch/x86/lib/memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <types.h>

--- a/hypervisor/arch/x86/lib/retpoline-thunk.S
+++ b/hypervisor/arch/x86/lib/retpoline-thunk.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/arch/x86/nmi.c
+++ b/hypervisor/arch/x86/nmi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/platform_caps.c
+++ b/hypervisor/arch/x86/platform_caps.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/arch/x86/rdt.c
+++ b/hypervisor/arch/x86/rdt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/rtcm.c
+++ b/hypervisor/arch/x86/rtcm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/sched.S
+++ b/hypervisor/arch/x86/sched.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/security.c
+++ b/hypervisor/arch/x86/security.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed.c
+++ b/hypervisor/arch/x86/seed/seed.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed_abl.c
+++ b/hypervisor/arch/x86/seed/seed_abl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed_abl.h
+++ b/hypervisor/arch/x86/seed/seed_abl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed_sbl.c
+++ b/hypervisor/arch/x86/seed/seed_sbl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/seed/seed_sbl.h
+++ b/hypervisor/arch/x86/seed/seed_sbl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/sgx.c
+++ b/hypervisor/arch/x86/sgx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/trampoline.c
+++ b/hypervisor/arch/x86/trampoline.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/arch/x86/wakeup.S
+++ b/hypervisor/arch/x86/wakeup.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/boot/acpi_base.c
+++ b/hypervisor/boot/acpi_base.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
  *
  * Copyright (c) 2003 John Baldwin <jhb@FreeBSD.org>
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/boot/guest/bzimage_loader.c
+++ b/hypervisor/boot/guest/bzimage_loader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/guest/elf_loader.c
+++ b/hypervisor/boot/guest/elf_loader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/guest/rawimage_loader.c
+++ b/hypervisor/boot/guest/rawimage_loader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/include/boot.h
+++ b/hypervisor/boot/include/boot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/include/guest/vboot.h
+++ b/hypervisor/boot/include/guest/vboot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/include/multiboot_std.h
+++ b/hypervisor/boot/include/multiboot_std.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/include/reloc.h
+++ b/hypervisor/boot/include/reloc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/boot/multiboot/multiboot.c
+++ b/hypervisor/boot/multiboot/multiboot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/multiboot/multiboot2.c
+++ b/hypervisor/boot/multiboot/multiboot2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/multiboot/multiboot_priv.h
+++ b/hypervisor/boot/multiboot/multiboot_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/event.c
+++ b/hypervisor/common/event.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/irq.c
+++ b/hypervisor/common/irq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/sched_bvt.c
+++ b/hypervisor/common/sched_bvt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/sched_iorr.c
+++ b/hypervisor/common/sched_iorr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/sched_noop.c
+++ b/hypervisor/common/sched_noop.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/softirq.c
+++ b/hypervisor/common/softirq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/timer.c
+++ b/hypervisor/common/timer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/trusty_hypercall.c
+++ b/hypervisor/common/trusty_hypercall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/dbg_cmd.c
+++ b/hypervisor/debug/dbg_cmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/hypercall.c
+++ b/hypervisor/debug/hypercall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/debug/printf.c
+++ b/hypervisor/debug/printf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -1,7 +1,7 @@
 /*
  * SHARED BUFFER
  *
- * Copyright (C) 2017 Intel Corporation.
+ * Copyright (C) 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/string.c
+++ b/hypervisor/debug/string.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/trace.c
+++ b/hypervisor/debug/trace.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/io_req.c
+++ b/hypervisor/dm/io_req.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/dm/mmio_dev.c
+++ b/hypervisor/dm/mmio_dev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/vgpio.c
+++ b/hypervisor/dm/vgpio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -1,7 +1,7 @@
 /*-
  * Copyright (c) 2013 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/ivshmem.c
+++ b/hypervisor/dm/vpci/ivshmem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -1,6 +1,6 @@
 /*-
 * Copyright (c) 2011 NetApp, Inc.
-* Copyright (c) 2018 Intel Corporation
+* Copyright (c) 2018-2022 Intel Corporation.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vdev.c
+++ b/hypervisor/dm/vpci/vdev.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -1,6 +1,6 @@
 /*-
 * Copyright (c) 2011 NetApp, Inc.
-* Copyright (c) 2018 Intel Corporation
+* Copyright (c) 2018-2022 Intel Corporation.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vmcs9900.c
+++ b/hypervisor/dm/vpci/vmcs9900.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vmsix_on_msi.c
+++ b/hypervisor/dm/vpci/vmsix_on_msi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -1,6 +1,6 @@
 /*-
 * Copyright (c) 2011 NetApp, Inc.
-* Copyright (c) 2018 Intel Corporation
+* Copyright (c) 2018-2022 Intel Corporation.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vpci_bridge.c
+++ b/hypervisor/dm/vpci/vpci_bridge.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -1,6 +1,6 @@
 /*-
 * Copyright (c) 2011 NetApp, Inc.
-* Copyright (c) 2018 Intel Corporation
+* Copyright (c) 2018-2022 Intel Corporation.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpci/vroot_port.c
+++ b/hypervisor/dm/vpci/vroot_port.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Intel Corporation.
+ * Copyright (c) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/dm/vpci/vsriov.c
+++ b/hypervisor/dm/vpci/vsriov.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/dm/vrtc.c
+++ b/hypervisor/dm/vrtc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014, Neel Natu (neel@freebsd.org)
- * Copyright (c) 2022 Intel Corporation
+ * Copyright (c) 2022 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -1,7 +1,7 @@
 /*-
  * Copyright (c) 2012 NetApp, Inc.
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -2,7 +2,7 @@
  * Copyright (c) 1997, Stefan Esser <se@freebsd.org>
  * Copyright (c) 2000, Michael Smith <msmith@freebsd.org>
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/apicreg.h
+++ b/hypervisor/include/arch/x86/asm/apicreg.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 1996, by Peter Wemm and Steve Passe
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/board.h
+++ b/hypervisor/include/arch/x86/asm/board.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/boot/ld_sym.h
+++ b/hypervisor/include/arch/x86/asm/boot/ld_sym.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/cpu.h
+++ b/hypervisor/include/arch/x86/asm/cpu.h
@@ -1,7 +1,7 @@
 /*-
  * Copyright (c) 1989, 1990 William F. Jolitz
  * Copyright (c) 1990 The Regents of the University of California.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * This code is derived from software contributed to Berkeley by
  * William Jolitz.

--- a/hypervisor/include/arch/x86/asm/cpu_caps.h
+++ b/hypervisor/include/arch/x86/asm/cpu_caps.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/cpufeatures.h
+++ b/hypervisor/include/arch/x86/asm/cpufeatures.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/cpuid.h
+++ b/hypervisor/include/arch/x86/asm/cpuid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/default_acpi_info.h
+++ b/hypervisor/include/arch/x86/asm/default_acpi_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/e820.h
+++ b/hypervisor/include/arch/x86/asm/e820.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/gdt.h
+++ b/hypervisor/include/arch/x86/asm/gdt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/assign.h
+++ b/hypervisor/include/arch/x86/asm/guest/assign.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/ept.h
+++ b/hypervisor/include/arch/x86/asm/guest/ept.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/guest_memory.h
+++ b/hypervisor/include/arch/x86/asm/guest/guest_memory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/guest_pm.h
+++ b/hypervisor/include/arch/x86/asm/guest/guest_pm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/hyperv.h
+++ b/hypervisor/include/arch/x86/asm/guest/hyperv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/instr_emul.h
+++ b/hypervisor/include/arch/x86/asm/guest/instr_emul.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2012 NetApp, Inc.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/guest/lock_instr_emul.h
+++ b/hypervisor/include/arch/x86/asm/guest/lock_instr_emul.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/optee.h
+++ b/hypervisor/include/arch/x86/asm/guest/optee.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/trusty.h
+++ b/hypervisor/include/arch/x86/asm/guest/trusty.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/ucode.h
+++ b/hypervisor/include/arch/x86/asm/guest/ucode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vcat.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vcpuid.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpuid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vept.h
+++ b/hypervisor/include/arch/x86/asm/guest/vept.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/virq.h
+++ b/hypervisor/include/arch/x86/asm/guest/virq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/virtual_cr.h
+++ b/hypervisor/include/arch/x86/asm/guest/virtual_cr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/asm/guest/vlapic.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/guest/vm.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vm_reset.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm_reset.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vmcs.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmcs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vmexit.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmexit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/guest/vmtrr.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmtrr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 /**

--- a/hypervisor/include/arch/x86/asm/guest/vmx_io.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmx_io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/host_pm.h
+++ b/hypervisor/include/arch/x86/asm/host_pm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/include/arch/x86/asm/idt.h
+++ b/hypervisor/include/arch/x86/asm/idt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/init.h
+++ b/hypervisor/include/arch/x86/asm/init.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/include/arch/x86/asm/io.h
+++ b/hypervisor/include/arch/x86/asm/io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/ioapic.h
+++ b/hypervisor/include/arch/x86/asm/ioapic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/irq.h
+++ b/hypervisor/include/arch/x86/asm/irq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/lapic.h
+++ b/hypervisor/include/arch/x86/asm/lapic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/lib/atomic.h
+++ b/hypervisor/include/arch/x86/asm/lib/atomic.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 1998 Doug Rabson
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/lib/bits.h
+++ b/hypervisor/include/arch/x86/asm/lib/bits.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 1998 Doug Rabson
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/arch/x86/asm/lib/spinlock.h
+++ b/hypervisor/include/arch/x86/asm/lib/spinlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/mmu.h
+++ b/hypervisor/include/arch/x86/asm/mmu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/msr.h
+++ b/hypervisor/include/arch/x86/asm/msr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/notify.h
+++ b/hypervisor/include/arch/x86/asm/notify.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/page.h
+++ b/hypervisor/include/arch/x86/asm/page.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/pci_dev.h
+++ b/hypervisor/include/arch/x86/asm/pci_dev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/per_cpu.h
+++ b/hypervisor/include/arch/x86/asm/per_cpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/pgtable.h
+++ b/hypervisor/include/arch/x86/asm/pgtable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/platform_caps.h
+++ b/hypervisor/include/arch/x86/asm/platform_caps.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/rdt.h
+++ b/hypervisor/include/arch/x86/asm/rdt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/rtcm.h
+++ b/hypervisor/include/arch/x86/asm/rtcm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/rtct.h
+++ b/hypervisor/include/arch/x86/asm/rtct.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/security.h
+++ b/hypervisor/include/arch/x86/asm/security.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/seed.h
+++ b/hypervisor/include/arch/x86/asm/seed.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/sgx.h
+++ b/hypervisor/include/arch/x86/asm/sgx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/trampoline.h
+++ b/hypervisor/include/arch/x86/asm/trampoline.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/hypervisor/include/arch/x86/asm/vm_config.h
+++ b/hypervisor/include/arch/x86/asm/vm_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/vmx.h
+++ b/hypervisor/include/arch/x86/asm/vmx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/vtd.h
+++ b/hypervisor/include/arch/x86/asm/vtd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/arch/x86/asm/zeropage.h
+++ b/hypervisor/include/arch/x86/asm/zeropage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/softirq.h
+++ b/hypervisor/include/common/softirq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/common/timer.h
+++ b/hypervisor/include/common/timer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/dbg_cmd.h
+++ b/hypervisor/include/debug/dbg_cmd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/dump.h
+++ b/hypervisor/include/debug/dump.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/profiling.h
+++ b/hypervisor/include/debug/profiling.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 int32_tel Corporation. All rights reserved.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 int32_tel Corporation. All rights reserved.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/sbuf.h
+++ b/hypervisor/include/debug/sbuf.h
@@ -1,7 +1,7 @@
 /*
  * SHARED BUFFER
  *
- * Copyright (C) 2017 Intel Corporation.
+ * Copyright (C) 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/include/debug/shell.h
+++ b/hypervisor/include/debug/shell.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/debug/trace.h
+++ b/hypervisor/include/debug/trace.h
@@ -1,7 +1,7 @@
 /*
  * ACRN TRACE
  *
- * Copyright (C) 2017 Intel Corporation.
+ * Copyright (C) 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/hypervisor/include/debug/uart16550.h
+++ b/hypervisor/include/debug/uart16550.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/io_req.h
+++ b/hypervisor/include/dm/io_req.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/ivshmem.h
+++ b/hypervisor/include/dm/ivshmem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/mmio_dev.h
+++ b/hypervisor/include/dm/mmio_dev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/vacpi.h
+++ b/hypervisor/include/dm/vacpi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/vgpio.h
+++ b/hypervisor/include/dm/vgpio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/vioapic.h
+++ b/hypervisor/include/dm/vioapic.h
@@ -1,7 +1,7 @@
 /*-
  * Copyright (c) 2013 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/dm/vmcs9900.h
+++ b/hypervisor/include/dm/vmcs9900.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -1,6 +1,6 @@
 /*-
 * Copyright (c) 2011 NetApp, Inc.
-* Copyright (c) 2018 Intel Corporation
+* Copyright (c) 2018-2022 Intel Corporation.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions

--- a/hypervisor/include/dm/vpic.h
+++ b/hypervisor/include/dm/vpic.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/dm/vuart.h
+++ b/hypervisor/include/dm/vuart.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -1,7 +1,7 @@
 /*-
 * Copyright (c) 1997, Stefan Esser <se@freebsd.org>
 * Copyright (c) 2011 NetApp, Inc.
-* Copyright (c) 2018 Intel Corporation
+* Copyright (c) 2018-2022 Intel Corporation.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions

--- a/hypervisor/include/lib/crypto/crypto_api.h
+++ b/hypervisor/include/lib/crypto/crypto_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/efi.h
+++ b/hypervisor/include/lib/efi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/errno.h
+++ b/hypervisor/include/lib/errno.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/hash.h
+++ b/hypervisor/include/lib/hash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/list.h
+++ b/hypervisor/include/lib/list.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (C) 2005-2011 HighPoint Technologies, Inc.
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2017-2022 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/sprintf.h
+++ b/hypervisor/include/lib/sprintf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/types.h
+++ b/hypervisor/include/lib/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/lib/util.h
+++ b/hypervisor/include/lib/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -1,7 +1,7 @@
 /*
  * common definition
  *
- * Copyright (C) 2017 Intel Corporation.
+ * Copyright (C) 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -1,7 +1,7 @@
 /*
  * hypercall definition
  *
- * Copyright (C) 2017 Intel Corporation.
+ * Copyright (C) 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/lib/crypto/crypto_api.c
+++ b/hypervisor/lib/crypto/crypto_api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/lib/crypto/mbedtls/md.c
+++ b/hypervisor/lib/crypto/mbedtls/md.c
@@ -6,7 +6,7 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation.
+ *  Copyright (C) 2018-2022, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/md.h
+++ b/hypervisor/lib/crypto/mbedtls/md.h
@@ -7,7 +7,7 @@
  */
 /*
  *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation.
+ *  Copyright (C) 2018-2022, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/md_internal.h
+++ b/hypervisor/lib/crypto/mbedtls/md_internal.h
@@ -9,7 +9,7 @@
  */
 /*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation.
+ *  Copyright (C) 2018-2022, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/md_wrap.c
+++ b/hypervisor/lib/crypto/mbedtls/md_wrap.c
@@ -6,7 +6,7 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation.
+ *  Copyright (C) 2018-2022, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/sha256.c
+++ b/hypervisor/lib/crypto/mbedtls/sha256.c
@@ -2,7 +2,7 @@
  *  FIPS-180-2 compliant SHA-256 implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation.
+ *  Copyright (C) 2018-2022, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/crypto/mbedtls/sha256.h
+++ b/hypervisor/lib/crypto/mbedtls/sha256.h
@@ -8,7 +8,7 @@
  */
 /*
  *  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved
- *  Copyright (C) 2018, Intel Corporation.
+ *  Copyright (C) 2018-2022, Intel Corporation.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/lib/stack_protector.c
+++ b/hypervisor/lib/stack_protector.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/lib/string.c
+++ b/hypervisor/lib/string.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <types.h>

--- a/hypervisor/quirks/security_vm_fixup.c
+++ b/hypervisor/quirks/security_vm_fixup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/quirks/security_vm_fixup.h
+++ b/hypervisor/quirks/security_vm_fixup.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/quirks/smbios.h
+++ b/hypervisor/quirks/smbios.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/console.c
+++ b/hypervisor/release/console.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/dump.c
+++ b/hypervisor/release/dump.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/hypercall.c
+++ b/hypervisor/release/hypercall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/logmsg.c
+++ b/hypervisor/release/logmsg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/npk_log.c
+++ b/hypervisor/release/npk_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/profiling.c
+++ b/hypervisor/release/profiling.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/sbuf.c
+++ b/hypervisor/release/sbuf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/trace.c
+++ b/hypervisor/release/trace.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/release/uart16550.c
+++ b/hypervisor/release/uart16550.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/hypervisor/scripts/genconf.sh
+++ b/hypervisor/scripts/genconf.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 base_dir=$1

--- a/hypervisor/scripts/makefile/config.mk
+++ b/hypervisor/scripts/makefile/config.mk
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # usage: check_coexistence <symbol 1> <symbol 2>

--- a/hypervisor/scripts/makefile/unified.xml.in
+++ b/hypervisor/scripts/makefile/unified.xml.in
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 
-<!-- Copyright (C) 2021 Intel Corporation. -->
+<!-- Copyright (C) 2021-2022 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <acrn-offline-data

--- a/misc/config_tools/acpi_gen/__init__.py
+++ b/misc/config_tools/acpi_gen/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 """__init__ for acpi generator.

--- a/misc/config_tools/acpi_gen/acpi_const.py
+++ b/misc/config_tools/acpi_gen/acpi_const.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 """constant for offline ACPI generator.

--- a/misc/config_tools/acpi_gen/asl_gen.py
+++ b/misc/config_tools/acpi_gen/asl_gen.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 """the tool to generate ASL code of ACPI tables for Pre-launched VMs.

--- a/misc/config_tools/acpi_gen/bin_gen.py
+++ b/misc/config_tools/acpi_gen/bin_gen.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 """the tool to generate ACPI binary for Pre-launched VMs.

--- a/misc/config_tools/acpi_template/template/apic.asl
+++ b/misc/config_tools/acpi_template/template/apic.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [APIC]
  *

--- a/misc/config_tools/acpi_template/template/facp.asl
+++ b/misc/config_tools/acpi_template/template/facp.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [FACP]
  *

--- a/misc/config_tools/acpi_template/template/mcfg.asl
+++ b/misc/config_tools/acpi_template/template/mcfg.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [MCFG]
  *

--- a/misc/config_tools/acpi_template/template/rsdp.asl
+++ b/misc/config_tools/acpi_template/template/rsdp.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * iASL Compiler/Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * Template for [RSDP] ACPI Table (AML byte code table)
  */

--- a/misc/config_tools/acpi_template/template/tpm2.asl
+++ b/misc/config_tools/acpi_template/template/tpm2.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [TPM2]
  *

--- a/misc/config_tools/acpi_template/template/xsdt.asl
+++ b/misc/config_tools/acpi_template/template/xsdt.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [XSDT]
  *

--- a/misc/config_tools/board_config/acpi_platform_h.py
+++ b/misc/config_tools/board_config/acpi_platform_h.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_config/board_c.py
+++ b/misc/config_tools/board_config/board_c.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_config/board_cfg_gen.py
+++ b/misc/config_tools/board_config/board_cfg_gen.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_config/board_info_h.py
+++ b/misc/config_tools/board_config/board_info_h.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation.
+# Copyright (C) 2020-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_config/pci_devices_h.py
+++ b/misc/config_tools/board_config/pci_devices_h.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_config/vbar_base_h.py
+++ b/misc/config_tools/board_config/vbar_base_h.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation.
+# Copyright (C) 2020-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/__init__.py
+++ b/misc/config_tools/board_inspector/acpiparser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/_utils.py
+++ b/misc/config_tools/board_inspector/acpiparser/_utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/builder.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/builder.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/context.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/context.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/datatypes.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/datatypes.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/exception.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/exception.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/grammar.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/grammar.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/interpreter.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/interpreter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/parser.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/parser.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/stream.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/stream.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/tree.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/tree.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/aml/visitors.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/visitors.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/apic.py
+++ b/misc/config_tools/board_inspector/acpiparser/apic.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/asf.py
+++ b/misc/config_tools/board_inspector/acpiparser/asf.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/dmar.py
+++ b/misc/config_tools/board_inspector/acpiparser/dmar.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/dsdt.py
+++ b/misc/config_tools/board_inspector/acpiparser/dsdt.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/facp.py
+++ b/misc/config_tools/board_inspector/acpiparser/facp.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/prt.py
+++ b/misc/config_tools/board_inspector/acpiparser/prt.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/rdt.py
+++ b/misc/config_tools/board_inspector/acpiparser/rdt.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/rtct.py
+++ b/misc/config_tools/board_inspector/acpiparser/rtct.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/acpiparser/tpm2.py
+++ b/misc/config_tools/board_inspector/acpiparser/tpm2.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/board_inspector.py
+++ b/misc/config_tools/board_inspector/board_inspector.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/cpuparser/__init__.py
+++ b/misc/config_tools/board_inspector/cpuparser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/cpuparser/cpuids.py
+++ b/misc/config_tools/board_inspector/cpuparser/cpuids.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/cpuparser/platformbase.py
+++ b/misc/config_tools/board_inspector/cpuparser/platformbase.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/10-processors.py
+++ b/misc/config_tools/board_inspector/extractors/10-processors.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/20-cache.py
+++ b/misc/config_tools/board_inspector/extractors/20-cache.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/30-memory.py
+++ b/misc/config_tools/board_inspector/extractors/30-memory.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/40-acpi-tables.py
+++ b/misc/config_tools/board_inspector/extractors/40-acpi-tables.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/50-acpi-namespace.py
+++ b/misc/config_tools/board_inspector/extractors/50-acpi-namespace.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/60-pci.py
+++ b/misc/config_tools/board_inspector/extractors/60-pci.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/80-lookup.py
+++ b/misc/config_tools/board_inspector/extractors/80-lookup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/90-sorting.py
+++ b/misc/config_tools/board_inspector/extractors/90-sorting.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/extractors/helpers.py
+++ b/misc/config_tools/board_inspector/extractors/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/inspectorlib/bitfields.py
+++ b/misc/config_tools/board_inspector/inspectorlib/bitfields.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2022 Intel Corporation.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/misc/config_tools/board_inspector/inspectorlib/cdata.py
+++ b/misc/config_tools/board_inspector/inspectorlib/cdata.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2022 Intel Corporation.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/misc/config_tools/board_inspector/inspectorlib/unpack.py
+++ b/misc/config_tools/board_inspector/inspectorlib/unpack.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013, Intel Corporation
+# Copyright (c) 2013-2022 Intel Corporation.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/misc/config_tools/board_inspector/legacy/acpi.py
+++ b/misc/config_tools/board_inspector/legacy/acpi.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/board_parser.py
+++ b/misc/config_tools/board_inspector/legacy/board_parser.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/clos.py
+++ b/misc/config_tools/board_inspector/legacy/clos.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/dmar.py
+++ b/misc/config_tools/board_inspector/legacy/dmar.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/dmi.py
+++ b/misc/config_tools/board_inspector/legacy/dmi.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/misc.py
+++ b/misc/config_tools/board_inspector/legacy/misc.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/parser_lib.py
+++ b/misc/config_tools/board_inspector/legacy/parser_lib.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/legacy/pci_dev.py
+++ b/misc/config_tools/board_inspector/legacy/pci_dev.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/memmapparser/__init__.py
+++ b/misc/config_tools/board_inspector/memmapparser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/memmapparser/e820.py
+++ b/misc/config_tools/board_inspector/memmapparser/e820.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/pcieparser/__init__.py
+++ b/misc/config_tools/board_inspector/pcieparser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/pcieparser/caps.py
+++ b/misc/config_tools/board_inspector/pcieparser/caps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/pcieparser/extcaps.py
+++ b/misc/config_tools/board_inspector/pcieparser/extcaps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/pcieparser/header.py
+++ b/misc/config_tools/board_inspector/pcieparser/header.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/smbiosparser/__init__.py
+++ b/misc/config_tools/board_inspector/smbiosparser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/board_inspector/smbiosparser/smbios.py
+++ b/misc/config_tools/board_inspector/smbiosparser/smbios.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/data/generic_board/generic_code/boards/board.c
+++ b/misc/config_tools/data/generic_board/generic_code/boards/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/data/generic_board/generic_code/boards/board_info.h
+++ b/misc/config_tools/data/generic_board/generic_code/boards/board_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/data/generic_board/generic_code/boards/pci_devices.h
+++ b/misc/config_tools/data/generic_board/generic_code/boards/pci_devices.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/data/generic_board/generic_code/boards/platform_acpi_info.h
+++ b/misc/config_tools/data/generic_board/generic_code/boards/platform_acpi_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/data/generic_board/generic_code/hybrid/ACPI_VM0/apic.asl
+++ b/misc/config_tools/data/generic_board/generic_code/hybrid/ACPI_VM0/apic.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [APIC]
  *

--- a/misc/config_tools/data/generic_board/generic_code/hybrid/ACPI_VM0/facp.asl
+++ b/misc/config_tools/data/generic_board/generic_code/hybrid/ACPI_VM0/facp.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [FACP]
  *

--- a/misc/config_tools/data/generic_board/generic_code/hybrid/ACPI_VM0/mcfg.asl
+++ b/misc/config_tools/data/generic_board/generic_code/hybrid/ACPI_VM0/mcfg.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [MCFG]
  *

--- a/misc/config_tools/data/generic_board/generic_code/hybrid/ACPI_VM0/rsdp.asl
+++ b/misc/config_tools/data/generic_board/generic_code/hybrid/ACPI_VM0/rsdp.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * iASL Compiler/Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * Template for [RSDP] ACPI Table (AML byte code table)
  */

--- a/misc/config_tools/data/generic_board/generic_code/hybrid/ACPI_VM0/xsdt.asl
+++ b/misc/config_tools/data/generic_board/generic_code/hybrid/ACPI_VM0/xsdt.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [XSDT]
  *

--- a/misc/config_tools/data/generic_board/generic_code/hybrid/vbar_base.h
+++ b/misc/config_tools/data/generic_board/generic_code/hybrid/vbar_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM0/apic.asl
+++ b/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM0/apic.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [APIC]
  *

--- a/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM0/facp.asl
+++ b/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM0/facp.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [FACP]
  *

--- a/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM0/mcfg.asl
+++ b/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM0/mcfg.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [MCFG]
  *

--- a/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM0/rsdp.asl
+++ b/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM0/rsdp.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * iASL Compiler/Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * Template for [RSDP] ACPI Table (AML byte code table)
  */

--- a/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM0/xsdt.asl
+++ b/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM0/xsdt.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [XSDT]
  *

--- a/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM1/apic.asl
+++ b/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM1/apic.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [APIC]
  *

--- a/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM1/facp.asl
+++ b/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM1/facp.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [FACP]
  *

--- a/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM1/mcfg.asl
+++ b/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM1/mcfg.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [MCFG]
  *

--- a/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM1/rsdp.asl
+++ b/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM1/rsdp.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * iASL Compiler/Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * Template for [RSDP] ACPI Table (AML byte code table)
  */

--- a/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM1/xsdt.asl
+++ b/misc/config_tools/data/generic_board/generic_code/partitioned/ACPI_VM1/xsdt.asl
@@ -1,7 +1,7 @@
 /*
  * Intel ACPI Component Architecture
  * AML/ASL+ Disassembler version 20190703 (64-bit version)
- * Copyright (c) 2000 - 2019 Intel Corporation
+ * Copyright (c) 2000 - 2022 Intel Corporation
  *
  * ACPI Data Table [XSDT]
  *

--- a/misc/config_tools/data/generic_board/generic_code/partitioned/vbar_base.h
+++ b/misc/config_tools/data/generic_board/generic_code/partitioned/vbar_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/data/generic_board/generic_code/shared/vbar_base.h
+++ b/misc/config_tools/data/generic_board/generic_code/shared/vbar_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/data/sample_launch_scripts/apl-mrb/launch_uos.sh
+++ b/misc/config_tools/data/sample_launch_scripts/apl-mrb/launch_uos.sh
@@ -1,0 +1,594 @@
+#!/bin/bash
+# Copyright (C) 2019-2022 Intel Corporation.
+# SPDX-License-Identifier: BSD-3-Clause
+
+kernel_version=$(uname -r)
+audio_module="/usr/lib/modules/$kernel_version/kernel/sound/soc/intel/boards/snd-soc-sst_bxt_sos_tdf8532.ko"
+ipu_passthrough=0
+
+# Check the device file of /dev/vbs_ipu to determine the IPU mode
+if [ ! -e "/dev/vbs_ipu" ]; then
+ipu_passthrough=1
+fi
+
+# use the modprobe to force loading snd-soc-skl/sst_bxt_bdf8532
+if [ ! -e $(audio_module)]; then
+modprobe -q snd-soc-skl
+modprobe -q snd-soc-sst_bxt_tdf8532
+else
+
+modprobe -q snd_soc_skl
+modprobe -q snd_soc_tdf8532
+modprobe -q snd_soc_sst_bxt_sos_tdf8532
+modprobe -q snd_soc_skl_virtio_be
+fi
+audio_passthrough=0
+
+# Check the device file of /dev/vbs_k_audio to determine the audio mode
+if [ ! -e "/dev/vbs_k_audio" ]; then
+audio_passthrough=1
+fi
+
+cse_passthrough=0
+hbm_ver=`cat /sys/class/mei/mei0/hbm_ver`
+major_ver=`echo $hbm_ver | cut -d '.' -f1`
+minor_ver=`echo $hbm_ver | cut -d '.' -f2`
+if [[ "$major_ver" -lt "2" ]] || \
+   [[ "$major_ver" == "2" && "$minor_ver" -le "2" ]]; then
+    cse_passthrough=1
+fi
+
+# pci devices for passthru
+declare -A passthru_vpid
+declare -A passthru_bdf
+
+passthru_vpid=(
+["usb_xdci"]="8086 5aaa"
+["ipu"]="8086 5a88"
+["ipu_i2c"]="8086 5aac"
+["cse"]="8086 5a9a"
+["sd_card"]="8086 5aca"
+["audio"]="8086 5a98"
+["audio_codec"]="8086 5ab4"
+["wifi"]="11ab 2b38"
+["bluetooth"]="8086 5abc"
+)
+passthru_bdf=(
+["usb_xdci"]="0000:00:15.1"
+["ipu"]="0000:00:03.0"
+["ipu_i2c"]="0000:00:16.0"
+["cse"]="0000:00:0f.0"
+["sd_card"]="0000:00:1b.0"
+["audio"]="0000:00:0e.0"
+["audio_codec"]="0000:00:17.0"
+["wifi"]="0000:03:00.0"
+["bluetooth"]="0000:00:18.0"
+)
+
+function launch_clearlinux()
+{
+if [ ! -f "/data/$4/$4.img" ]; then
+  echo "no /data/$4/$4.img, exit"
+  exit
+fi
+
+#vm-name used to generate uos-mac address
+mac=$(cat /sys/class/net/e*/address)
+vm_name=vm$1
+mac_seed=${mac:9:8}-${vm_name}
+
+# create a unique tap device for each VM
+tap=tap_$5
+tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
+if [ "$tap_exist"x != "x" ]; then
+  echo "tap device existed, reuse $tap"
+else
+  ip tuntap add dev $tap mode tap
+fi
+
+# if acrn-br0 exists, add VM's unique tap device under it
+br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
+if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
+  echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
+  ip link set "$tap" master acrn-br0
+  ip link set dev "$tap" down
+  ip link set dev "$tap" up
+fi
+
+#check if the vm is running or not
+vm_ps=$(pgrep -a -f acrn-dm)
+result=$(echo $vm_ps | grep -w "${vm_name}")
+if [[ "$result" != "" ]]; then
+  echo "$vm_name is running, can't create twice!"
+  exit
+fi
+
+#for VT-d device setting
+modprobe pci_stub
+echo ${passthru_vpid["usb_xdci"]} > /sys/bus/pci/drivers/pci-stub/new_id
+echo ${passthru_bdf["usb_xdci"]} > /sys/bus/pci/devices/${passthru_bdf["usb_xdci"]}/driver/unbind
+echo ${passthru_bdf["usb_xdci"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+echo 100 > /sys/bus/usb/drivers/usb-storage/module/parameters/delay_use
+
+boot_ipu_option=""
+if [ $ipu_passthrough == 1 ];then
+    # for ipu passthrough - ipu device
+    if [ -d "/sys/bus/pci/devices/${passthru_bdf["ipu"]}" ]; then
+        echo ${passthru_vpid["ipu"]} > /sys/bus/pci/drivers/pci-stub/new_id
+        echo ${passthru_bdf["ipu"]} > /sys/bus/pci/devices/${passthru_bdf["ipu"]}/driver/unbind
+        echo ${passthru_bdf["ipu"]} > /sys/bus/pci/drivers/pci-stub/bind
+        boot_ipu_option="$boot_ipu_option"" -s 12,passthru,0/3/0 "
+    fi
+
+    # for ipu passthrough - ipu related i2c
+    # please use virtual slot 22 for i2c to make sure that the i2c controller
+    # could get the same virtaul BDF as physical BDF
+    if [ -d "/sys/bus/pci/devices/${passthru_bdf["ipu_i2c"]}" ]; then
+        echo ${passthru_vpid["ipu_i2c"]} > /sys/bus/pci/drivers/pci-stub/new_id
+        echo ${passthru_bdf["ipu_i2c"]} > /sys/bus/pci/devices/${passthru_bdf["ipu_i2c"]}/driver/unbind
+        echo ${passthru_bdf["ipu_i2c"]} > /sys/bus/pci/drivers/pci-stub/bind
+        boot_ipu_option="$boot_ipu_option"" -s 22,passthru,0/16/0 "
+    fi
+else
+    boot_ipu_option="$boot_ipu_option"" -s 21,virtio-ipu "
+fi
+
+boot_cse_option=""
+if [ $cse_passthrough == 1 ]; then
+    echo ${passthru_vpid["cse"]} > /sys/bus/pci/drivers/pci-stub/new_id
+    echo ${passthru_bdf["cse"]} > /sys/bus/pci/devices/${passthru_bdf["cse"]}/driver/unbind
+    echo ${passthru_bdf["cse"]} > /sys/bus/pci/drivers/pci-stub/bind
+    boot_cse_option="$boot_cse_option"" -s 15,passthru,0/0f/0 "
+else
+    boot_cse_option="$boot_cse_option"" -s 15,virtio-heci,0/0f/0 "
+fi
+
+# for sd card passthrough - SDXC/MMC Host Controller 00:1b.0
+echo ${passthru_vpid["sd_card"]} > /sys/bus/pci/drivers/pci-stub/new_id
+echo ${passthru_bdf["sd_card"]} > /sys/bus/pci/devices/${passthru_bdf["sd_card"]}/driver/unbind
+echo ${passthru_bdf["sd_card"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+#for memsize setting, total 8GB(>7.5GB) uos->6GB, 4GB(>3.5GB) uos->2GB
+memsize=`cat /proc/meminfo|head -n 1|awk '{print $2}'`
+if [ $memsize -gt 7500000 ];then
+    mem_size=6G
+elif [ $memsize -gt 3500000 ];then
+    mem_size=2G
+else
+    mem_size=1750M
+fi
+
+if [ "$setup_mem" != "" ];then
+    mem_size=$setup_mem
+fi
+
+boot_dev_flag=",b"
+if [ $6 == 1 ];then
+  boot_image_option="--vsbl /usr/share/acrn/bios/VSBL_debug.bin"
+else
+  boot_image_option="--vsbl /usr/share/acrn/bios/VSBL.bin"
+fi
+
+#interrupt storm monitor for pass-through devices, params order: 
+#threshold/s,probe-period(s),intr-inject-delay-time(ms),delay-duration(ms)
+intr_storm_monitor="--intr_monitor 10000,10,1,100"
+
+acrn-dm --help 2>&1 | grep 'GVT args'
+if [ $? == 0 ];then
+  GVT_args=$2
+  boot_GVT_option=" -s 0:2:0,pci-gvt -G "
+else
+  boot_GVT_option=''
+  GVT_args=''
+fi
+
+
+acrn-dm -A -m $mem_size $boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
+  -s 5,virtio-console,@pty:pty_port \
+  -s 6,virtio-hyper_dmabuf \
+  -s 8,wdt-i6300esb \
+  -s 3,virtio-blk$boot_dev_flag,/data/$4/$4.img \
+  -s 4,virtio-net,$tap $boot_image_option \
+  -s 7,xhci,1-1:1-2:1-3:2-1:2-2:2-3:cap=apl \
+  -s 9,passthru,0/15/1 \
+  $boot_cse_option \
+  --mac_seed $mac_seed \
+  -s 27,passthru,0/1b/0 \
+  $intr_storm_monitor \
+  $boot_ipu_option      \
+  -i /run/acrn/ioc_$vm_name,0x20 \
+  -l com2,/run/acrn/ioc_$vm_name \
+  --pm_notify_channel ioc \
+  -B "root=/dev/vda2 rw rootwait nohpet console=hvc0 \
+  snd_soc_skl_virtio_fe.domain_id=1 \
+  snd_soc_skl_virtio_fe.domain_name="GuestOS" \
+  console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
+  consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$3 i915.enable_guc_loading=0 \
+  i915.enable_hangcheck=0 i915.nuclear_pageflip=1 \
+  i915.enable_guc_submission=0 i915.enable_guc=0" $vm_name
+}
+
+function launch_android()
+{
+if [ ! -f "/data/$4/$4.img" ]; then
+  echo "no /data/$4/$4.img, exit"
+  exit
+fi
+
+#vm-name used to generate uos-mac address
+mac=$(cat /sys/class/net/e*/address)
+vm_name=vm$1
+mac_seed=${mac:9:8}-${vm_name}
+
+# create a unique tap device for each VM
+tap=tap_$5
+tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
+if [ "$tap_exist"x != "x" ]; then
+  echo "tap device existed, reuse $tap"
+else
+  ip tuntap add dev $tap mode tap
+fi
+
+# if acrn-br0 exists, add VM's unique tap device under it
+br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
+if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
+  echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
+  ip link set "$tap" master acrn-br0
+  ip link set dev "$tap" down
+  ip link set dev "$tap" up
+fi
+
+#Use MMC name + serial for ADB serial no., same as native android
+mmc_name=`cat /sys/block/mmcblk1/device/name`
+mmc_serial=`cat /sys/block/mmcblk1/device/serial | sed -n 's/^..//p'`
+ser=$mmc_name$mmc_serial
+
+#check if the vm is running or not
+vm_ps=$(pgrep -a -f acrn-dm)
+result=$(echo $vm_ps | grep -w "${vm_name}")
+if [[ "$result" != "" ]]; then
+  echo "$vm_name is running, can't create twice!"
+  exit
+fi
+
+#for VT-d device setting
+modprobe pci_stub
+echo ${passthru_vpid["usb_xdci"]} > /sys/bus/pci/drivers/pci-stub/new_id
+echo ${passthru_bdf["usb_xdci"]} > /sys/bus/pci/devices/${passthru_bdf["usb_xdci"]}/driver/unbind
+echo ${passthru_bdf["usb_xdci"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+#for audio device
+boot_audio_option=""
+if [ $audio_passthrough == 1 ]; then
+    echo ${passthru_vpid["audio"]} > /sys/bus/pci/drivers/pci-stub/new_id
+    echo ${passthru_bdf["audio"]} > /sys/bus/pci/devices/${passthru_bdf["audio"]}/driver/unbind
+    echo ${passthru_bdf["audio"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+    #for audio codec
+    echo ${passthru_vpid["audio_codec"]} > /sys/bus/pci/drivers/pci-stub/new_id
+    echo ${passthru_bdf["audio_codec"]} > /sys/bus/pci/devices/${passthru_bdf["audio_codec"]}/driver/unbind
+    echo ${passthru_bdf["audio_codec"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+    boot_audio_option="-s 14,passthru,0/e/0,keep_gsi -s 23,passthru,0/17/0"
+else
+    boot_audio_option="-s 14,virtio-audio"
+fi
+
+# for sd card passthrough - SDXC/MMC Host Controller 00:1b.0
+echo ${passthru_vpid["sd_card"]} > /sys/bus/pci/drivers/pci-stub/new_id
+echo ${passthru_bdf["sd_card"]} > /sys/bus/pci/devices/${passthru_bdf["sd_card"]}/driver/unbind
+echo ${passthru_bdf["sd_card"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+# WIFI
+echo ${passthru_vpid["wifi"]} > /sys/bus/pci/drivers/pci-stub/new_id
+echo ${passthru_bdf["wifi"]} > /sys/bus/pci/devices/${passthru_bdf["wifi"]}/driver/unbind
+echo ${passthru_bdf["wifi"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+# Bluetooth passthrough depends on WIFI
+echo ${passthru_vpid["bluetooth"]} > /sys/bus/pci/drivers/pci-stub/new_id
+echo ${passthru_bdf["bluetooth"]} > /sys/bus/pci/devices/${passthru_bdf["bluetooth"]}/driver/unbind
+echo ${passthru_bdf["bluetooth"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+# Check if the NPK device/driver is present
+ls -d /sys/bus/pci/drivers/intel_th_pci/0000* 2>/dev/null 1>/dev/null
+if [ $? == 0 ];then
+  npk_virt="-s 0:0:2,npk,8/24"
+else
+  npk_virt=""
+fi
+
+# WA for USB role switch hang issue, disable runtime PM of xHCI device
+echo on > /sys/devices/pci0000:00/0000:00:15.0/power/control
+
+echo 100 > /sys/bus/usb/drivers/usb-storage/module/parameters/delay_use
+
+boot_ipu_option=""
+if [ $ipu_passthrough == 1 ];then
+    # for ipu passthrough - ipu device
+    if [ -d "/sys/bus/pci/devices/${passthru_bdf["ipu"]}" ]; then
+        echo ${passthru_vpid["ipu"]} > /sys/bus/pci/drivers/pci-stub/new_id
+        echo ${passthru_bdf["ipu"]} > /sys/bus/pci/devices/${passthru_bdf["ipu"]}/driver/unbind
+        echo ${passthru_bdf["ipu"]} > /sys/bus/pci/drivers/pci-stub/bind
+        boot_ipu_option="$boot_ipu_option"" -s 12,passthru,0/3/0 "
+    fi
+
+    # for ipu passthrough - ipu related i2c
+    # please use virtual slot 22 for i2c to make sure that the i2c controller
+    # could get the same virtaul BDF as physical BDF
+    if [ -d "/sys/bus/pci/devices/${passthru_bdf["ipu_i2c"]}" ]; then
+        echo ${passthru_vpid["ipu_i2c"]} > /sys/bus/pci/drivers/pci-stub/new_id
+        echo ${passthru_bdf["ipu_i2c"]} > /sys/bus/pci/devices/${passthru_bdf["ipu_i2c"]}/driver/unbind
+        echo ${passthru_bdf["ipu_i2c"]} > /sys/bus/pci/drivers/pci-stub/bind
+        boot_ipu_option="$boot_ipu_option"" -s 22,passthru,0/16/0 "
+    fi
+else
+    boot_ipu_option="$boot_ipu_option"" -s 21,virtio-ipu "
+fi
+
+boot_cse_option=""
+if [ $cse_passthrough == 1 ]; then
+    echo ${passthru_vpid["cse"]} /sys/bus/pci/drivers/pci-stub/new_id
+    echo ${passthru_bdf["cse"]} > /sys/bus/pci/devices/${passthru_bdf["cse"]}/driver/unbind
+    echo ${passthru_bdf["cse"]} > /sys/bus/pci/drivers/pci-stub/bind
+    boot_cse_option="$boot_cse_option"" -s 15,passthru,0/0f/0 "
+else
+    boot_cse_option="$boot_cse_option"" -s 15,virtio-heci,0/0f/0 "
+fi
+
+#for memsize setting, total 8GB(>7.5GB) uos->6GB, 4GB(>3.5GB) uos->2GB
+memsize=`cat /proc/meminfo|head -n 1|awk '{print $2}'`
+if [ $memsize -gt 7500000 ];then
+    mem_size=6G
+elif [ $memsize -gt 3500000 ];then
+    mem_size=2G
+else
+    mem_size=1750M
+fi
+
+if [ "$setup_mem" != "" ];then
+    mem_size=$setup_mem
+fi
+
+kernel_cmdline_generic="nohpet tsc=reliable intel_iommu=off \
+   androidboot.serialno=$ser \
+   snd_soc_skl_virtio_fe.domain_id=1 \
+   snd_soc_skl_virtio_fe.domain_name="GuestOS" \
+   i915.enable_rc6=1 i915.enable_fbc=1 i915.enable_guc_loading=0 i915.avail_planes_per_pipe=$3 \
+   i915.enable_hangcheck=0 use_nuclear_flip=1 i915.enable_guc_submission=0 i915.enable_guc=0"
+
+boot_dev_flag=",b"
+if [ $6 == 1 ];then
+  boot_image_option="--vsbl /usr/share/acrn/bios/VSBL_debug.bin"
+else
+  boot_image_option="--vsbl /usr/share/acrn/bios/VSBL.bin"
+fi
+kernel_cmdline="$kernel_cmdline_generic"
+
+: '
+select right virtual slots for acrn_dm:
+1. some passthru device need virtual slot same as physical, like audio 0:e.0 at
+virtual #14 slot, so "-s 14,passthru,0/e/0"
+2. acrn_dm share vioapic irq between some virtual slots: like 6&14, 7&15. Need
+guarantee no virt irq sharing for each passthru device.
+FIXME: picking a virtual slot (#24 now) which is level-triggered to make sure
+audio codec passthrough working
+3. the bootable device slot is configured in compile stating in Android Guest
+image, it should be kept using 3 as fixed value for Android Guest on Gordon_peak
+ACRN project
+'
+
+#interrupt storm monitor for pass-through devices, params order: 
+#threshold/s,probe-period(s),intr-inject-delay-time(ms),delay-duration(ms)
+intr_storm_monitor="--intr_monitor 10000,10,1,100"
+
+acrn-dm --help 2>&1 | grep 'GVT args'
+if [ $? == 0 ];then
+  GVT_args=$2
+  boot_GVT_option=" -s 2,pci-gvt -G "
+else
+  boot_GVT_option=''
+  GVT_args=''
+fi
+
+ acrn-dm -A -m $mem_size $boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio $npk_virt\
+   -s 9,virtio-net,$tap \
+   -s 3,virtio-blk$boot_dev_flag,/data/$4/$4.img \
+   -s 7,xhci,1-1:1-2:1-3:2-1:2-2:2-3:cap=apl \
+   -s 8,passthru,0/15/1 \
+   -s 13,virtio-rpmb \
+   -s 10,virtio-hyper_dmabuf \
+   -s 11,wdt-i6300esb \
+   $boot_audio_option \
+   $boot_cse_option \
+   --mac_seed $mac_seed \
+   -s 27,passthru,0/1b/0 \
+   -s 24,passthru,0/18/0 \
+   -s 18,passthru,3/0/0,keep_gsi \
+   $intr_storm_monitor \
+   $boot_ipu_option      \
+   -i /run/acrn/ioc_$vm_name,0x20 \
+   -l com2,/run/acrn/ioc_$vm_name \
+   --pm_notify_channel ioc \
+   $boot_image_option \
+   --enable_trusty \
+   -B "$kernel_cmdline" $vm_name
+}
+
+function launch_alios()
+{
+#AliOS is not Android, only has same configuration currently, reuse launch function
+
+launch_android "$@"
+}
+
+function help()
+{
+echo "Use luanch_uos.sh like that ./launch_uos.sh -V <#>"
+echo "The option -V means the UOSs group to be launched by vsbl as below"
+echo "-V 1 means just launching 1 clearlinux UOS"
+echo "-V 2 means just launching 1 android UOS"
+echo "-V 3 means launching 1 clearlinux UOS + 1 android UOS"
+echo "-V 4 means launching 2 clearlinux UOSs"
+echo "-V 5 means just launching 1 alios UOS"
+echo "-V 6 means auto check android/linux/alios UOS; if exist, launch it"
+echo "-C means launching acrn-dm in runC container for QoS"
+}
+
+launch_type=1
+debug=0
+runC_enable=0
+
+function run_container()
+{
+vm_name=vm1
+config_src="/usr/share/acrn/samples/apl-mrb/runC.json"
+shell="/usr/share/acrn/conf/add/$vm_name.sh"
+arg_file="/usr/share/acrn/conf/add/$vm_name.args"
+runc_bundle="/usr/share/acrn/conf/add/runc/$vm_name"
+rootfs_dir="/usr/share/acrn/conf/add/runc/rootfs"
+config_dst="$runc_bundle/config.json"
+
+
+input=$(runc list -f table | awk '{print $1}''{print $3}')
+arr=(${input// / })
+
+for((i=0;i<${#arr[@]};i++))
+do
+	if [ "$vm_name" = "${arr[$i]}" ]; then
+		if [ "running" = "${arr[$i+1]}" ]; then
+			echo "runC instance ${arr[$i]} is running"
+			exit
+		else
+			runc kill ${arr[$i]}
+			runc delete ${arr[$i]}
+		fi
+	fi
+done
+vmsts=$(acrnctl list)
+vms=(${vmsts// / })
+for((i=0;i<${#vms[@]};i++))
+do
+	if [ "$vm_name" = "${vms[$i]}" ]; then
+		if [ "stopped" != "${vms[$i+1]}" ]; then
+			echo "Uos ${vms[$i]} ${vms[$i+1]}"
+			acrnctl stop ${vms[$i]}
+		fi
+	fi
+done
+
+if [ ! -f "$shell" ]; then
+        echo "Pls add the vm at first!"
+        exit
+fi
+
+if [ ! -f "$arg_file" ]; then
+        echo "Pls add the vm args!"
+        exit
+fi
+
+if [ ! -d "$rootfs_dir" ]; then
+        mkdir -p "$rootfs_dir"
+fi
+if [ ! -d "$runc_bundle" ]; then
+	mkdir -p "$runc_bundle"
+fi
+if [ ! -f "$config_dst" ]; then
+        cp  "$config_src"  "$config_dst"
+        args=$(sed '{s/-C//g;s/^[ \t]*//g;s/^/\"/;s/ /\",\"/g;s/$/\"/}' ${arg_file})
+        sed -i "s|\"sh\"|\"$shell\", $args|" $config_dst
+fi
+runc run --bundle $runc_bundle -d $vm_name
+echo "The runC container is running in backgroud"
+echo "'#runc exec <vmname> bash' to login the container bash"
+exit
+}
+
+while getopts "V:M:hdC" opt
+do
+	case $opt in
+		V) launch_type=$[$OPTARG]
+			;;
+		M) setup_mem=$OPTARG
+			;;
+		d) debug=1
+			;;
+		C) runC_enable=1
+			;;
+		h) help
+			exit 1
+			;;
+		?) help
+			exit 1
+			;;
+	esac
+done
+
+if [ ! -b "/dev/mmcblk1p3" ]; then
+  echo "no /dev/mmcblk1p3 data partition, exit"
+  exit
+fi
+
+mkdir -p /data
+mount /dev/mmcblk1p3 /data
+
+if [ $launch_type == 6 ]; then
+	if [ -f "/data/android/android.img" ]; then
+	  launch_type=2;
+	elif [ -f "/data/alios/alios.img" ]; then
+	  launch_type=5;
+	else
+	  launch_type=1;
+	fi
+fi
+
+if [ $runC_enable == 1 ]; then
+	if [ $(hostname) = "runc" ]; then
+		echo "Already in container exit!"
+		exit
+	fi
+	run_container
+	exit
+fi
+
+# offline SOS CPUs except BSP before launch UOS
+for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
+        online=`cat $i/online`
+        idx=`echo $i | tr -cd "[1-99]"`
+        echo cpu$idx online=$online
+        if [ "$online" = "1" ]; then
+                echo 0 > $i/online
+		online=`cat $i/online`
+		# during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
+		while [ "$online" = "1" ]; do
+			sleep 1
+			echo 0 > $i/online
+			online=`cat $i/online`
+		done
+                echo $idx > /sys/devices/virtual/misc/acrn_hsm/remove_cpu
+        fi
+done
+
+case $launch_type in
+	1) echo "Launch clearlinux UOS"
+		launch_clearlinux 1 "64 448 8" 0x070F00 clearlinux "LaaG" $debug
+		;;
+	2) echo "Launch android UOS"
+		launch_android 1 "64 448 8" 0x070F00 android "AaaG" $debug
+		;;
+	3) echo "Launch clearlinux UOS + android UOS"
+		launch_android 1 "64 448 4" 0x00000C android "AaaG" $debug &
+		sleep 5
+		launch_clearlinux 2 "64 448 4" 0x070F00 clearlinux "LaaG" $debug
+		;;
+	4) echo "Launch two clearlinux UOSs"
+		launch_clearlinux 1 "64 448 4" 0x00000C clearlinux "L1aaG" $debug &
+		sleep 5
+		launch_clearlinux 2 "64 448 4" 0x070F00 clearlinux_dup "L2aaG" $debug
+		;;
+	5) echo "Launch alios UOS"
+		launch_alios 1 "64 448 8" 0x070F00 alios "AliaaG" $debug
+		;;
+esac
+
+umount /data

--- a/misc/config_tools/data/sample_launch_scripts/apl-up2/launch_uos.sh
+++ b/misc/config_tools/data/sample_launch_scripts/apl-up2/launch_uos.sh
@@ -1,0 +1,481 @@
+#!/bin/bash
+# Copyright (C) 2019-2022 Intel Corporation.
+# SPDX-License-Identifier: BSD-3-Clause
+
+kernel_version=$(uname -r | awk -F. '{ printf("%d.%d", $1,$2) }')
+
+ipu_passthrough=0
+
+# Check the device file of /dev/vbs_ipu to determine the IPU mode
+if [ ! -e "/dev/vbs_ipu" ]; then
+ipu_passthrough=1
+fi
+
+audio_passthrough=0
+
+# Check the device file of /dev/vbs_k_audio to determine the audio mode
+if [ ! -e "/dev/vbs_k_audio" ]; then
+audio_passthrough=1
+fi
+
+cse_passthrough=0
+hbm_ver=`cat /sys/class/mei/mei0/hbm_ver`
+major_ver=`echo $hbm_ver | cut -d '.' -f1`
+minor_ver=`echo $hbm_ver | cut -d '.' -f2`
+if [[ "$major_ver" -lt "2" ]] || \
+   [[ "$major_ver" == "2" && "$minor_ver" -le "2" ]]; then
+    cse_passthrough=1
+fi
+
+# pci devices for passthru
+declare -A passthru_vpid
+declare -A passthru_bdf
+
+passthru_vpid=(
+["usb_xdci"]="8086 5aaa"
+["ipu"]="8086 5a88"
+["ipu_i2c"]="8086 5aac"
+["cse"]="8086 5a9a"
+["sd_card"]="8086 5acc"
+["audio"]="8086 5a98"
+["audio_codec"]="8086 5ab4"
+)
+passthru_bdf=(
+["usb_xdci"]="0000:00:15.1"
+["ipu"]="0000:00:03.0"
+["ipu_i2c"]="0000:00:16.0"
+["cse"]="0000:00:0f.0"
+["sd_card"]="0000:00:1c.0"
+["audio"]="0000:00:0e.0"
+["audio_codec"]="0000:00:17.0"
+)
+
+function launch_clearlinux()
+{
+if [ ! -f "/data/$4/$4.img" ]; then
+  echo "no /data/$4/$4.img, exit"
+  exit
+fi
+
+#vm-name used to generate uos-mac address
+mac=$(cat /sys/class/net/en*/address)
+vm_name=vm$1
+mac_seed=${mac:9:8}-${vm_name} 
+
+# create a unique tap device for each VM
+tap=tap_$5
+tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
+if [ "$tap_exist"x != "x" ]; then
+  echo "tap device existed, reuse $tap"
+else
+  ip tuntap add dev $tap mode tap
+fi
+
+# if acrn-br0 exists, add VM's unique tap device under it
+br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
+if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
+  echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
+  ip link set "$tap" master acrn-br0
+  ip link set dev "$tap" down
+  ip link set dev "$tap" up
+fi
+
+#check if the vm is running or not
+vm_ps=$(pgrep -a -f acrn-dm)
+result=$(echo $vm_ps | grep -w "${vm_name}")
+if [[ "$result" != "" ]]; then
+  echo "$vm_name is running, can't create twice!"
+  exit
+fi
+
+#for VT-d device setting
+modprobe pci_stub
+echo ${passthru_vpid["usb_xdci"]} > /sys/bus/pci/drivers/pci-stub/new_id
+echo ${passthru_bdf["usb_xdci"]} > /sys/bus/pci/devices/${passthru_bdf["usb_xdci"]}/driver/unbind
+echo ${passthru_bdf["usb_xdci"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+boot_ipu_option=""
+if [ $ipu_passthrough == 1 ];then
+    # for ipu passthrough - ipu device 0:3.0
+    if [ -d "/sys/bus/pci/devices/${passthru_bdf["ipu"]}" ]; then
+        echo ${passthru_vpid["ipu"]} > /sys/bus/pci/drivers/pci-stub/new_id
+        echo ${passthru_bdf["ipu"]} > /sys/bus/pci/devices/${passthru_bdf["ipu"]}/driver/unbind
+        echo ${passthru_bdf["ipu"]} > /sys/bus/pci/drivers/pci-stub/bind
+        boot_ipu_option="$boot_ipu_option"" -s 12,passthru,0/3/0 "
+    fi
+
+    # for ipu passthrough - ipu related i2c
+    # please use virtual slot 22 for i2c to make sure that the i2c controller
+    # could get the same virtaul BDF as physical BDF
+    if [ -d "/sys/bus/pci/devices/${passthru_bdf["ipu_i2c"]}" ]; then
+        echo ${passthru_vpid["ipu_i2c"]} > /sys/bus/pci/drivers/pci-stub/new_id
+        echo ${passthru_bdf["ipu_i2c"]} > /sys/bus/pci/devices/${passthru_bdf["ipu_i2c"]}/driver/unbind
+        echo ${passthru_bdf["ipu_i2c"]} > /sys/bus/pci/drivers/pci-stub/bind
+        boot_ipu_option="$boot_ipu_option"" -s 22,passthru,0/16/0 "
+    fi
+else
+    boot_ipu_option="$boot_ipu_option"" -s 21,virtio-ipu "
+fi
+
+boot_cse_option=""
+if [ $cse_passthrough == 1 ]; then
+    echo ${passthru_vpid["cse"]} > /sys/bus/pci/drivers/pci-stub/new_id
+    echo ${passthru_bdf["cse"]} > /sys/bus/pci/devices/${passthru_bdf["cse"]}/driver/unbind
+    echo ${passthru_bdf["cse"]} > /sys/bus/pci/drivers/pci-stub/bind
+    boot_cse_option="$boot_cse_option"" -s 15,passthru,0/0f/0 "
+else
+    boot_cse_option="$boot_cse_option"" -s 15,virtio-heci,0/0f/0 "
+fi
+
+# for sd card passthrough - SDXC/MMC Host Controller
+# echo ${passthru_vpid["sd_card"]} > /sys/bus/pci/drivers/pci-stub/new_id
+# echo ${passthru_bdf["sd_card"]} > /sys/bus/pci/devices/${passthru_bdf["sd_card"]}/driver/unbind
+# echo ${passthru_bdf["sd_card"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+#for memsize setting, total 8GB(>7.5GB) uos->6GB, 4GB(>3.5GB) uos->2GB
+memsize=`cat /proc/meminfo|head -n 1|awk '{print $2}'`
+if [ $memsize -gt 7500000 ];then
+    mem_size=6G
+elif [ $memsize -gt 3500000 ];then
+    mem_size=2G
+else
+    mem_size=1750M
+fi
+
+if [ "$setup_mem" != "" ];then
+    mem_size=$setup_mem
+fi
+
+boot_dev_flag=",b"
+if [ $6 == 1 ];then
+  boot_image_option="--vsbl /usr/share/acrn/bios/VSBL_debug.bin"
+else
+  boot_image_option="--vsbl /usr/share/acrn/bios/VSBL.bin"
+fi
+
+#interrupt storm monitor for pass-through devices, params order: 
+#threshold/s,probe-period(s),intr-inject-delay-time(ms),delay-duration(ms)
+intr_storm_monitor="--intr_monitor 10000,10,1,100"
+
+acrn-dm --help 2>&1 | grep 'GVT args'
+if [ $? == 0 ];then
+  GVT_args=$2
+  boot_GVT_option=" -s 0:2:0,pci-gvt -G "
+else
+  boot_GVT_option=''
+  GVT_args=''
+fi
+
+#logger_setting, format: logger_name,level; like following
+logger_setting="--logger_setting console,level=4;kmsg,level=3;disk,level=5"
+
+acrn-dm -A -m $mem_size $boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
+  -s 5,virtio-console,@pty:pty_port \
+  -s 6,virtio-hyper_dmabuf \
+  -s 8,wdt-i6300esb \
+  -s 3,virtio-blk$boot_dev_flag,/data/$4/$4.img \
+  -s 4,virtio-net,$tap $boot_image_option \
+  -s 7,xhci,1-1:1-2:1-3:2-1:2-2:2-3:cap=apl \
+  -s 9,passthru,0/15/1 \
+  $boot_cse_option \
+  $intr_storm_monitor \
+  $logger_setting \
+  $boot_ipu_option      \
+  --mac_seed $mac_seed \
+  --pm_notify_channel power_button \
+  -B "root=/dev/vda2 rw rootwait nohpet console=hvc0 \
+  console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
+  consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$3 i915.enable_guc_loading=0 \
+  i915.enable_hangcheck=0 i915.nuclear_pageflip=1 \
+  i915.enable_guc_submission=0 i915.enable_guc=0" $vm_name
+}
+
+function launch_android()
+{
+if [ ! -f "/data/$4/$4.img" ]; then
+  echo "no /data/$4/$4.img, exit"
+  exit
+fi
+
+#vm-name used to generate uos-mac address
+mac=$(cat /sys/class/net/en*/address)
+vm_name=vm$1
+mac_seed=${mac:9:8}-${vm_name} 
+
+# create a unique tap device for each VM
+tap=tap_$5
+tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
+if [ "$tap_exist"x != "x" ]; then
+  echo "tap device existed, reuse $tap"
+else
+  ip tuntap add dev $tap mode tap
+fi
+
+# if acrn-br0 exists, add VM's unique tap device under it
+br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
+if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
+  echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
+  ip link set "$tap" master acrn-br0
+  ip link set dev "$tap" down
+  ip link set dev "$tap" up
+fi
+
+#Use MMC name + serial for ADB serial no., same as native android
+mmc_name=`cat /sys/block/mmcblk0/device/name`
+mmc_serial=`cat /sys/block/mmcblk0/device/serial | sed -n 's/^..//p'`
+ser=$mmc_name$mmc_serial
+
+#check if the vm is running or not
+vm_ps=$(pgrep -a -f acrn-dm)
+result=$(echo $vm_ps | grep -w "${vm_name}")
+if [[ "$result" != "" ]]; then
+  echo "$vm_name is running, can't create twice!"
+  exit
+fi
+
+#for VT-d device setting
+modprobe pci_stub
+echo ${passthru_vpid["usb_xdci"]} > /sys/bus/pci/drivers/pci-stub/new_id
+echo ${passthru_bdf["usb_xdci"]} > /sys/bus/pci/devices/${passthru_bdf["usb_xdci"]}/driver/unbind
+echo ${passthru_bdf["usb_xdci"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+#for audio device
+boot_audio_option=""
+if [ $audio_passthrough == 1 ]; then
+    echo ${passthru_vpid["audio"]} > /sys/bus/pci/drivers/pci-stub/new_id
+    echo ${passthru_bdf["audio"]} > /sys/bus/pci/devices/${passthru_bdf["audio"]}/driver/unbind
+    echo ${passthru_bdf["audio"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+    #for audio codec
+    echo ${passthru_vpid["audio_codec"]} > /sys/bus/pci/drivers/pci-stub/new_id
+    echo ${passthru_bdf["audio_codec"]} > /sys/bus/pci/devices/${passthru_bdf["audio_codec"]}/driver/unbind
+    echo ${passthru_bdf["audio_codec"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+    boot_audio_option="-s 14,passthru,0/e/0,keep_gsi -s 23,passthru,0/17/0"
+else
+    boot_audio_option="-s 14,virtio-audio"
+fi
+# # for sd card passthrough - SDXC/MMC Host Controller 00:1b.0
+# echo ${passthru_vpid["sd_card"]} > /sys/bus/pci/drivers/pci-stub/new_id
+# echo ${passthru_bdf["sd_card"]} > /sys/bus/pci/devices/${passthru_bdf["sd_card"]}/driver/unbind
+# echo ${passthru_bdf["sd_card"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+# Check if the NPK device/driver is present
+ls -d /sys/bus/pci/drivers/intel_th_pci/0000* 2>/dev/null 1>/dev/null
+if [ $? == 0 ];then
+  npk_virt="-s 0:0:2,npk,8/24"
+else
+  npk_virt=""
+fi
+
+# WA for USB role switch hang issue, disable runtime PM of xHCI device
+echo on > /sys/devices/pci0000:00/0000:00:15.0/power/control
+
+boot_ipu_option=""
+if [ $ipu_passthrough == 1 ];then
+    # for ipu passthrough - ipu device
+    if [ -d "/sys/bus/pci/devices/${passthru_bdf["ipu"]}" ]; then
+        echo ${passthru_vpid["ipu"]} > /sys/bus/pci/drivers/pci-stub/new_id
+        echo ${passthru_bdf["ipu"]} > /sys/bus/pci/devices/${passthru_bdf["ipu"]}/driver/unbind
+        echo ${passthru_bdf["ipu"]} > /sys/bus/pci/drivers/pci-stub/bind
+        boot_ipu_option="$boot_ipu_option"" -s 12,passthru,0/3/0 "
+    fi
+
+    # for ipu passthrough - ipu related i2c 0:16.0
+    # please use virtual slot 22 for i2c 0:16.0 to make sure that the i2c controller
+    # could get the same virtaul BDF as physical BDF
+    if [ -d "/sys/bus/pci/devices/0000:00:16.0" ]; then
+        echo ${passthru_vpid["ipu_i2c"]} > /sys/bus/pci/drivers/pci-stub/new_id
+        echo ${passthru_bdf["ipu_i2c"]} > /sys/bus/pci/devices/${passthru_bdf["ipu_i2c"]}/driver/unbind
+        echo ${passthru_bdf["ipu_i2c"]} > /sys/bus/pci/drivers/pci-stub/bind
+        boot_ipu_option="$boot_ipu_option"" -s 22,passthru,0/16/0 "
+    fi
+else
+    boot_ipu_option="$boot_ipu_option"" -s 21,virtio-ipu "
+fi
+
+boot_cse_option=""
+if [ $cse_passthrough == 1 ]; then
+    echo ${passthru_vpid["cse"]} > /sys/bus/pci/drivers/pci-stub/new_id
+    echo ${passthru_bdf["cse"]} > /sys/bus/pci/devices/${passthru_bdf["cse"]}/driver/unbind
+    echo ${passthru_bdf["cse"]} > /sys/bus/pci/drivers/pci-stub/bind
+    boot_cse_option="$boot_cse_option"" -s 15,passthru,0/0f/0 "
+else
+    boot_cse_option="$boot_cse_option"" -s 15,virtio-heci,0/0f/0 "
+fi
+
+#for memsize setting, total 8GB(>7.5GB) uos->6GB, 4GB(>3.5GB) uos->2GB
+memsize=`cat /proc/meminfo|head -n 1|awk '{print $2}'`
+if [ $memsize -gt 7500000 ];then
+    mem_size=6G
+elif [ $memsize -gt 3500000 ];then
+    mem_size=2G
+else
+    mem_size=1750M
+fi
+
+if [ "$setup_mem" != "" ];then
+    mem_size=$setup_mem
+fi
+
+kernel_cmdline_generic="nohpet tsc=reliable intel_iommu=off \
+   androidboot.serialno=$ser \
+   i915.enable_rc6=1 i915.enable_fbc=1 i915.enable_guc_loading=0 i915.avail_planes_per_pipe=$3 \
+   i915.enable_hangcheck=0 use_nuclear_flip=1 i915.enable_guc_submission=0 i915.enable_guc=0"
+
+boot_dev_flag=",b"
+if [ $6 == 1 ];then
+  boot_image_option="--vsbl /usr/share/acrn/bios/VSBL_debug.bin"
+else
+  boot_image_option="--vsbl /usr/share/acrn/bios/VSBL.bin"
+fi
+kernel_cmdline="$kernel_cmdline_generic"
+
+: '
+select right virtual slots for acrn_dm:
+1. some passthru device need virtual slot same as physical, like audio 0:e.0 at
+virtual #14 slot, so "-s 14,passthru,0/e/0"
+2. acrn_dm share vioapic irq between some virtual slots: like 6&14, 7&15. Need
+guarantee no virt irq sharing for each passthru device.
+FIXME: picking a virtual slot (#24 now) which is level-triggered to make sure
+audio codec passthrough working
+3. the bootable device slot is configured in compile stating in Android Guest
+image, it should be kept using 3 as fixed value for Android Guest on Gordon_peak
+ACRN project
+'
+
+#interrupt storm monitor for pass-through devices, params order: 
+#threshold/s,probe-period(s),intr-inject-delay-time(ms),delay-duration(ms)
+intr_storm_monitor="--intr_monitor 10000,10,1,100"
+
+acrn-dm --help 2>&1 | grep 'GVT args'
+if [ $? == 0 ];then
+  GVT_args=$2
+  boot_GVT_option=" -s 2,pci-gvt -G "
+else
+  boot_GVT_option=''
+  GVT_args=''
+fi
+
+#logger_setting, format: logger_name,level; like following
+logger_setting="--logger_setting console,level=4;kmsg,level=3;disk,level=5"
+
+ acrn-dm -A -m $mem_size $boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio $npk_virt\
+   -s 9,virtio-net,$tap \
+   -s 3,virtio-blk$boot_dev_flag,/data/$4/$4.img \
+   -s 7,xhci,1-1:1-2:1-3:2-1:2-2:2-3:cap=apl \
+   -s 8,passthru,0/15/1 \
+   -s 13,virtio-rpmb \
+   -s 10,virtio-hyper_dmabuf \
+   -s 11,wdt-i6300esb \
+   $boot_audio_option \
+   $boot_cse_option \
+   $intr_storm_monitor \
+   $logger_setting \
+   $boot_ipu_option      \
+   --mac_seed $mac_seed \
+   $boot_image_option \
+   --enable_trusty \
+   --pm_notify_channel power_button \
+   -B "$kernel_cmdline" $vm_name
+}
+
+function launch_alios()
+{
+#AliOS is not Android, only has same configuration currently, reuse launch function
+
+launch_android "$@"
+}
+
+function help()
+{
+echo "Use luanch_uos.sh like that ./launch_uos.sh -V <#>"
+echo "The option -V means the UOSs group to be launched by vsbl as below"
+echo "-V 1 means just launching 1 clearlinux UOS"
+echo "-V 2 means just launching 1 android UOS"
+echo "-V 3 means launching 1 clearlinux UOS + 1 android UOS"
+echo "-V 4 means launching 2 clearlinux UOSs"
+echo "-V 5 means just launching 1 alios UOS"
+echo "-V 6 means auto check android/linux/alios UOS; if exist, launch it"
+}
+
+launch_type=1
+debug=0
+
+while getopts "V:M:hd" opt
+do
+	case $opt in
+		V) launch_type=$[$OPTARG]
+			;;
+		M) setup_mem=$OPTARG
+			;;
+		d) debug=1
+			;;
+		h) help
+			exit 1
+			;;
+		?) help
+			exit 1
+			;;
+	esac
+done
+
+if [ ! -b "/dev/mmcblk0p1" ]; then
+  echo "no /dev/mmcblk0p1 data partition, exit"
+  exit
+fi
+
+mkdir -p /data
+mount /dev/mmcblk0p1 /data
+
+if [ $launch_type == 6 ]; then
+	if [ -f "/data/android/android.img" ]; then
+	  launch_type=2;
+	elif [ -f "/data/alios/alios.img" ]; then
+	  launch_type=5;
+	else
+	  launch_type=1;
+	fi
+fi
+
+# offline SOS CPUs except BSP before launch UOS
+for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
+        online=`cat $i/online`
+        idx=`echo $i | tr -cd "[1-99]"`
+        echo cpu$idx online=$online
+        if [ "$online" = "1" ]; then
+                echo 0 > $i/online
+		online=`cat $i/online`
+		# during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
+		while [ "$online" = "1" ]; do
+			sleep 1
+			echo 0 > $i/online
+			online=`cat $i/online`
+		done
+                echo $idx > /sys/devices/virtual/misc/acrn_hsm/remove_cpu
+        fi
+done
+
+case $launch_type in
+	1) echo "Launch clearlinux UOS"
+		launch_clearlinux 1 "64 448 8" 0x070F00 clearlinux "LaaG" $debug
+		;;
+	2) echo "Launch android UOS"
+		launch_android 1 "64 448 8" 0x070F00 android "AaaG" $debug
+		;;
+	3) echo "Launch clearlinux UOS + android UOS"
+		launch_android 1 "64 448 4" 0x00000C android "AaaG" $debug &
+		sleep 5
+		launch_clearlinux 2 "64 448 4" 0x070F00 clearlinux "LaaG" $debug
+		;;
+	4) echo "Launch two clearlinux UOSs"
+		launch_clearlinux 1 "64 448 4" 0x00000C clearlinux "L1aaG" $debug &
+		sleep 5
+		launch_clearlinux 2 "64 448 4" 0x070F00 clearlinux_dup "L2aaG" $debug
+		;;
+	5) echo "Launch alios UOS"
+		launch_alios 1 "64 448 8" 0x070F00 alios "AliaaG" $debug
+		;;
+esac
+
+umount /data

--- a/misc/config_tools/data/sample_launch_scripts/launch_ubuntu.sh
+++ b/misc/config_tools/data/sample_launch_scripts/launch_ubuntu.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2020 Intel Corporation.
+# Copyright (C) 2020-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 function launch_ubuntu()

--- a/misc/config_tools/data/sample_launch_scripts/nuc/launch_hard_rt_vm.sh
+++ b/misc/config_tools/data/sample_launch_scripts/nuc/launch_hard_rt_vm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 # This is an example, if use different HW,the script must be adapted to match the BDF on the actual HW platform
 

--- a/misc/config_tools/data/sample_launch_scripts/nuc/launch_uos.sh
+++ b/misc/config_tools/data/sample_launch_scripts/nuc/launch_uos.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 function run_container()

--- a/misc/config_tools/data/sample_launch_scripts/nuc/launch_vxworks.sh
+++ b/misc/config_tools/data/sample_launch_scripts/nuc/launch_vxworks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 function launch_vxworks()

--- a/misc/config_tools/data/sample_launch_scripts/nuc/launch_xenomai.sh
+++ b/misc/config_tools/data/sample_launch_scripts/nuc/launch_xenomai.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2020 Intel Corporation.
+# Copyright (C) 2020-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # set -x

--- a/misc/config_tools/data/sample_launch_scripts/nuc/launch_zephyr.sh
+++ b/misc/config_tools/data/sample_launch_scripts/nuc/launch_zephyr.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 
 function launch_zephyr()

--- a/misc/config_tools/hv_config/board_defconfig.py
+++ b/misc/config_tools/hv_config/board_defconfig.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/hv_config/hv_item.py
+++ b/misc/config_tools/hv_config/hv_item.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation.
+# Copyright (C) 2020-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/library/board_cfg_lib.py
+++ b/misc/config_tools/library/board_cfg_lib.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/library/common.py
+++ b/misc/config_tools/library/common.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/library/hv_cfg_lib.py
+++ b/misc/config_tools/library/hv_cfg_lib.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation.
+# Copyright (C) 2020-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/library/hypervisor_license
+++ b/misc/config_tools/library/hypervisor_license
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Intel Corporation.
+ * Copyright (C) 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/config_tools/library/launch_cfg_lib.py
+++ b/misc/config_tools/library/launch_cfg_lib.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/library/scenario_cfg_lib.py
+++ b/misc/config_tools/library/scenario_cfg_lib.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/scenario_config/scenario_cfg_gen.py
+++ b/misc/config_tools/scenario_config/scenario_cfg_gen.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/scenario_config/scenario_item.py
+++ b/misc/config_tools/scenario_config/scenario_item.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation.
+# Copyright (C) 2019-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/service_vm_config/serial_config.py
+++ b/misc/config_tools/service_vm_config/serial_config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/bdf.py
+++ b/misc/config_tools/static_allocators/bdf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/board_capability.py
+++ b/misc/config_tools/static_allocators/board_capability.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/cpu_affinity.py
+++ b/misc/config_tools/static_allocators/cpu_affinity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/gpa.py
+++ b/misc/config_tools/static_allocators/gpa.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/hv_ram.py
+++ b/misc/config_tools/static_allocators/hv_ram.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 Intel Corporation. All rights reserved.
+# Copyright (C) 2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/intx.py
+++ b/misc/config_tools/static_allocators/intx.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/lib/__init__.py
+++ b/misc/config_tools/static_allocators/lib/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/lib/error.py
+++ b/misc/config_tools/static_allocators/lib/error.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/lib/lib.py
+++ b/misc/config_tools/static_allocators/lib/lib.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/main.py
+++ b/misc/config_tools/static_allocators/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/static_allocators/pio.py
+++ b/misc/config_tools/static_allocators/pio.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/misc/config_tools/xforms/board_info.h.xsl
+++ b/misc/config_tools/xforms/board_info.h.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. -->
+<!-- Copyright (C) 2021-2022 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/config.h.xsl
+++ b/misc/config_tools/xforms/config.h.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. -->
+<!-- Copyright (C) 2021-2022 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/config.mk.xsl
+++ b/misc/config_tools/xforms/config.mk.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. -->
+<!-- Copyright (C) 2021-2022 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/ivshmem_cfg.h.xsl
+++ b/misc/config_tools/xforms/ivshmem_cfg.h.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. -->
+<!-- Copyright (C) 2021-2022 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/lib.xsl
+++ b/misc/config_tools/xforms/lib.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 
-<!-- Copyright (C) 2021 Intel Corporation. -->
+<!-- Copyright (C) 2021-2022 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. -->
+<!-- Copyright (C) 2021-2022 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/pci_dev.c.xsl
+++ b/misc/config_tools/xforms/pci_dev.c.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 
-<!-- Copyright (C) 2021 Intel Corporation. -->
+<!-- Copyright (C) 2021-2022 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/pt_intx.c.xsl
+++ b/misc/config_tools/xforms/pt_intx.c.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. -->
+<!-- Copyright (C) 2021-2022 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/config_tools/xforms/vm_configurations.h.xsl
+++ b/misc/config_tools/xforms/vm_configurations.h.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (C) 2021 Intel Corporation. -->
+<!-- Copyright (C) 2021-2022 Intel Corporation. -->
 <!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <xsl:stylesheet

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/android_events.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/android_events.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/channels.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/channels.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/crash_reclassify.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/crash_reclassify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/event_handler.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/event_handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/event_queue.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/event_queue.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/history.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/history.c
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/android_events.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/android_events.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/channels.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/channels.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/crash_reclassify.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/crash_reclassify.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/event_handler.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/event_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/event_queue.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/event_queue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/history.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/history.h
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/load_conf.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/load_conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/loop.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/loop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/probeutils.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/probeutils.h
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/property.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/property.h
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/sender.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/sender.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/startupreason.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/startupreason.h
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/vmrecord.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/vmrecord.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/load_conf.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/load_conf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/loop.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/loop.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/main.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/probeutils.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/probeutils.c
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/property.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/property.c
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/sender.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/sender.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/startupreason.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/startupreason.c
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/vmrecord.c
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/vmrecord.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/common/cmdutils.c
+++ b/misc/debug_tools/acrn_crashlog/common/cmdutils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/common/fsutils.c
+++ b/misc/debug_tools/acrn_crashlog/common/fsutils.c
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/misc/debug_tools/acrn_crashlog/common/include/cmdutils.h
+++ b/misc/debug_tools/acrn_crashlog/common/include/cmdutils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/common/include/fsutils.h
+++ b/misc/debug_tools/acrn_crashlog/common/include/fsutils.h
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/misc/debug_tools/acrn_crashlog/common/include/log_sys.h
+++ b/misc/debug_tools/acrn_crashlog/common/include/log_sys.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/common/include/strutils.h
+++ b/misc/debug_tools/acrn_crashlog/common/include/strutils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/common/log_sys.c
+++ b/misc/debug_tools/acrn_crashlog/common/log_sys.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/common/strutils.c
+++ b/misc/debug_tools/acrn_crashlog/common/strutils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/data/crashlogctl
+++ b/misc/debug_tools/acrn_crashlog/data/crashlogctl
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # crashlogctl is part of acrn-hypervisor.

--- a/misc/debug_tools/acrn_crashlog/data/usercrash-wrapper
+++ b/misc/debug_tools/acrn_crashlog/data/usercrash-wrapper
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) <2018> Intel Corporation
+# Copyright (C) 2018-2022 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/misc/debug_tools/acrn_crashlog/license_header
+++ b/misc/debug_tools/acrn_crashlog/license_header
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/usercrash/client.c
+++ b/misc/debug_tools/acrn_crashlog/usercrash/client.c
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/misc/debug_tools/acrn_crashlog/usercrash/crash_dump.c
+++ b/misc/debug_tools/acrn_crashlog/usercrash/crash_dump.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/usercrash/debugger.c
+++ b/misc/debug_tools/acrn_crashlog/usercrash/debugger.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/usercrash/include/crash_dump.h
+++ b/misc/debug_tools/acrn_crashlog/usercrash/include/crash_dump.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/usercrash/include/packet.h
+++ b/misc/debug_tools/acrn_crashlog/usercrash/include/packet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/usercrash/include/protocol.h
+++ b/misc/debug_tools/acrn_crashlog/usercrash/include/protocol.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/debug_tools/acrn_crashlog/usercrash/protocol.c
+++ b/misc/debug_tools/acrn_crashlog/usercrash/protocol.c
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/misc/debug_tools/acrn_crashlog/usercrash/server.c
+++ b/misc/debug_tools/acrn_crashlog/usercrash/server.c
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) <2018> Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /*
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/misc/debug_tools/acrn_log/acrnlog.c
+++ b/misc/debug_tools/acrn_log/acrnlog.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/debug_tools/acrn_trace/acrntrace.c
+++ b/misc/debug_tools/acrn_trace/acrntrace.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/debug_tools/acrn_trace/acrntrace.h
+++ b/misc/debug_tools/acrn_trace/acrntrace.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/debug_tools/acrn_trace/sbuf.c
+++ b/misc/debug_tools/acrn_trace/sbuf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/debug_tools/acrn_trace/sbuf.h
+++ b/misc/debug_tools/acrn_trace/sbuf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/efi-stub/Makefile
+++ b/misc/efi-stub/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011 - 2021, Intel Corporation
+# Copyright (c) 2011 - 2022, Intel Corporation.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/misc/efi-stub/boot.c
+++ b/misc/efi-stub/boot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 - 2021, Intel Corporation
+ * Copyright (c) 2011 - 2022, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/boot.h
+++ b/misc/efi-stub/boot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 - 2021, Intel Corporation
+ * Copyright (c) 2011 - 2022, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/container.c
+++ b/misc/efi-stub/container.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Intel Corporation.
+ * Copyright (c) 2021 - 2022, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/container.h
+++ b/misc/efi-stub/container.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Intel Corporation.
+ * Copyright (c) 2021 - 2022, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/efilinux.h
+++ b/misc/efi-stub/efilinux.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 - 2021, Intel Corporation
+ * Copyright (c) 2011 - 2022, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/elf32.c
+++ b/misc/efi-stub/elf32.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Intel Corporation.
+ * Copyright (c) 2021 - 2022, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/elf32.h
+++ b/misc/efi-stub/elf32.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Intel Corporation.
+ * Copyright (c) 2021 - 2022, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/malloc.c
+++ b/misc/efi-stub/malloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 - 2021, Intel Corporation
+ * Copyright (c) 2011 - 2022, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/multiboot.c
+++ b/misc/efi-stub/multiboot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Intel Corporation.
+ * Copyright (c) 2021 - 2022, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/pe.c
+++ b/misc/efi-stub/pe.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 - 2021, Intel Corporation
+ * Copyright (c) 2011 - 2022, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/efi-stub/stdlib.h
+++ b/misc/efi-stub/stdlib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 - 2021, Intel Corporation
+ * Copyright (c) 2011 - 2022, Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/misc/hv_prebuild/hv_prebuild.h
+++ b/misc/hv_prebuild/hv_prebuild.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/hv_prebuild/main.c
+++ b/misc/hv_prebuild/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/hv_prebuild/static_checks.c
+++ b/misc/hv_prebuild/static_checks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/hv_prebuild/vm_cfg_checks.c
+++ b/misc/hv_prebuild/vm_cfg_checks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation.
+ * Copyright (C) 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/misc/packaging/100_ACRN
+++ b/misc/packaging/100_ACRN
@@ -1,5 +1,5 @@
 #!/bin/bash
-#* Copyright (c) 2020 Intel Corporation.
+#* Copyright (c) 2020-2022 Intel Corporation.
 # postinst script for acrn kernel
 set -e
 

--- a/misc/packaging/acrn-board-inspector.postinst
+++ b/misc/packaging/acrn-board-inspector.postinst
@@ -1,5 +1,5 @@
 #!/bin/bash
-#* Copyright (c) 2020 Intel Corporation SPDX-License-Identifier: BSD-3-Clause
+#* Copyright (c) 2020-2022 Intel Corporation SPDX-License-Identifier: BSD-3-Clause
 # postinst script for acrn-board-inspector
 
 pip3 install xmlschema

--- a/misc/packaging/acrn-hypervisor.postinst
+++ b/misc/packaging/acrn-hypervisor.postinst
@@ -1,5 +1,5 @@
 #!/bin/bash
-#* Copyright (c) 2020 Intel Corporation SPDX-License-Identifier: BSD-3-Clause
+#* Copyright (c) 2020-2022 Intel Corporation SPDX-License-Identifier: BSD-3-Clause
 # postinst script for acrn-hypervisor
 # please NOTE ！！！  scenario_info/board_info changed by python scripts, so do not add content there!!!
 # please NOTE ！！！  scenario_info/board_info please add in release.json if needed !!!

--- a/misc/packaging/acrn-kernel.postinst
+++ b/misc/packaging/acrn-kernel.postinst
@@ -1,5 +1,5 @@
 #!/bin/bash
-#* Copyright (c) 2020 Intel Corporation.
+#* Copyright (c) 2020-2022 Intel Corporation.
 # postinst script for acrn kernel
 filename="/etc/grub.d/40_custom"
 menu=$(grep ACRN_deb_multiboot2 ${filename}) || true

--- a/misc/packaging/compile_iasl.py
+++ b/misc/packaging/compile_iasl.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#* Copyright (c) 2020 Intel Corporation
+#* Copyright (c) 2020-2022 Intel Corporation.
 import os,sys,copy,json
 import subprocess
 import datetime

--- a/misc/services/acrn_manager/acrn_mngr.c
+++ b/misc/services/acrn_manager/acrn_mngr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2018 Intel Corporation
+ * Copyright (C)2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/services/acrn_manager/acrn_mngr.h
+++ b/misc/services/acrn_manager/acrn_mngr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2018 Intel Corporation
+ * Copyright (C)2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/services/acrn_manager/acrn_vm_ops.c
+++ b/misc/services/acrn_manager/acrn_vm_ops.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/services/acrn_manager/acrnctl.c
+++ b/misc/services/acrn_manager/acrnctl.c
@@ -2,7 +2,7 @@
  * ProjectAcrn
  * Acrnctl
  *
- * Copyright (C) 2018 Intel Corporation.
+ * Copyright (C) 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/misc/services/acrn_manager/acrnctl.h
+++ b/misc/services/acrn_manager/acrnctl.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/services/acrn_manager/acrnd.c
+++ b/misc/services/acrn_manager/acrnd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2018 Intel Corporation
+ * Copyright (C)2018-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/services/life_mngr/command.c
+++ b/misc/services/life_mngr/command.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/services/life_mngr/command.h
+++ b/misc/services/life_mngr/command.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _CMD_H_

--- a/misc/services/life_mngr/command_handler.c
+++ b/misc/services/life_mngr/command_handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <stdio.h>

--- a/misc/services/life_mngr/command_handler.h
+++ b/misc/services/life_mngr/command_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _CMD_HANDLER_H_

--- a/misc/services/life_mngr/config.c
+++ b/misc/services/life_mngr/config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/services/life_mngr/config.h
+++ b/misc/services/life_mngr/config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _CONFIG_H_

--- a/misc/services/life_mngr/life_mngr_win.c
+++ b/misc/services/life_mngr/life_mngr_win.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2019 Intel Corporation
+ * Copyright (C)2019-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/services/life_mngr/log.h
+++ b/misc/services/life_mngr/log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _LOG_H_

--- a/misc/services/life_mngr/monitor.c
+++ b/misc/services/life_mngr/monitor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/services/life_mngr/socket.c
+++ b/misc/services/life_mngr/socket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/services/life_mngr/socket.h
+++ b/misc/services/life_mngr/socket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _SOCKET_H_

--- a/misc/services/life_mngr/uart.c
+++ b/misc/services/life_mngr/uart.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/services/life_mngr/uart.h
+++ b/misc/services/life_mngr/uart.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _UART_H_

--- a/misc/services/life_mngr/uart_channel.c
+++ b/misc/services/life_mngr/uart_channel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/misc/services/life_mngr/uart_channel.h
+++ b/misc/services/life_mngr/uart_channel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2021 Intel Corporation
+ * Copyright (C)2021-2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _UART_CHANNEL_H_

--- a/misc/services/life_mngr/user_vm_shutdown.py
+++ b/misc/services/life_mngr/user_vm_shutdown.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation.
+# Copyright (C) 2021-2022 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #


### PR DESCRIPTION
Modified the copyright year range in code, and corrected "int32_tel"
into "Intel" in two "hypervisor/include/debug/profiling.h" and
"hypervisor/include/debug/profiling_internal.h".

Tracked-On: #7559
Signed-off-by: Ziheng Li <ziheng.li@intel.com>