### PR TITLE
config-tools: hide the 'update-pciids: download failed' message

### DIFF
--- a/misc/config_tools/board_inspector/board_inspector.py
+++ b/misc/config_tools/board_inspector/board_inspector.py
@@ -67,7 +67,7 @@ def check_deps():
     # Try updating pci.ids for latest PCI device descriptions
     try:
         logger.info("Updating pci.ids for latest PCI device descriptions.")
-        res = subprocess.Popen(["update-pciids", "-q"])
+        res = subprocess.Popen(["update-pciids", "-q"], stderr=subprocess.DEVNULL)
         if res.wait() != 0:
             logger.warning(f"Failed to invoke update-pciids. No functional impact is foreseen, but descriptions of PCI devices may be inaccurate.")
     except Exception as e:


### PR DESCRIPTION
Use stderror to redirect error message to subprocess.DEVNULL
to hide it when the "update pciids" command is called.

Tracked-On: #7886
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Signed-off-by: Ziheng Li <ziheng.li@intel.com>