### PR TITLE
dm: fix the secure coding style violations

### DIFF
--- a/devicemodel/hw/mmio/core.c
+++ b/devicemodel/hw/mmio/core.c
@@ -115,11 +115,11 @@ int create_pt_acpidev(char *opt)
  *
  * @pre (name != NULL) && (strlen(name) > 0)
  */
-int get_mmio_hpa_resource(char *name, uint64_t *res_start, uint64_t *res_size)
+bool get_mmio_hpa_resource(char *name, uint64_t *res_start, uint64_t *res_size)
 {
 	FILE *fp;
 	uint64_t start, end;
-	int found = false;
+	bool found = false;
 	char line[128];
 	char *cp;
 

--- a/devicemodel/hw/pci/virtio/virtio_net.c
+++ b/devicemodel/hw/pci/virtio/virtio_net.c
@@ -850,14 +850,14 @@ virtio_net_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	unsigned char digest[16];
 	char nstr[80];
 	char tname[MAXCOMLEN + 1];
-	struct virtio_net *net;
+	struct virtio_net *net = NULL;
 	char *devopts = NULL;
 	char *name = NULL;
 	char *type = NULL;
 	char *mac_seed = NULL;
-	char *tmp;
-	char *vtopts;
-	char *opt;
+	char *tmp = NULL;
+	char *vtopts = NULL;
+	char *opt = NULL;
 	int mac_provided;
 	pthread_mutexattr_t attr;
 	int rc;
@@ -940,8 +940,11 @@ virtio_net_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		return -1;
 	}
 
-	vtopts = tmp = strdup(opts);
-	if (strncmp(tmp, "tap", 3) == 0) {
+	if (opts != NULL) {
+		vtopts = tmp = strdup(opts);
+	}
+
+	if ((tmp != NULL) && (strncmp(tmp, "tap", 3) == 0)) {
 		type = strsep(&tmp, "=");
 		name = strsep(&tmp, ",");
 	}
@@ -963,8 +966,13 @@ virtio_net_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	 * followed by an MD5 of the PCI slot/func number and dev name
 	 */
 	if (!mac_provided) {
-		snprintf(nstr, sizeof(nstr), "%d-%d-%s", dev->slot,
-		    dev->func, mac_seed);
+		if (mac_seed != NULL) {
+			snprintf(nstr, sizeof(nstr), "%d-%d-%s", dev->slot,
+				dev->func, mac_seed);
+		} else {
+			snprintf(nstr, sizeof(nstr), "%d-%d", dev->slot,
+				dev->func);
+		}
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 		EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
 		EVP_DigestInit_ex(mdctx, EVP_md5(), NULL);

--- a/devicemodel/hw/platform/tpm/tpm.c
+++ b/devicemodel/hw/platform/tpm/tpm.c
@@ -108,7 +108,7 @@ static int init_tpm2_pt(char *opts, struct mmio_dev *tpm2dev)
 	uint64_t tpm2_buffer_hpa, tpm2_buffer_size;
 	uint32_t base = 0;
 	struct acpi_table_tpm2 tpm2 = { 0 };
-	char *devopts, *vtopts;
+	char *devopts, *vtopts = NULL;
 
 	/* TODO: Currently we did not validate if the opts is a valid one.
 	 * We trust it to be valid as specifying --acpidev_pt is regarded
@@ -119,6 +119,9 @@ static int init_tpm2_pt(char *opts, struct mmio_dev *tpm2dev)
 	}
 
 	devopts = strdup(opts);
+	if (devopts == NULL) {
+		return -EINVAL;
+	}
 	vtopts = strstr(devopts,",");
 
 	/* Check whether user set the uid to identify same hid devices for

--- a/devicemodel/include/mmio_dev.h
+++ b/devicemodel/include/mmio_dev.h
@@ -27,7 +27,7 @@ struct acpi_dev_pt_ops {
 #define DEFINE_ACPI_PT_DEV(x) DATA_SET(acpi_dev_pt_ops_set, x);
 
 struct mmio_dev *get_mmiodev(char *name);
-int get_mmio_hpa_resource(char *name, uint64_t *res_start, uint64_t *res_size);
+bool get_mmio_hpa_resource(char *name, uint64_t *res_start, uint64_t *res_size);
 int get_more_acpi_dev_info(char *hid, uint32_t instance, struct acpi_dev_pt_ops *ops);
 void acpi_dev_write_dsdt(struct vmctx *ctx);
 


### PR DESCRIPTION
Merge from release_3.0

There was some secure coding style violations of virtio net and tmp,
this patch add some NULL check to fix these violations.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>
