### PR TITLE
config-tools: fix board inspector crashed error

### DIFF
--- a/misc/config_tools/board_inspector/extractors/40-acpi-tables.py
+++ b/misc/config_tools/board_inspector/extractors/40-acpi-tables.py
@@ -34,7 +34,7 @@ def extract_gsi_number(ioapic_node, apic_id):
                 add_child(ioapic_node, "gsi_number", str(current_max - previous_max))
                 break
         except:
-            add_child(ioapic_node, "gsi_number", DEFAULT_MAX_IOAPIC_LINES)
+            add_child(ioapic_node, "gsi_number", str(DEFAULT_MAX_IOAPIC_LINES))
             break
     os.close(fd)
 


### PR DESCRIPTION
Fixed the problem of exception handling of the
incoming type error in reading GSI number method
in 40-acpi-tables.py line 37 when dmesg command
line is too long.

Tracked-On: 7906
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Signed-off-by: Ziheng Li <ziheng.li@intel.com>