### PR TITLE
config_tools: add two spaces for error messgae.

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -354,8 +354,8 @@ export default {
       console.log(vmNameArr)
       for (let i = 0; i < vmNameArr.length - 1; i++) {
         if (vmNameArr[i] === vmNameArr[i + 1]) {
-          alert("ERROR\n" + `Multiple VMs have the same name: ${vmNameArr[i]}.` +
-              "Your configuration cannot be saved." + "Make sure each VM has a unique name.");
+          alert("ERROR\n" + `Multiple VMs have the same name: ${vmNameArr[i]}. ` +
+              "Your configuration cannot be saved. " + "Make sure each VM has a unique name.");
           errorFlag = true
         }
       }


### PR DESCRIPTION
add two spacings in alert sentence.

Tracked-On: #7915
Signed-off-by: Chuang-Ke <chuangx.ke@intel.com>
Reviewed-by:Junjie Mao <junjie.mao@intel.com>