### PR TITLE
hv: tlfs: fix the incorrect vLAPIC freq MSR

### DIFF
--- a/hypervisor/arch/x86/guest/hyperv.c
+++ b/hypervisor/arch/x86/guest/hyperv.c
@@ -212,8 +212,8 @@ hyperv_rdmsr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t *rval)
 		*rval = get_tsc_khz() * 1000UL;
 		break;
 	case HV_X64_MSR_APIC_FREQUENCY:
-		/* both KVM and XEN hardcode the APIC freq as 1GHz ... */
-		*rval = 1000000000UL;
+		/* vLAPIC freq is the same as TSC freq */
+		*rval = get_tsc_khz() * 1000UL;
 		break;
 	default:
 		pr_err("hv: %s: unexpected MSR[0x%x] read", __func__, msr);


### PR DESCRIPTION
When LAPIC timer is working in oneshot or periodic mode, OS uses
initial counter register/current counter register to program
a timer. Both initial counter and current counter depend on the
LAPIC frequency. ACRN emulated vLAPIC timer based on the TSC.
vLAPIC freq is the same as TSC freq.

Tracked-On: #7876
Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>
Reviewed-by: Zhao Yakui <yakui.zhao@intel.com>