### PR TITLE
[ACRN3.0-branch]hv: shell: add cmd to sample vmexit data per-vCPU

### DIFF
--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -28,7 +28,6 @@
  * According to "SDM APPENDIX C VMX BASIC EXIT REASONS",
  * there are 65 Basic Exit Reasons.
  */
-#define NR_VMX_EXIT_REASONS	70U
 
 static int32_t triple_fault_vmexit_handler(struct acrn_vcpu *vcpu);
 static int32_t unhandled_vmexit_handler(struct acrn_vcpu *vcpu);

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -45,6 +45,8 @@ void vcpu_thread(struct thread_object *obj)
 		profiling_vmenter_handler(vcpu);
 
 		TRACE_2L(TRACE_VM_ENTER, 0UL, 0UL);
+		sample_vmexit_end(vcpu);
+
 		ret = run_vcpu(vcpu);
 		if (ret != 0) {
 			pr_fatal("vcpu resume failed");
@@ -55,6 +57,7 @@ void vcpu_thread(struct thread_object *obj)
 			continue;
 		}
 		TRACE_2L(TRACE_VM_EXIT, vcpu->arch.exit_reason, vcpu_get_rip(vcpu));
+		sample_vmexit_begin(vcpu);
 
 		profiling_pre_vmexit_handler(vcpu);
 

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -106,4 +106,8 @@ struct shell {
 #define SHELL_CMD_WRMSR_PARAM		"[-p<pcpu_id>]	<msr_index> <value>"
 #define SHELL_CMD_WRMSR_HELP		"Write value (in hexadecimal) to the MSR at msr_index (in hexadecimal) for CPU"\
 					" ID pcpu_id"
+#define SHELL_CMD_VMEXIT		"vmexit"
+#define SHELL_CMD_VMEXIT_PARAM		NULL
+#define SHELL_CMD_VMEXIT_HELP	"profiling vmexit, use: vmexit [clear | enable | disable | vm_id] enabled by default"
+
 #endif /* SHELL_PRIV_H */

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -26,6 +26,7 @@
 #include <io_req.h>
 #include <asm/msr.h>
 #include <asm/cpu.h>
+#include <asm/guest/vmexit.h>
 #include <asm/guest/instr_emul.h>
 #include <asm/guest/nested.h>
 #include <asm/vmx.h>
@@ -197,6 +198,11 @@ enum reset_mode;
 
 #define EOI_EXIT_BITMAP_SIZE	256U
 
+#ifdef HV_DEBUG
+	#define MAX_VMEXIT_LEVEL 14 /* from 0 to 14 for counts*/
+	#define TOTAL_ARRAY_LEVEL (MAX_VMEXIT_LEVEL + 1)
+#endif
+
 struct guest_cpu_context {
 	struct run_context run_ctx;
 	struct ext_context ext_ctx;
@@ -321,6 +327,14 @@ struct acrn_vcpu {
 	uint64_t reg_updated;
 
 	struct sched_event events[VCPU_EVENT_NUM];
+
+#ifdef HV_DEBUG
+	uint64_t vmexit_begin;
+
+	uint64_t vmexit_cnt[NR_VMX_EXIT_REASONS][TOTAL_ARRAY_LEVEL];
+	uint64_t vmexit_time[NR_VMX_EXIT_REASONS]; /* for max latency */
+#endif
+
 } __aligned(PAGE_SIZE);
 
 struct vcpu_dump {

--- a/hypervisor/include/arch/x86/asm/guest/vmexit.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmexit.h
@@ -7,6 +7,8 @@
 #ifndef VMEXIT_H_
 #define VMEXIT_H_
 
+#define NR_VMX_EXIT_REASONS	70U
+
 struct vm_exit_dispatch {
 	int32_t (*handler)(struct acrn_vcpu *);
 	uint32_t need_exit_qualification;

--- a/hypervisor/include/debug/profiling.h
+++ b/hypervisor/include/debug/profiling.h
@@ -18,4 +18,8 @@ void profiling_pre_vmexit_handler(struct acrn_vcpu *vcpu);
 void profiling_post_vmexit_handler(struct acrn_vcpu *vcpu);
 void profiling_setup(void);
 
+/* for vmexit sample */
+void sample_vmexit_end(struct acrn_vcpu *vcpu);
+void sample_vmexit_begin(struct acrn_vcpu *vcpu);
+
 #endif /* PROFILING_H */

--- a/hypervisor/release/profiling.c
+++ b/hypervisor/release/profiling.c
@@ -11,3 +11,6 @@ void profiling_vmenter_handler(__unused struct acrn_vcpu *vcpu) {}
 void profiling_pre_vmexit_handler(__unused struct acrn_vcpu *vcpu) {}
 void profiling_post_vmexit_handler(__unused struct acrn_vcpu *vcpu) {}
 void profiling_setup(void) {}
+
+void sample_vmexit_end(__unused struct acrn_vcpu *vcpu) {}
+void sample_vmexit_begin(__unused struct acrn_vcpu *vcpu) {}


### PR DESCRIPTION
this feature is used to sample vmexit data per virtual CPU of VM,
command used in HV console as following:
  1. vmexit clear : to clear current vmexit buffer
  2. vmexit [vm_id] : output vmexit info per-vCPU of one or all VMs
  3. vmexit enable | disable, by default enabled

Tracked-On: #5232
Signed-off-by: Minggui Cao <minggui.cao@intel.com>