### PR TITLE
config_tools: order of plus and minus icons is inconsistent

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/Virtio/Console.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/Virtio/Console.vue
@@ -188,6 +188,7 @@ export default {
 <style scoped>
 .ToolSet {
   display: flex;
+  flex-direction: row;
   justify-content: space-around;
   margin: 1rem;
   gap: 0.5rem;

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/cpu_affinity.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/cpu_affinity.vue
@@ -33,14 +33,14 @@
           </b-col>
           <b-col>
             <div class="ToolSet">
-              <div @click="addPCPU(index)" :class="{'d-none': (this.defaultVal.pcpu.length-1)!==index}">
-                <Icon size="18px">
-                  <Plus/>
-                </Icon>
-              </div>
               <div @click="removePCPU(index)">
                 <Icon size="18px">
                   <Minus/>
+                </Icon>
+              </div>
+              <div @click="addPCPU(index)" :class="{'d-none': (this.defaultVal.pcpu.length-1)!==index}">
+                <Icon size="18px">
+                  <Plus/>
                 </Icon>
               </div>
             </div>


### PR DESCRIPTION
let minus icons in front of plus icons in those views below: Virtio input device, Virtio network device, Virtio console device, CPU affinity.

Tracked-On: projectacrn#7917 
Signed-off-by: Chuang-Ke <chuangx.ke@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>