### PR TITLE
hv: shell: improve HV console as bash-like one

### DIFF
--- a/hypervisor/arch/x86/lib/memory.c
+++ b/hypervisor/arch/x86/lib/memory.c
@@ -24,9 +24,18 @@ void *memset(void *base, uint8_t v, size_t n)
 	return base;
 }
 
-static inline void memcpy_erms(void *d, const void *s, size_t slen)
+void memcpy_erms(void *d, const void *s, size_t slen)
 {
 	asm volatile ("rep; movsb"
+		: "=&D"(d), "=&S"(s)
+		: "c"(slen), "0" (d), "1" (s)
+		: "memory");
+}
+
+/* copy data from tail to head (backwards) with ERMS (Enhanced REP MOVSB/STOSB) */
+void memcpy_erms_backwards(void *d, const void *s, size_t slen)
+{
+	asm volatile ("std; rep; movsb; cld"
 		: "=&D"(d), "=&S"(s)
 		: "c"(slen), "0" (d), "1" (s)
 		: "memory");

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -26,11 +26,17 @@ struct shell_cmd {
 
 };
 
+#define MAX_BUFFERED_CMDS 8
+
 /* Shell Control Block */
 struct shell {
-	char input_line[2][SHELL_CMD_MAX_LEN + 1U];	/* current & last */
+	/* a ring buffer to buffer former commands and use one as current active input */
+	char buffered_line[MAX_BUFFERED_CMDS][SHELL_CMD_MAX_LEN + 1U];
 	uint32_t input_line_len;	/* Length of current input line */
-	uint32_t input_line_active;	/* Active input line index */
+	int32_t input_line_active;	/* Active input line index */
+
+	int32_t to_select_index; /* used for up/down key to select former cmds */
+
 	struct shell_cmd *cmds;	/* cmds supported */
 	uint32_t cmd_count;		/* Count of cmds supported */
 };

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -36,6 +36,7 @@ struct shell {
 	int32_t input_line_active;	/* Active input line index */
 
 	int32_t to_select_index; /* used for up/down key to select former cmds */
+	uint32_t cursor_offset; /* cursor offset position from left input line */
 
 	struct shell_cmd *cmds;	/* cmds supported */
 	uint32_t cmd_count;		/* Count of cmds supported */

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -42,6 +42,8 @@ char *strchr(char *s_arg, char ch);
 size_t strnlen_s(const char *str_arg, size_t maxlen_arg);
 void *memset(void *base, uint8_t v, size_t n);
 int32_t memcpy_s(void *d, size_t dmax, const void *s, size_t slen);
+void memcpy_erms(void *d, const void *s, size_t slen);
+void memcpy_erms_backwards(void *d, const void *s, size_t slen);
 int64_t strtol_deci(const char *nptr);
 uint64_t strtoul_hex(const char *nptr);
 char *strstr_s(const char *str1, size_t maxlen1, const char *str2, size_t maxlen2);


### PR DESCRIPTION
hv: shell: improve console to buffer history cmds and modify input easier
  1. buffer history commands.
  2. support up/down key to select history buffered commands
  3. make memcpy_erms as a public API; add a new one
  memcpy_erms_backwards, which supports to copy data from tail to head.
  4. improve to use right/left/home/end key to move cursor, and support
delete/backspace key to modify current input command.

Tracked-On: #7931
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>