### PR TITLE
SampleApplication: Add Makefile for the entire SampleApplication

### DIFF
--- a/misc/sample_application/Makefile
+++ b/misc/sample_application/Makefile
@@ -1,0 +1,18 @@
+T := $(CURDIR)
+OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build/;pwd)
+
+.PHONY: all userapp rtapp
+all: userapp histapp rtapp
+
+userapp:
+	$(MAKE) -C $(T)/uservm OUT_DIR=$(OUT_DIR)
+histapp:
+	cp $(T)/uservm/histapp.py $(OUT_DIR)
+rtapp:
+	$(MAKE) -C $(T)/rtvm OUT_DIR=$(OUT_DIR)
+
+.PHONY: clean
+
+clean:
+	rm -rf $(OUT_DIR)
+

--- a/misc/sample_application/rtvm/Makefile
+++ b/misc/sample_application/rtvm/Makefile
@@ -1,12 +1,14 @@
 CC = gcc
-CP = g++
+CXX ?= g++
+T := $(CURDIR)
+OUT_DIR ?= $(shell mkdir -p $(T)i/../build;cd $(T)/../build;pwd)
 
 CFLAGS = -Wall -Wextra -Wabi=11 -pedantic
 
 LDLIBS = -lrt -pthread
 
 all: rtApp.c
-	$(CC) $(CFLAGS) -o rtapp rtApp.c ivshmemlib.c
+	$(CXX) $(CFLAGS) -o $(OUT_DIR)/rtApp rtApp.c ivshmemlib.c
 
 clean:
-	rm rtapp
+	rm $(OUT_DIR)/rtApp

--- a/misc/sample_application/uservm/Makefile
+++ b/misc/sample_application/uservm/Makefile
@@ -1,12 +1,19 @@
-CC = gcc
-CP = g++
+CC ?= gcc
+CXX ?= g++
+T := $(CURDIR)
+OUT_DIR ?= $(shell mkdir -p $(T)i/../build;cd $(T)/../build;pwd)
 
 CFLAGS = -Wall -Wextra -Wabi=11 -pedantic
 
 LDLIBS = -lrt -pthread
 
-all: userApp.cpp
-	$(CP) $(CFLAGS) -o userapp userApp.cpp ivshmemlib.c $(LDLIBS)
+all: userApp histapp
+
+userApp:
+	$(CXX) $(CFLAGS) -o $(OUT_DIR)/userApp userApp.cpp ivshmemlib.c $(LDLIBS)
+histapp:
+	cp $(T)/histapp.py $(OUT_DIR)
 
 clean:
-	rm userapp
+	rm $(OUT_DIR)/userApp
+	rm $(OUT_DIR)/histapp.py


### PR DESCRIPTION
Add the Makefile in the SampleApplication root directory. User
don't need to separate build the userapp and rtapp, just need make
once at the SampleApplication root directory.

Tracked-On #7820
Signed-off-by: Liu Long <long.liu@linux.intel.com>