### PR TITLE
config_tool: Instruction missing for L2-only users

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/CAT.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/CAT.vue
@@ -61,9 +61,7 @@
       {{ CAT_INFO.errorMsg }}
     </div>
     <div class="py-4" v-for="CACHE_ALLOCATION in CAT_INFO.regions" v-if="RDT_ENABLED==='y'">
-      <p v-if="CACHE_ALLOCATION.level===3">
-        L3 Cache Allocation Technology
-        <br/>
+      <p v-if="CACHE_ALLOCATION.level===3||CACHE_ALLOCATION.level===2">
         Drag the ends of the boxes to cover the cache chunks you want to allocate to specific VMs. If you have a
         real-time
         VM,ensure its cache chunks do not overlap with any other VM's cache chunks.


### PR DESCRIPTION
In the cache widget, there are instructions: "Drag the ends of the boxes to cover the cache chunks you want to allocate to specific VMs. If you have a real-time VM, ensure its cache chunks do not overlap with any other VM's cache chunks."

Tracked-On: #7921
Signed-off-by: Chuang-Ke <chuangx.ke@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>