### PR TITLE
misc: add assert to check the duplicate devices

### DIFF
--- a/misc/config_tools/schema/checks/pci_config.xsd
+++ b/misc/config_tools/schema/checks/pci_config.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2022 Intel Corporation. -->
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+
+<xs:schema xml:id="root"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:acrn="https://projectacrn.org">
+
+  <xs:assert test="every $pci_device in /acrn-config//pci_dev satisfies
+                   count(/acrn-config//pci_dev[./text()=$pci_device]) = 1">
+    <xs:annotation acrn:severity="error" acrn:report-on="//vm[./pci_devs/pci_dev/text()=$pci_device]">
+      <xs:documentation>The PCI device '{$pci_device}' has been assigned multiple times to VM(s) '{//vm[./pci_devs/pci_dev/text()=$pci_device]/name}'  </xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+</xs:schema>

--- a/misc/config_tools/schema/datachecks.xsd
+++ b/misc/config_tools/schema/datachecks.xsd
@@ -18,6 +18,7 @@
       <xi:include href="checks/vuart_config.xsd" xpointer="xpointer(id('root')/*)" />
       <xi:include href="checks/ivsh_memory.xsd" xpointer="xpointer(id('root')/*)" />
       <xi:include href="checks/rdt_support.xsd" xpointer="xpointer(id('root')/*)" />
+      <xi:include href="checks/pci_config.xsd" xpointer="xpointer(id('root')/*)" />
 
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
The current ACRN-Configurator allow user add duplicate PCI devices to
passthrough which it is not correct.

This patch add an assert to check the duplicate of PCI devices.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>