### PR TITLE
hv: sched: fix bug when reboot vm

### DIFF
--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -105,6 +105,8 @@ extern struct acrn_scheduler sched_bvt;
 struct sched_bvt_control {
 	struct list_head runqueue;
 	struct hv_timer tick_timer;
+	/* The minimum AVT of any runnable threads */
+	int64_t svt;
 };
 
 extern struct acrn_scheduler sched_prio;


### PR DESCRIPTION
BVT schedule rule:
When a new thread is wakeup and added to runqueue, it will get the
smallest avt (svt) from runqueue to initiate its avt. If the svt is
smaller than it's avt, it will keep the original avt. With the svt, it
can prevent a thread from claiming an excessive share of CPU after
sleepting for a long time.

For the reboot issue, when the VM is reboot, it means a new vcpu thread
is wakeup, but at this time, the Service VM's vcpu thread is blocked,
and removed from the runqueue, and the runqueue is empty, so the svt is
0. The new vcpu thread will get avt=0. avt=0 means very high priority,
and can run for a very long time until it catch up with other thread's
avt in runqueue.
At this time, when Service VM's vcpu thread wakeup, it will check the
svt, but the svt is very small, so will not update it's avt according to
the rule, thus has a very low priority and cannot be scheduled.

To fix it, update svt in pick_next handler to make sure svt is align
with the avt of the first obj in runqueue.

Tracked-On: #7944
Signed-off-by: Conghui <conghui.chen@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Reviewed-by: Wang, Yu1 <yu1.wang@intel.com>