### PR TITLE
Generate vRTCT for pre-launched RT VMs and guess presence of L3 CAT in the board inspector

### DIFF
--- a/misc/config_tools/acpi_gen/acpi_const.py
+++ b/misc/config_tools/acpi_gen/acpi_const.py
@@ -15,7 +15,7 @@ TEMPLATE_ACPI_PATH = os.path.join(VM_CONFIGS_PATH, 'acpi_template', 'template')
 
 ACPI_TABLE_LIST = [('rsdp.asl', 'rsdp.aml'), ('xsdt.asl', 'xsdt.aml'), ('facp.asl', 'facp.aml'),
                    ('mcfg.asl', 'mcfg.aml'), ('apic.asl', 'apic.aml'), ('tpm2.asl', 'tpm2.aml'),
-                   ('dsdt.aml', 'dsdt.aml'), ('PTCT', 'ptct.aml'), ('RTCT', 'rtct.aml')]
+                   ('dsdt.aml', 'dsdt.aml'), ('ptct.aml', 'ptct.aml'), ('rtct.aml', 'rtct.aml')]
 
 ACPI_BASE = 0x7fe00000
 
@@ -49,5 +49,3 @@ ACPI_MADT_TYPE_LOCAL_APIC_NMI = 4
 TSN_DEVICE_LIST = ['8086:4ba0',
                    '8086:4bb0',
                    '8086:4b32']
-
-RTCT = ['RTCT', 'PTCT']

--- a/misc/config_tools/acpi_gen/bin_gen.py
+++ b/misc/config_tools/acpi_gen/bin_gen.py
@@ -70,7 +70,7 @@ def asl_to_aml(dest_vm_acpi_path, dest_vm_acpi_bin_path, scenario_etree, allocat
                         os.remove(os.path.join(dest_vm_acpi_path, acpi_table[1]))
                     rmsg = 'failed to compile {}'.format(acpi_table[0])
                     break
-        elif acpi_table[0] in ['PTCT', 'RTCT']:
+        elif acpi_table[0] in ['ptct.aml', 'rtct.aml']:
             if acpi_table[0] in os.listdir(dest_vm_acpi_path):
                 rtct = acpiparser.rtct.RTCT(os.path.join(dest_vm_acpi_path, acpi_table[0]))
                 outfile = os.path.join(dest_vm_acpi_bin_path, acpi_table[1])
@@ -95,7 +95,7 @@ def asl_to_aml(dest_vm_acpi_path, dest_vm_acpi_bin_path, scenario_etree, allocat
                         os.remove(os.path.join(dest_vm_acpi_path, acpi_table[1]))
                     rmsg = 'failed to compile {}'.format(acpi_table[0])
                     break
-            elif acpi_table[0].endswith(".aml"):
+            elif acpi_table[0].endswith(".aml") and acpi_table[0] in os.listdir(dest_vm_acpi_path):
                 shutil.copy(os.path.join(dest_vm_acpi_path, acpi_table[0]),
                             os.path.join(dest_vm_acpi_bin_path, acpi_table[1]))
 
@@ -171,11 +171,11 @@ def aml_to_bin(dest_vm_acpi_path, dest_vm_acpi_bin_path, acpi_bin_name, board_et
         with open(os.path.join(dest_vm_acpi_bin_path, ACPI_TABLE_LIST[6][1]), 'rb') as asl:
             acpi_bin.write(asl.read())
 
-        if 'PTCT' in os.listdir(dest_vm_acpi_path):
+        if ACPI_TABLE_LIST[7][1] in os.listdir(dest_vm_acpi_path):
             acpi_bin.seek(ACPI_RTCT_ADDR_OFFSET)
             with open(os.path.join(dest_vm_acpi_bin_path, ACPI_TABLE_LIST[7][1]), 'rb') as asl:
                 acpi_bin.write(asl.read())
-        elif 'RTCT' in os.listdir(dest_vm_acpi_path):
+        elif ACPI_TABLE_LIST[8][1] in os.listdir(dest_vm_acpi_path):
             acpi_bin.seek(ACPI_RTCT_ADDR_OFFSET)
             with open(os.path.join(dest_vm_acpi_bin_path, ACPI_TABLE_LIST[8][1]), 'rb') as asl:
                 acpi_bin.write(asl.read())

--- a/misc/config_tools/board_inspector/acpiparser/rdt.py
+++ b/misc/config_tools/board_inspector/acpiparser/rdt.py
@@ -30,7 +30,7 @@ SMALL_RESOURCE_ITEM_END_TAG                       = 0x0F
 
 # 6.4.2.1 IRQ Descriptor
 
-def SmallResourceItemIRQ_factory(_len):
+def SmallResourceItemIRQ_factory(_len=2):
     class SmallResourceItemIRQ(cdata.Struct):
         _pack_ = 1
         _fields_ = SmallResourceDataTag._fields_ + [

--- a/misc/config_tools/board_inspector/acpiparser/rtct.py
+++ b/misc/config_tools/board_inspector/acpiparser/rtct.py
@@ -15,7 +15,7 @@ class RTCTSubtable(cdata.Struct):
     _pack_ = 1
     _fields_ = [
         ('subtable_size', ctypes.c_uint16),
-        ('format', ctypes.c_uint16),
+        ('format_or_version', ctypes.c_uint16),
         ('type', ctypes.c_uint32),
     ]
 
@@ -152,17 +152,15 @@ class RTCTSubtableSSRAMWayMask(cdata.Struct):
         ('waymask', ctypes.c_uint32),
     ]
 
-def RTCTSubtableSoftwareSRAM_v2_factory(data_len):
-    class RTCTSubtableSoftwareSRAM_v2(cdata.Struct):
-        _pack_ = 1
-        _fields_ = copy.copy(RTCTSubtable._fields_) + [
-            ('level', ctypes.c_uint32),
-            ('cache_id', ctypes.c_uint32),
-            ('base', ctypes.c_uint64),
-            ('size', ctypes.c_uint32),
-            ('shared', ctypes.c_uint32),
-        ]
-    return RTCTSubtableSoftwareSRAM_v2
+class RTCTSubtableSoftwareSRAM_v2(cdata.Struct):
+    _pack_ = 1
+    _fields_ = copy.copy(RTCTSubtable._fields_) + [
+        ('level', ctypes.c_uint32),
+        ('cache_id', ctypes.c_uint32),
+        ('base', ctypes.c_uint64),
+        ('size', ctypes.c_uint32),
+        ('shared', ctypes.c_uint32),
+    ]
 
 def RTCTSubtableMemoryHierarchyLatency_v2_factory(data_len):
     class RTCTSubtableMemoryHierarchyLatency_v2(cdata.Struct):
@@ -226,7 +224,9 @@ def rtct_v2_subtable_list(addr, length):
         subtable_num += 1
         subtable = RTCTSubtable.from_address(addr)
         data_len = subtable.subtable_size - ctypes.sizeof(RTCTSubtable)
-        if subtable.type == ACPI_RTCT_V2_TYPE_RTCD_Limits:
+        if subtable.type == ACPI_RTCT_TYPE_COMPATIBILITY:
+            cls = RTCTSubtableCompatibility
+        elif subtable.type == ACPI_RTCT_V2_TYPE_RTCD_Limits:
             cls = RTCTSubtableRTCDLimits
         elif subtable.type == ACPI_RTCT_V2_TYPE_CRL_Binary:
             cls = RTCTSubtableRTCMBinary
@@ -239,7 +239,7 @@ def rtct_v2_subtable_list(addr, length):
         elif subtable.type == ACPI_RTCT_V2_TYPE_SSRAM_WayMask:
             cls = RTCTSubtableSSRAMWayMask
         elif subtable.type == ACPI_RTCT_V2_TYPE_SoftwareSRAM:
-            cls = RTCTSubtableSoftwareSRAM_v2_factory(data_len)
+            cls = RTCTSubtableSoftwareSRAM_v2
         elif subtable.type == ACPI_RTCT_V2_TYPE_MemoryHierarchyLatency:
             cls = RTCTSubtableMemoryHierarchyLatency_v2_factory(data_len)
         elif subtable.type == ACPI_RTCT_V2_TYPE_ErrorLogAddress:

--- a/misc/config_tools/board_inspector/cpuparser/msr.py
+++ b/misc/config_tools/board_inspector/cpuparser/msr.py
@@ -255,3 +255,18 @@ class MSR_IA32_VMX_ENTRY_CTLS(VMXCapabilityReportingMSR):
         "vmx_entry_ctls_load_pat",
         "vmx_entry_ctls_ia32e_mode",
     ]
+
+class MSR_IA32_L3_QOS_CFG(MSR):
+    addr = 0x00000c81
+    cdp_enable = msrfield(0, 0, doc="L3 CDP enable")
+
+def MSR_IA32_L3_MASK_n(n):
+    if n >= 128:
+        logging.debug("Attempt to access an out-of-range IA32_L3_MASK_n register. Fall back to 0.")
+        n = 0
+
+    class IA32_L3_MASK_n(MSR):
+        addr = 0x00000c90 + n
+        bit_mask = msrfield(32, 0, doc="Capacity bit mask")
+
+    return IA32_L3_MASK_n

--- a/misc/config_tools/board_inspector/cpuparser/msr.py
+++ b/misc/config_tools/board_inspector/cpuparser/msr.py
@@ -7,7 +7,7 @@ from cpuparser.platformbase import MSR, msrfield
 
 class MSR_IA32_MISC_ENABLE(MSR):
     addr = 0x1a0
-    fast_string = msrfield(1, 0, doc=None)
+    fast_string = msrfield(0, 0, doc="Fast-strings enable")
 
     capability_bits = [
         "fast_string",
@@ -15,39 +15,76 @@ class MSR_IA32_MISC_ENABLE(MSR):
 
 class MSR_IA32_FEATURE_CONTROL(MSR):
     addr = 0x03a
-    msr_ia32_feature_control_lock = msrfield(1, 0, doc=None)
-    msr_ia32_feature_control_vmx_no_smx = msrfield(1, 2, doc=None)
+    lock = msrfield(0, 0, doc="Lock bit")
+    vmx_outside_smx = msrfield(2, 2, doc="Enable VMX outside SMX operation")
 
     @property
     def disable_vmx(self):
-        return self.msr_ia32_feature_control_lock and not self.msr_ia32_feature_control_vmx_no_smx
+        return self.lock and not self.vmx_outside_smx
 
     capability_bits = [
         "disable_vmx",
     ]
 
-class MSR_IA32_VMX_PROCBASED_CTLS2(MSR):
+class VMXCapabilityReportingMSR(MSR):
+    def get_field_idx(self, field):
+        if isinstance(field, int):
+            return field
+        if isinstance(field, str):
+            return getattr(type(self), field).lsb
+        assert False, f"Invalid field type: {field}, {type(field)}"
+
+    def allows_0_setting(self, field):
+        field_idx = self.get_field_idx(field)
+        if field_idx >= 32:
+            return False
+
+        bit_mask = (1 << field_idx)
+        return (self.value & bit_mask) == 0
+
+    def allows_1_setting(self, field):
+        field_idx = self.get_field_idx(field)
+        if field_idx >= 32:
+            return False
+
+        bit_mask = (1 << field_idx)
+        high = self.value >> 32
+        return (high & bit_mask) == bit_mask
+
+    def allows_flexible_setting(self, field):
+        field_idx = self.get_field_idx(field)
+        return self.allows_0_setting(field_idx) and self.allows_1_setting(field_idx)
+
+class MSR_IA32_VMX_PROCBASED_CTLS2(VMXCapabilityReportingMSR):
     addr = 0x0000048B
+
+    vapic_access = msrfield(0, 0, doc="Virtualize APIC accesses")
+    ept = msrfield(1, 1, doc="Enable EPT")
+    rdtscp = msrfield(3, 3, doc="Enable RDTSCP")
+    vx2apic = msrfield(4, 4, doc="Virtualize x2APIC mode")
+    vpid = msrfield(5, 5, doc="Enable VPID")
+    unrestricted_guest = msrfield(7, 7, doc="Unrestricted guest")
+    apic_reg_virt = msrfield(8, 8, doc="APIC-register virtualization")
 
     @property
     def vmx_procbased_ctls2_vapic(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 0)
+        return self.allows_flexible_setting("vapic_access")
 
     @property
     def vmx_procbased_ctls2_ept(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 1)
+        return self.allows_flexible_setting("ept")
 
     @property
     def vmx_procbased_ctls2_vpid(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 5)
+        return self.allows_flexible_setting("vpid")
 
     @property
     def vmx_procbased_ctls2_rdtscp(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 3)
+        return self.allows_flexible_setting("rdtscp")
 
     @property
     def vmx_procbased_ctls2_unrestrict(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 7)
+        return self.allows_flexible_setting("unrestricted_guest")
 
     capability_bits = [
         "vmx_procbased_ctls2_vapic",
@@ -57,82 +94,69 @@ class MSR_IA32_VMX_PROCBASED_CTLS2(MSR):
         "vmx_procbased_ctls2_unrestrict",
     ]
 
-class MSR_IA32_VMX_PINBASED_CTLS(MSR):
+class MSR_IA32_VMX_PINBASED_CTLS(VMXCapabilityReportingMSR):
     addr = 0x00000481
+
+    irq_exiting = msrfield(0, 0, doc="External-interrupt existing")
 
     @property
     def vmx_pinbased_ctls_irq_exit(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 0)
+        return self.allows_flexible_setting("irq_exiting")
 
     capability_bits = [
         "vmx_pinbased_ctls_irq_exit",
     ]
 
-class MSR_IA32_VMX_PROCBASED_CTLS(MSR):
+class MSR_IA32_VMX_PROCBASED_CTLS(VMXCapabilityReportingMSR):
     addr = 0x00000482
+
+    tsc_offsetting = msrfield(3, 3, doc="Use TSC offsetting")
+    hlt_exiting = msrfield(7, 7, doc="HLT exiting")
+    tpr_shadow = msrfield(21, 21, doc="Use TPR shadow")
+    io_bitmaps = msrfield(25, 25, doc="Use I/O bitmaps")
+    msr_bitmaps = msrfield(28, 28, doc="Use MSR bitmaps")
+    secondary_ctrls = msrfield(31, 31, doc="Activate secondary controls")
 
     @property
     def vmx_procbased_ctls_tsc_off(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 3)
+        return self.allows_flexible_setting("tsc_offsetting")
 
     @property
     def vmx_procbased_ctls_tpr_shadow(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 21)
+        return self.allows_flexible_setting("tpr_shadow")
 
     @property
     def vmx_procbased_ctls_io_bitmap(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 25)
+        return self.allows_flexible_setting("io_bitmaps")
 
     @property
     def vmx_procbased_ctls_msr_bitmap(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 28)
+        return self.allows_flexible_setting("msr_bitmaps")
 
     @property
     def vmx_procbased_ctls_hlt(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 7)
+        return self.allows_flexible_setting("hlt_exiting")
 
     @property
     def vmx_procbased_ctls_secondary(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 31)
+        return self.allows_flexible_setting("secondary_ctrls")
 
     @property
     def ept(self):
-        is_ept_supported = False
-        if ((self.value >> 32) & (1 << 31)) != 0:
-            msr_val = MSR_IA32_VMX_PROCBASED_CTLS2.rdmsr(self.cpu_id)
-            if msrfield.is_ctrl_setting_allowed(msr_val.value, 1 << 1):
-                is_ept_supported = True
-        return is_ept_supported
+        if self.allows_1_setting("secondary_ctrls"):
+            ctls2 = MSR_IA32_VMX_PROCBASED_CTLS2.rdmsr(self.cpu_id)
+            return ctls2.allows_1_setting("ept")
+        return False
 
     @property
     def apicv(self):
-        features = 0
-        vapic_feature_tpr_shadow = 1 << 3
-        vapic_feature_virt_access = 1 << 0
-        vapic_feature_vx2apic_mode = 1 << 5
-        vapic_feature_virt_reg = 1 << 1
-        vapic_feature_intr_delivery = 1 << 2
-        vapic_feature_post_intr = 1 << 4
+        if not self.allows_1_setting("tpr_shadow"):
+            return False
 
-        if msrfield.is_ctrl_setting_allowed(self.value, 1 << 21):
-            features |= vapic_feature_tpr_shadow
-
-        msr_val = MSR_IA32_VMX_PROCBASED_CTLS2.rdmsr(self.cpu_id)
-        if msrfield.is_ctrl_setting_allowed(msr_val.value, 1 << 0):
-            features |= vapic_feature_virt_access
-        if msrfield.is_ctrl_setting_allowed(msr_val.value, 1 << 4):
-            features |= vapic_feature_vx2apic_mode
-        if msrfield.is_ctrl_setting_allowed(msr_val.value, 1 << 8):
-            features |= vapic_feature_virt_reg
-        if msrfield.is_ctrl_setting_allowed(msr_val.value, 1 << 9):
-            features |= vapic_feature_intr_delivery
-
-        msr_val = MSR_IA32_VMX_PINBASED_CTLS.rdmsr(self.cpu_id)
-        if msrfield.is_ctrl_setting_allowed(msr_val.value, 1 << 7):
-            features |= vapic_feature_post_intr
-
-        apicv_basic_feature = (vapic_feature_tpr_shadow | vapic_feature_virt_access | vapic_feature_vx2apic_mode)
-        return (features & apicv_basic_feature) == apicv_basic_feature
+        ctls2 = MSR_IA32_VMX_PROCBASED_CTLS2.rdmsr(self.cpu_id)
+        return \
+            ctls2.allows_1_setting("vapic_access") and \
+            ctls2.allows_1_setting("vx2apic")
 
     capability_bits = [
         "ept",
@@ -148,10 +172,16 @@ class MSR_IA32_VMX_PROCBASED_CTLS(MSR):
 class MSR_IA32_VMX_EPT_VPID_CAP(MSR):
     addr = 0x0000048C
 
-    invept = msrfield(1, 20)
-    ept_2mb_page = msrfield(1, 16)
-    vmx_ept_1gb_page = msrfield(1, 17)
-    invvpid = msrfield(1, 32) and msrfield(1, 41) and msrfield(1, 42)
+    invept = msrfield(20, 20, doc="INVEPT instruction supported")
+    ept_2mb_page = msrfield(16, 16, doc="EPT 2-Mbyte page supported")
+    vmx_ept_1gb_page = msrfield(17, 17, doc="EPT 1-Gbyte page supported")
+    invvpid_inst = msrfield(32, 32, doc="INVVPID instruction supported")
+    invvpid_single_context = msrfield(41, 41, doc="single-context INVVPID type supported")
+    invvpid_all_context = msrfield(42, 42, doc="all-context INVVPID type supported")
+
+    @property
+    def invvpid(self):
+        return self.invvpid_inst and self.invvpid_single_context and self.invvpid_all_context
 
     capability_bits = [
         "invept",
@@ -162,38 +192,43 @@ class MSR_IA32_VMX_EPT_VPID_CAP(MSR):
 
 class MSR_IA32_VMX_MISC(MSR):
     addr = 0x00000485
-    unrestricted_guest = msrfield(1, 5)
+    stores_lma_on_exit = msrfield(5, 5, doc="VM exits stores the value of IA32_EFER.LMA into the 'IA-32e mode guest' VM-entry control")
 
     capability_bits = [
-        "unrestricted_guest",
+        "stores_lma_on_exit",
     ]
 
 class MSR_IA32_VMX_BASIC(MSR):
     addr = 0x00000480
-    set_32bit_addr_width = msrfield(1, 48)
+    set_32bit_addr_width = msrfield(48, 48, doc="Addresses of VMXON, VMCS and referenced structures limited to 32-bit")
 
     capability_bits = [
         "set_32bit_addr_width",
     ]
 
-class MSR_IA32_VMX_EXIT_CTLS(MSR):
+class MSR_IA32_VMX_EXIT_CTLS(VMXCapabilityReportingMSR):
     addr = 0x00000483
+
+    host_addr_size = msrfield(9, 9, doc="Host address-space size")
+    ack_irq_on_exit = msrfield(15, 15, doc="Acknowledge interrupt on exit")
+    save_pat = msrfield(18, 18, doc="Save IA32_PAT")
+    load_pat = msrfield(19, 19, doc="Load IA32_PAT")
 
     @property
     def vmx_exit_ctls_ack_irq(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 15)
+        return self.allows_flexible_setting("ack_irq_on_exit")
 
     @property
     def vmx_exit_ctls_save_pat(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 18)
+        return self.allows_flexible_setting("save_pat")
 
     @property
     def vmx_exit_ctls_load_pat(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 19)
+        return self.allows_flexible_setting("load_pat")
 
     @property
     def vmx_exit_ctls_host_addr64(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 9)
+        return self.allows_flexible_setting("host_addr_size")
 
     capability_bits = [
         "vmx_exit_ctls_ack_irq",
@@ -202,16 +237,19 @@ class MSR_IA32_VMX_EXIT_CTLS(MSR):
         "vmx_exit_ctls_host_addr64",
     ]
 
-class MSR_IA32_VMX_ENTRY_CTLS(MSR):
+class MSR_IA32_VMX_ENTRY_CTLS(VMXCapabilityReportingMSR):
     addr = 0x00000484
+
+    ia32e_mode_guest = msrfield(9, 9, doc="IA-32e mode guest")
+    load_pat = msrfield(14, 14, doc="Load IA32_PAT")
 
     @property
     def vmx_entry_ctls_load_pat(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 14)
+        return self.allows_flexible_setting("load_pat")
 
     @property
     def vmx_entry_ctls_ia32e_mode(self):
-        return msrfield.is_vmx_cap_supported(self, 1 << 9)
+        return self.allows_flexible_setting("ia32e_mode_guest")
 
     capability_bits = [
         "vmx_entry_ctls_load_pat",

--- a/misc/config_tools/board_inspector/cpuparser/platformbase.py
+++ b/misc/config_tools/board_inspector/cpuparser/platformbase.py
@@ -202,10 +202,12 @@ class msrfield(property):
     def __init__(self, msb, lsb, doc=None):
         self.msb = msb
         self.lsb = lsb
-        bit_mask = self.msb << self.lsb
+
+        max_value = (1 << (msb - lsb + 1)) - 1
+        field_mask = max_value << lsb
 
         def getter(self):
-            return (self.value & bit_mask) != 0
+            return (self.value & field_mask) >> lsb
 
         def setter(self, value):
             if value > max_value:
@@ -219,14 +221,3 @@ class msrfield(property):
             self.value = (self.value & ~field_mask) | (value << lsb)
 
         super(msrfield, self).__init__(getter, setter, doc=doc)
-
-    def is_vmx_cap_supported(self, bits):
-        vmx_msr = self.value
-        vmx_msr_bin = int.to_bytes(vmx_msr, 8, 'big')
-        vmx_msr_low = int.from_bytes(vmx_msr_bin[4:], 'big')
-        vmx_msr_high = int.from_bytes(vmx_msr_bin[:4], 'big')
-        return ((vmx_msr_high & bits) == bits) and ((vmx_msr_low & bits) == 0)
-
-    @staticmethod
-    def is_ctrl_setting_allowed(msr_val, ctrl):
-        return ((msr_val >> 32) & ctrl) == ctrl

--- a/misc/config_tools/board_inspector/extractors/20-cache.py
+++ b/misc/config_tools/board_inspector/extractors/20-cache.py
@@ -8,10 +8,85 @@ import lxml.etree
 from extractors.helpers import add_child, get_node
 
 from cpuparser import parse_cpuid
+import cpuparser.msr as msr
 from acpiparser import parse_rtct
 import acpiparser.rtct
 
-def extract_topology(root_node, caches_node):
+known_cbms = {
+    # From 11th Gen Intel(R) Core(TM) Processors Real-Time Tuning Guide, document number 640980-1.4
+    "11th Gen Intel(R) Core(TM) i3-1115GRE": 12,
+    "11th Gen Intel(R) Core(TM) i5-1145GRE": 8,
+    "11th Gen Intel(R) Core(TM) i7-1185GRE": 12,
+}
+
+def infer_l3_cat(cpu_id, processor_model_node, cache_node):
+    # First of all, existence of L3 CAT is indicated by the presence of IA32_L3_MASK_0 at C90H
+    try:
+        ia32_l3_mask_0 = msr.MSR_IA32_L3_MASK_n(0).rdmsr(cpu_id)
+    except IOError:
+        return
+
+    # If L3 CAT does exist, try inferring its parameters:
+    #
+    #   - For capacity mask length, detect in an trial-and-error way starting from:
+    #     a. the capacity mask length documented in any public real-time tuning guide, if any.
+    #     b. or, the number of ways of the L3 cache.
+    #
+    #   - For the number of CLOS IDs available, detect by searching the last programmable IA32_L3_MASK_n register within
+    #     the C90H - D0FH range which is the architecturally defined MSR space for those registers.
+    #
+    #   - For CDP, try setting the enable bit in IA32_L3_QOS_CFG. CDP is available if and only if that MSR is present
+    #     and its bit 0 can be set.
+
+    # Initial guess of the capacity mask length
+    capacity_mask_length = int(cache_node.find("ways").text)
+    processor_model = processor_model_node.get("description")
+    for k, v in known_cbms.items():
+        if processor_model.startswith(k):
+            capacity_mask_length = v
+            break
+
+    # Verify our guess. If the verification fails, decrease by 1 and guess again.
+    while capacity_mask_length > 0:
+        ia32_l3_mask_0.bit_mask = (1 << capacity_mask_length) - 1
+        try:
+            ia32_l3_mask_0.wrmsr()
+            break
+        except IOError:
+            capacity_mask_length = capacity_mask_length - 1
+            continue
+    else:
+        logging.debug("All writes to IA32_L3_MASK_0 failed. Cannot guess the capacity mask length of L3 CAT.")
+        return
+
+    # Binary search of the number of CLOS available
+    known_good = 1
+    known_bad = 129
+    while known_good + 1 < known_bad:
+        mid = (known_good + known_bad) // 2
+        try:
+            msr.MSR_IA32_L3_MASK_n(mid - 1).rdmsr(cpu_id)
+            known_good = mid
+        except IOError:
+            known_bad = mid
+    clos_number = known_good
+
+    # Detect availability of CDP by trying to write the enable bit.
+    try:
+        l3_qos_cfg = msr.MSR_IA32_L3_QOS_CFG.rdmsr(cpu_id)
+        l3_qos_cfg.cdp_enable = 1
+        l3_qos_cfg.wrmsr()
+        has_cdp = True
+    except IOError:
+        has_cdp = False
+
+    cap = add_child(cache_node, "capability", None, id="CAT")
+    add_child(cap, "capacity_mask_length", str(capacity_mask_length))
+    add_child(cap, "clos_number", str(clos_number))
+    if has_cdp:
+        add_child(cap, "capability", None, id="CDP")
+
+def extract_topology(args, root_node, caches_node):
     threads = root_node.xpath("//processors//*[cpu_id]")
     for thread in threads:
         subleaf = 0
@@ -56,6 +131,27 @@ def extract_topology(root_node, caches_node):
                     if leaf_10.code_and_data_prioritization == 1:
                         add_child(n, "capability", None, id="CDP")
 
+                    # Inform the user if L3 CAT capability is specified manually.
+                    if args.add_llc_cat:
+                        logging.warning(r"The last level cache (cache ID: {cache_id}) already reports CAT capability. The explicit settings from the command line options are ignored.")
+                elif cache_level == 3:
+                    if args.add_llc_cat:
+                        # Inject L3 CAT capability specified by the user
+                        cap = add_child(llc_node, "capability", None, id="CAT")
+                        add_child(cap, "capacity_mask_length", str(args.add_llc_cat.capacity_mask_length))
+                        add_child(cap, "clos_number", str(args.add_llc_cat.clos_number))
+                        if args.add_llc_cat.has_CDP:
+                            add_child(cap, "capability", None, id="CDP")
+                    else:
+                        # Try inferring L3 CAT according to the methods described in section 7.2.3, 11th Gen Intel(R)
+                        # Core(TM) Processors Real-Time Tuning Guide (document number: 640980-1.4).
+                        family_id = thread.find("family_id").text
+                        model_id = thread.find("model_id").text
+                        core_type = thread.find("core_type").text
+                        native_model_id = thread.find("native_model_id").text
+                        processor_model_node = get_node(root_node, f"//processors/model[family_id='{family_id}' and model_id='{model_id}' and core_type='{core_type}' and native_model_id='{native_model_id}']")
+                        infer_l3_cat(cpu_id, processor_model_node, n)
+
             add_child(get_node(n, "processors"), "processor", get_node(thread, "apic_id/text()"))
 
             subleaf += 1
@@ -70,17 +166,4 @@ def extract_topology(root_node, caches_node):
 def extract(args, board_etree):
     root_node = board_etree.getroot()
     caches_node = get_node(board_etree, "//caches")
-    extract_topology(root_node, caches_node)
-
-    # Inject the explicitly specified CAT capability if exists
-    if args.add_llc_cat:
-        llc_node = get_node(root_node, "//caches/cache[@level='3']")
-        llc_cat_node = get_node(llc_node, "capability[@id='CAT']")
-        if llc_cat_node is None:
-            llc_cat_node = add_child(llc_node, "capability", None, id="CAT")
-            add_child(llc_cat_node, "capacity_mask_length", str(args.add_llc_cat.capacity_mask_length))
-            add_child(llc_cat_node, "clos_number", str(args.add_llc_cat.clos_number))
-            if args.add_llc_cat.has_CDP:
-                add_child(llc_node, "capability", None, id="CDP")
-        else:
-            logging.warning("The last level cache already reports CAT capability. The explicit settings from the command line options are ignored.")
+    extract_topology(args, root_node, caches_node)

--- a/misc/config_tools/board_inspector/extractors/40-acpi-tables.py
+++ b/misc/config_tools/board_inspector/extractors/40-acpi-tables.py
@@ -9,7 +9,7 @@ import re, os, fcntl, errno
 import lxml.etree
 from extractors.helpers import add_child, get_node
 
-from acpiparser import parse_apic, apic
+import acpiparser
 
 DEFAULT_MAX_IOAPIC_LINES = 240
 
@@ -40,16 +40,113 @@ def extract_gsi_number(ioapic_node, apic_id):
 
 def extract_topology(ioapics_node, tables):
     for subtable in tables.interrupt_controller_structures:
-        if subtable.subtype == apic.MADT_TYPE_IO_APIC:
+        if subtable.subtype == acpiparser.apic.MADT_TYPE_IO_APIC:
             apic_id = subtable.io_apic_id
             ioapic_node = add_child(ioapics_node, "ioapic", None, id=hex(apic_id))
             add_child(ioapic_node, "address", hex(subtable.io_apic_addr))
             add_child(ioapic_node, "gsi_base", hex(subtable.global_sys_int_base))
             extract_gsi_number(ioapic_node, apic_id)
 
+def extract_tcc_capabilities_from_rtct_v1(board_etree, rtct):
+    caches_node = get_node(board_etree, "//caches")
+
+    for entry in rtct.entries:
+        if entry.type == acpiparser.rtct.ACPI_RTCT_V1_TYPE_SoftwareSRAM:
+            cache_node = get_node(caches_node, f"cache[@level='{entry.cache_level}' and processors/processor='{hex(entry.apic_id_tbl[0])}']")
+            if cache_node is None:
+                logging.debug(f"Cannot find the level {entry.cache_level} cache of physical processor with apic ID {entry.apic_id_tbl[0]}")
+                continue
+            cap = add_child(cache_node, "capability", None, id="Software SRAM")
+            add_child(cap, "start", "0x{:08x}".format(entry.base))
+            add_child(cap, "end", "0x{:08x}".format(entry.base + entry.size - 1))
+            add_child(cap, "size", str(entry.size))
+
+def extract_tcc_capabilities_from_rtct_v2(board_etree, rtct):
+    def get_or_create_ssram_node(cache_node):
+        ssram_node = get_node(cache_node, "capability[@id = 'Software SRAM']")
+        if ssram_node is None:
+            ssram_node = add_child(cache_node, "capability", None, id="Software SRAM")
+        return ssram_node
+
+    caches_node = get_node(board_etree, "//caches")
+    memory_node = get_node(board_etree, "//memory")
+    devices_node = get_node(board_etree, "//devices")
+
+    for entry in rtct.entries:
+        cache_node = None
+        if hasattr(entry, "level") and hasattr(entry, "cache_id"):
+            cache_node = get_node(caches_node, f"cache[@level='{entry.level}' and @id='{hex(entry.cache_id)}']")
+            if cache_node is None:
+                logging.debug(f"Cannot find the level {entry.level} cache with cache ID {entry.cache_id}")
+                continue
+
+        if entry.type == acpiparser.rtct.ACPI_RTCT_TYPE_COMPATIBILITY:
+            rtct_version_node = add_child(caches_node, "parameter", None, id="RTCT Version")
+            add_child(rtct_version_node, "major", str(entry.rtct_version_major))
+            add_child(rtct_version_node, "minor", str(entry.rtct_version_minor))
+            rtcd_version_node = add_child(caches_node, "parameter", None, id="RTCD Version")
+            add_child(rtcd_version_node, "major", str(entry.rtcd_version_major))
+            add_child(rtcd_version_node, "minor", str(entry.rtcd_version_minor))
+        elif entry.type == acpiparser.rtct.ACPI_RTCT_V2_TYPE_RTCD_Limits:
+            add_child(caches_node, "parameter", str(entry.total_ia_l2_clos), id="Total IA L2 CLOS")
+            add_child(caches_node, "parameter", str(entry.total_ia_l3_clos), id="Total IA L3 CLOS")
+            add_child(caches_node, "parameter", str(entry.total_l2_instances), id="Total IA L2 Instances")
+            add_child(caches_node, "parameter", str(entry.total_l3_instances), id="Total IA L2 Instances")
+            add_child(caches_node, "parameter", str(entry.total_gt_clos), id="Total GT CLOS")
+            add_child(caches_node, "parameter", str(entry.total_wrc_clos), id="Total WRC CLOS")
+            add_child(devices_node, "parameter", str(entry.max_tcc_streams), id="Maximum TCC Streams")
+            add_child(devices_node, "parameter", str(entry.max_tcc_registers), id="Maximum TCC Registers")
+        elif entry.type == acpiparser.rtct.ACPI_RTCT_V2_TYPE_CRL_Binary:
+            start = "0x{:016x}".format(entry.address)
+            end = "0x{:016x}".format(entry.address + entry.size - 1)
+            size = str(entry.size)
+            region = add_child(memory_node, "range", None, id="CRL Binary", start=start, end=end, size=size)
+        elif entry.type == acpiparser.rtct.ACPI_RTCT_V2_TYPE_IA_WayMasks:
+            cap = add_child(cache_node, "parameter", None, id="IA Waymask")
+            for waymask in entry.waymask:
+                add_child(cap, "waymask", hex(waymask))
+        elif entry.type == acpiparser.rtct.ACPI_RTCT_V2_TYPE_WRC_WayMasks:
+            cap = add_child(cache_node, "parameter", None, id="WRC Waymask")
+            add_child(cap, "waymask", hex(entry.waymask))
+        elif entry.type == acpiparser.rtct.ACPI_RTCT_V2_TYPE_GT_WayMasks:
+            cap = add_child(cache_node, "parameter", None, id="GT Waymask")
+            for waymask in entry.waymask:
+                add_child(cap, "waymask", hex(waymask))
+        elif entry.type == acpiparser.rtct.ACPI_RTCT_V2_TYPE_SSRAM_WayMask:
+            ssram_node = get_or_create_ssram_node(cache_node)
+            add_child(ssram_node, "waymask", hex(entry.waymask))
+        elif entry.type == acpiparser.rtct.ACPI_RTCT_V2_TYPE_SoftwareSRAM:
+            ssram_node = get_or_create_ssram_node(cache_node)
+            add_child(ssram_node, "start", "0x{:08x}".format(entry.base))
+            add_child(ssram_node, "end", "0x{:08x}".format(entry.base + entry.size - 1))
+            add_child(ssram_node, "size", str(entry.size))
+        elif entry.type == acpiparser.rtct.ACPI_RTCT_V2_TYPE_MemoryHierarchyLatency:
+            for cache_id in entry.cache_id:
+                cache_node = get_node(caches_node, f"cache[@level='{entry.hierarchy}' and @id='{hex(cache_id)}']")
+                if cache_node is None:
+                    logging.debug(f"Cannot find the level {entry.hierarchy} cache with cache ID {cache_id}")
+                    continue
+                param = add_child(cache_node, "parameter", None, id="Worst Case Access Latency")
+                add_child(param, "native", str(entry.clock_cycles))
+        elif entry.type == acpiparser.rtct.ACPI_RTCT_V2_TYPE_ErrorLogAddress:
+            start = "0x{:016x}".format(entry.address)
+            end = "0x{:016x}".format(entry.address + entry.size - 1)
+            size = str(entry.size)
+            region = add_child(memory_node, "range", None, id="TCC Error Log", start=start, end=end, size=size)
+
+def extract_tcc_capabilities(board_etree):
+    try:
+        rtct = acpiparser.parse_rtct()
+        if rtct.version == 1:
+            extract_tcc_capabilities_from_rtct_v1(board_etree, rtct)
+        elif rtct.version == 2:
+            extract_tcc_capabilities_from_rtct_v2(board_etree, rtct)
+    except FileNotFoundError:
+        pass
+
 def extract(args, board_etree):
     try:
-        tables = parse_apic()
+        tables = acpiparser.parse_apic()
     except Exception as e:
         logging.warning(f"Parse ACPI tables failed: {str(e)}")
         logging.warning(f"Will not extract information from ACPI tables")
@@ -57,3 +154,5 @@ def extract(args, board_etree):
 
     ioapics_node = get_node(board_etree, "//ioapics")
     extract_topology(ioapics_node, tables)
+
+    extract_tcc_capabilities(board_etree)

--- a/misc/config_tools/board_inspector/legacy/acpi.py
+++ b/misc/config_tools/board_inspector/legacy/acpi.py
@@ -656,12 +656,3 @@ def generate_info(board_file):
     # Generate board info
     with open(board_file, 'a+') as config:
         gen_acpi_info(config)
-
-    # get the PTCT/RTCT table from native environment
-    out_dir = os.path.dirname(board_file)
-    if os.path.isfile(SYS_PATH[1] + 'PTCT'):
-        shutil.copy(SYS_PATH[1] + 'PTCT', out_dir if out_dir != "" else "./")
-        logging.info("PTCT table has been saved to {} successfully!".format(os.path.join(out_dir, 'PTCT')))
-    if os.path.isfile(SYS_PATH[1] + 'RTCT'):
-        shutil.copy(SYS_PATH[1] + 'RTCT', out_dir if out_dir != "" else "./")
-        logging.info("RTCT table has been saved to {} successfully!".format(os.path.join(out_dir, 'RTCT')))

--- a/misc/config_tools/board_inspector/schema/checks/platform_capabilities.xsd
+++ b/misc/config_tools/board_inspector/schema/checks/platform_capabilities.xsd
@@ -147,9 +147,9 @@ ACRN requires this feature to function properly. Please enable it in BIOS.</xs:d
     </xs:annotation>
   </xs:assert>
 
-  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='unrestricted_guest'])">
+  <xs:assert test="every $model in processors/model satisfies exists($model/capability[@id='stores_lma_on_exit'])">
     <xs:annotation acrn:severity="error">
-      <xs:documentation>Unrestricted guest is not supported on this processor. ACRN requires this feature to function properly.</xs:documentation>
+      <xs:documentation>The value of IA32_EFER.LMA is not saved upon VM exit on this processor. ACRN requires this feature to function properly.</xs:documentation>
     </xs:annotation>
   </xs:assert>
 

--- a/misc/config_tools/static_allocators/memory_allocator.py
+++ b/misc/config_tools/static_allocators/memory_allocator.py
@@ -13,12 +13,10 @@ import common, math, logging
 
 def import_memory_info(board_etree):
     ram_range = {}
-    start = board_etree.xpath("/acrn-config/memory/range/@start")
-    size = board_etree.xpath("/acrn-config/memory/range/@size")
-    for i in range(len(start)):
-        start_hex = int(start[i], 16)
-        size_hex = int(size[i], 10)
-        ram_range[start_hex] = size_hex
+    for memory_range in board_etree.xpath("/acrn-config/memory/range[not(@id) or @id = 'RAM']"):
+        start = int(memory_range.get("start"), base=16)
+        size = int(memory_range.get("size"), base=10)
+        ram_range[start] = size
 
     return ram_range
 


### PR DESCRIPTION
This PR resolves the following two issues.

First, today ACRN build system reuses the physical RTCT as the vRTCT for a pre-launched RT VM which has access to software SRAM. This results in two issues:

  1. Users have to manually copy the physical RTCT to their build machine.
     That violates ACRN development framework which defines the board XML
     as the only file users need to copy.

  2. All information in the physical RTCT will be visible to that
     pre-launched RT VM, including L2 software SRAM it does not have access
     to, way masks of GT even when graphics is not passed through to it and
     the addresses of CRL binary and TCC error log.

To resolve the developer experience and functionality concerns above, this patch series puts information extracted from RTCT to the board XML file and generates a virtual RTCT table (with only the information meaningful to that VM) when needed.

Second, some Intel platforms are known to be equipped with L3 CAT while they do not report its presence or parameters via the architectural CPUID interface. The public real-time tuning guide for 11th gen Core(TM) processors suggests to detect the availability of L3 CAT by trying to access the CAT MSRs directly.

This patch series also implements such logic in the board inspector so that users can leverage the hardware feature without the need to guess its presence by themselves. It includes three patches, with the former two refactoring and fixing the current MSR parsers and the last do the actual guesswork.