### PR TITLE
doc: update 3.0.1 release notes

### DIFF
--- a/doc/release_notes/release_notes_3.0.1.rst
+++ b/doc/release_notes/release_notes_3.0.1.rst
@@ -36,19 +36,19 @@ What's New in v3.0.1
 ********************
 
 Mitigation for Return Stack Buffer Underflow security vulnerability
-  For platforms that supports RRSBA (Restricted Return Stack Buffer
+  When running ACRN on Alder Lake platforms that support RRSBA (Restricted Return Stack Buffer
   Alternate), using retpoline may not be sufficient to guard against branch
   history injection or intra-mode branch target injection. RRSBA must
-  be disabled to prevent CPUs from using alternate predictors for RETs.
+  be disabled for Alder Lake platforms to prevent CPUs from using alternate predictors for RETs.
   (Addresses security issue tracked by CVE-2022-29901 and CVE-2022-28693.)
 
 ACRN shell commands added for real-time performance profiling
   ACRN shell commands were added to sample vmexit data per virtual CPU to
   facilitate real-time performance profiling:
 
-  * ``vmexit clear``: clears current vmexit buffer
-  * ``vmexit [vm_id]``: outputs vmexit info per vCPU
   * ``vmexit enable | disable``: enabled by default
-
+  * ``vmexit clear``: clears current vmexit buffer
+  * ``vmexit [vm_id]``: outputs vmexit reason code and latency count information per vCPU
+    for a VM ID (or for all VM IDs if none is specified).
 
 See :ref:`release_notes_3.0` for additional release information.


### PR DESCRIPTION
Clarify description of CVE fix (only impacts ACRN implementation on
Alder Lake platforms), and improve description of the ACRN shell's new
vmexit command.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>