### PR TITLE
doc: fix Build EFI-Stub fail problem

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -129,7 +129,8 @@ To set up the ACRN build environment on the development computer:
            libsdl2-dev \
            libegl-dev \
            libgles-dev \
-           libdrm-dev
+           libdrm-dev \
+           gnu-efi
 
 #. Install Python package dependencies:
 


### PR DESCRIPTION
In the "Enable ACRN Secure Boot With EFI-Stub" guide, to build EFI-Stub
smoothly, the installation of "gnu-efi" package is added to GSG.

Tracked-On: #7935
Signed-off-by: Ziheng Li <ziheng.li@intel.com>