### PR TITLE
SampleApplication: Change the unit of result

### DIFF
--- a/misc/sample_application/uservm/histapp.py
+++ b/misc/sample_application/uservm/histapp.py
@@ -49,7 +49,7 @@ def create_hist():
 	figure = plt.hist(dataset)
 
 	plt.title("Latency percentages")
-	plt.xlabel("Latency Value (ms)")
+	plt.xlabel("Latency Value (us)")
 	plt.ylabel("Frequency")
 	plt.savefig("hist.png")
 


### PR DESCRIPTION
Correct the unit of sample-application result, which should be us(microseconds).

Tracked-On #7820
Signed-off-by: Zhang Wei <wei6.zhang@linux.intel.com>