### PR TITLE
config_tools: fix vBDF schema pattern issue

### DIFF
--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -182,7 +182,7 @@ Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:docu
     <xs:documentation>A string with up to two hex digits, a ``:``, two hex digits, a ``.``, and one digit between 0-7.</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
-    <xs:pattern value="[0-9A-Fa-f]{1,2}:[0-1][0-9A-Fa-f].[0-7]" />
+    <xs:pattern value="[0-9A-Fa-f]{1,2}:[0-1][0-9A-Fa-f]\.[0-7]" />
   </xs:restriction>
 </xs:simpleType>
 


### PR DESCRIPTION
add escape charater to fix vBDF pattern match any character issue
for vUART and ivshmem.

Tracked-On: #7925
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>