### PR TITLE
dm: bugfix for iothread

### DIFF
--- a/devicemodel/core/iothread.c
+++ b/devicemodel/core/iothread.c
@@ -145,7 +145,7 @@ iothread_init(void)
 	pthread_mutex_init(&ioctx.mtx, &attr);
 	pthread_mutexattr_destroy(&attr);
 
-	ioctx.tid = -1;
+	ioctx.tid = 0;
 	ioctx.started = false;
 	ioctx.epfd = epoll_create1(0);
 


### PR DESCRIPTION
    dm: bugfix for iothread

    As the type of pthread_t is unsigned long, so the init value for it
    should not be '-1'. When the tid is '-1', it will continue to call
    pthread_kill/pthread_join. This is incorrect.

    Tracked-On: #7960
    Signed-off-by: Conghui <conghui.chen@intel.com>
    Reviewed-by: Zhao Yakui <yakui.zhao@intel.com>
    Acked-by: Wang, Yu1 <yu1.wang@intel.com>