### PR TITLE
misc: add assert to check the vBDF conflict

### DIFF
--- a/misc/config_tools/schema/checks/vbdf_assignment.xsd
+++ b/misc/config_tools/schema/checks/vbdf_assignment.xsd
@@ -14,4 +14,14 @@
     </xs:annotation>
   </xs:assert>
 
+
+  <xs:assert test="every $root in /acrn-config satisfies
+                   every $vm in $root/vm[./load_order/text()='SERVICE_VM'] satisfies
+                   every $vbdf in $root/hv//vuart_connection[type='pci']/endpoint[vm_name=$vm/name]/vbdf/text() | $root/hv//IVSHMEM_VM[VM_NAME=$vm/name]/VBDF/text() satisfies
+                   contains(/acrn-config//PCI_DEVICE/text(), $vbdf) = false()">
+    <xs:annotation acrn:severity="error" acrn:report-on="$root/hv//vuart_connection[type='pci']/endpoint[vm_name=$vm/name and vbdf=$vbdf] | $root/hv//IVSHMEM_VM[VM_NAME=$vm/name and VBDF=$vbdf]">
+      <xs:documentation>VM "{$vm/name}" virtual UART controllers or IVSHMEM interfaces using BDF {$vbdf} conflict with native PCI device. Adjust the BDF of those devices to be unique.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
 </xs:schema>


### PR DESCRIPTION
The current ACRN-Configurator just check the conflict of user setting.
have not check the conflict with native PCI device's bdf.

This patch add an assert to check the above conflict.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>