### PR TITLE
config-tools: modified requirements.txt and update GSG

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -142,7 +142,8 @@ To set up the ACRN build environment on the development computer:
 
    .. code-block:: bash
 
-      sudo pip3 install "elementpath==2.5.0" lxml "xmlschema==1.10.0" defusedxml tqdm
+      cd ~/acrn-work/acrn-hypervisor/misc/config_tools
+      sudo pip3 install -r requirements.txt
 
 #. Build and install the iASL compiler/disassembler used for advanced power management,
    device discovery, and configuration (ACPI) within the host OS:

--- a/doc/tutorials/acrn_configurator_tool.rst
+++ b/doc/tutorials/acrn_configurator_tool.rst
@@ -503,7 +503,7 @@ how to build the Debian package from source code.
 
    .. code-block:: bash
 
-      cd ~/acrn-work/acrn-hypervisor/misc/config_tools/configurator
+      cd ~/acrn-work/acrn-hypervisor/misc/config_tools
       python3 -m pip install -r requirements.txt
       yarn
 

--- a/misc/config_tools/requirements.txt
+++ b/misc/config_tools/requirements.txt
@@ -1,9 +1,9 @@
 defusedxml
 lxml
-elementpath
-xmlschema
-build
+elementpath==2.5.3
+xmlschema==1.9.2
 tqdm
+build
 requests
 xmltodict
 sphinx


### PR DESCRIPTION
Moved requirements.txt form misc/config_tools/configurator
directory to misc/config_tools directory and modified
relevant python package installing steps in GSG.

Tracked-On: #7975
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Signed-off-by: Ziheng Li <ziheng.li@intel.com>