### PR TITLE
doc: add libelf-dev dependency to GSG

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -130,7 +130,7 @@ To set up the ACRN build environment on the development computer:
            python3 python3-pip python3.8-venv libblkid-dev e2fslibs-dev \
            pkg-config libnuma-dev libcjson-dev liblz4-tool flex bison \
            xsltproc clang-format bc libpixman-1-dev libsdl2-dev libegl-dev \
-           libgles-dev libdrm-dev gnu-efi
+           libgles-dev libdrm-dev gnu-efi libelf-dev
 
 #. Install Python package dependencies:
 


### PR DESCRIPTION
The new acrn-kernel for v3.1 expects gelf.h that's installed with the libelf-dev
package that's not listed as a dependency in the GSG.  Without this
package, building acrn-kernel fails.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>