### PR TITLE
Acrn waag multi

### DIFF
--- a/devicemodel/hw/vdisplay_sdl.c
+++ b/devicemodel/hw/vdisplay_sdl.c
@@ -1254,7 +1254,7 @@ vdpy_init(int *num_vscreens)
 
 	vdpy.s.n_connect++;
 	if (num_vscreens)
-		*num_vscreens = 1;
+		*num_vscreens = vdpy.vscrs_num;
 	return vdpy.s.n_connect;
 }
 

--- a/devicemodel/hw/vdisplay_sdl.c
+++ b/devicemodel/hw/vdisplay_sdl.c
@@ -1301,6 +1301,10 @@ gfx_ui_init()
 		return -1;
 	}
 
+	if (vdpy.vscrs_num <= 0) {
+		pr_err("Incorrect geometry parameter for virtio-gpu\n");
+		return -1;
+	}
 	num_pscreen = SDL_GetNumVideoDisplays();
 
 	for (i = 0; i < vdpy.vscrs_num; i++) {


### PR DESCRIPTION
ACRN uses the DMABuf to render the framebuffer submitted from guest vm.
But the DMABuf doesn't work when guest_vm is booted with multi-display.
This patch set tries to fix the display issues when multi-display is used.

This issue is related with the  limitation in libSDL. One small texture(32x32) is added to WA the issue and
helps to assure that the libSDL can configure its internal state correctly. 
