### PR TITLE
Focus change to new VM when added

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -241,6 +241,7 @@ export default {
       }
       maxVMID++;
       this.scenario.vm.push(configurator.newVM(maxVMID, load_order))
+      this.switchTab(maxVMID)
     },
     deleteVM() {
       let currentVMIndex = -1;


### PR DESCRIPTION
the focus  change to that new VM on the Basic tab when the new VM  added

Tracked-On: #7914
Signed-off-by: Chuang-Ke <chuangx.ke@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>