### PR TITLE
doc: remove use of :term: role in tooltip

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -70,7 +70,7 @@
     </xs:element>
     <xs:element name="SECURITY_VM_FIXUP" type="Boolean" default="n">
       <xs:annotation acrn:title="Security VM Features" acrn:views="advanced">
-          <xs:documentation>This option enables hypervisor features potentially needed by a :term:`Security VM`:
+          <xs:documentation>This option enables hypervisor features potentially needed by a Security VM:
 
 - The virtual Trusted Platform Module (vTPM) 2.0 ACPI table, likely
   used by a security VM, is usually generated statically at build


### PR DESCRIPTION
The configurator can't process :term: glossary references, so remove it.

Tracked-On: #5692

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>