### PR TITLE
doc: revert to not using requirements.txt in the GSG

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -142,8 +142,7 @@ To set up the ACRN build environment on the development computer:
 
    .. code-block:: bash
 
-      cd ~/acrn-work/acrn-hypervisor/misc/config_tools
-      sudo pip3 install -r requirements.txt
+      sudo pip3 install "elementpath==2.5.0" lxml "xmlschema==1.9.2" defusedxml tqdm
 
 #. Build and install the iASL compiler/disassembler used for advanced power management,
    device discovery, and configuration (ACPI) within the host OS:


### PR DESCRIPTION
GSG was recently updated to use a requirements.txt for python
dependencies, but that file doesn't exist in the repo at the v3.0 tag
the instructions say to use.  Revert to not use a requirements.txt until
we get this figured out.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>