### PR TITLE
doc: Add a python package in GSG

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -142,7 +142,7 @@ To set up the ACRN build environment on the development computer:
 
    .. code-block:: bash
 
-      sudo pip3 install "elementpath==2.5.0" lxml "xmlschema==1.9.2" defusedxml tqdm
+      sudo pip3 install "elementpath==2.5.0" lxml "xmlschema==1.9.2" defusedxml tqdm requests
 
 #. Build and install the iASL compiler/disassembler used for advanced power management,
    device discovery, and configuration (ACPI) within the host OS:


### PR DESCRIPTION
The Getting Started Guide specifies that we need to install the Python packages lxml, xmlschema, and defusedxml.
However, a make clean involves the execution of the Python script manager.py. This script imports the package requests.py, which might not be installed if the developer follows the Getting Started Guide.

Add requests follow this command in GSG.
sudo pip3 install "elementpath==2.5.0" lxml "xmlschema==1.9.2" defusedxml tqdm requests

[External_System_ID] ACRN-9144
Tracked-On: #8029
Signed-off-by: Zhang Wei <wei6.zhang@intel.com>