### PR TITLE
misc: refine the ACRN Configurator error message

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -178,7 +178,8 @@ If your VM is not a security VM, leave this option unchecked. </xs:documentation
       </xs:annotation>
     </xs:element>
     <xs:element name="MAX_PCI_DEV_NUM" default="96">
-      <xs:annotation acrn:title="Max PCI devices" acrn:views="advanced">
+      <xs:annotation acrn:title="Max PCI devices" acrn:views="advanced"
+                     acrn:errormsg="'required': 'must config the max number of PCI devices'">
         <xs:documentation>Specify the maximum number of PCI devices. This impacts the amount of memory used to maintain information about these PCI devices. The default value is calculated from the board configuration file. If you have PCI devices that were not detected by the Board Inspector, you may need to change this maximum value.</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
@@ -206,7 +207,8 @@ If your VM is not a security VM, leave this option unchecked. </xs:documentation
       </xs:simpleType>
     </xs:element>
     <xs:element name="MAX_PT_IRQ_ENTRIES" default="256">
-      <xs:annotation acrn:title="Max passthrough IRQ entries" acrn:views="advanced">
+      <xs:annotation acrn:title="Max passthrough IRQ entries" acrn:views="advanced"
+                     acrn:errormsg="'required': 'must config the max number of passthrough IRQ entries'">
         <xs:documentation>Specify the maximum number of interrupt request (IRQ) entries from all passthrough devices.</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
@@ -220,7 +222,8 @@ If your VM is not a security VM, leave this option unchecked. </xs:documentation
       </xs:simpleType>
     </xs:element>
     <xs:element name="MAX_MSIX_TABLE_NUM" default="64">
-        <xs:annotation acrn:title="Max MSI-X tables" acrn:views="advanced">
+        <xs:annotation acrn:title="Max MSI-X tables" acrn:views="advanced"
+                       acrn:errormsg="'required': 'must config the max number of MSI-X tables'">
           <xs:documentation>Specify the maximum number of Message Signaled Interrupt MSI-X tables per device. The default value is calculated from the board configuration file.</xs:documentation>
         </xs:annotation>
       <xs:simpleType>
@@ -234,7 +237,8 @@ If your VM is not a security VM, leave this option unchecked. </xs:documentation
       </xs:simpleType>
     </xs:element>
     <xs:element name="MAX_EMULATED_MMIO" default="16">
-        <xs:annotation acrn:title="Max emulated MMIO regions" acrn:views="advanced">
+        <xs:annotation acrn:title="Max emulated MMIO regions" acrn:views="advanced"
+                       acrn:errormsg="'required': 'must config the max number of emulated MMIO regions'">
           <xs:documentation>Specify the maximum number of emulated MMIO regions for device virtualization. The default value is calculated from the board configuration file.</xs:documentation>
         </xs:annotation>
       <xs:simpleType>


### PR DESCRIPTION
The current ACRN Configurator show the XML name instead of DX-friendly
name when user delete the default value of some numeric field.

This patch add some "acrn:errormsg" which will show the DX-friendly name
to fix the above issue.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>