### PR TITLE
misc: add assert to check the RTVM CPU affinity

### DIFF
--- a/misc/config_tools/schema/checks/cpu_assignment.xsd
+++ b/misc/config_tools/schema/checks/cpu_assignment.xsd
@@ -39,4 +39,11 @@
     </xs:annotation>
   </xs:assert>
 
+  <xs:assert test="every $vm in /acrn-config/vm[vm_type = 'RTVM'] satisfies
+                   count($vm//pcpu_id[./text() = '0']) = 0">
+    <xs:annotation acrn:severity="error" acrn:report-on="$vm//cpu_affinity">
+      <xs:documentation>The CPU 0 can't assign to RTVM {$vm/name/text()}.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
 </xs:schema>


### PR DESCRIPTION
The current ACRN Configurator have no warning when the user set CPU zero
to RTVM.

This patch add an assert to check the above.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>