### PR TITLE
doc: update sample app doc to use sudo

### DIFF
--- a/doc/getting-started/sample-app.rst
+++ b/doc/getting-started/sample-app.rst
@@ -569,11 +569,13 @@ Install and Run ACRN on the Target System
 
       dhclient
 
-#. Run the HMI VM Sample Application userApp (in the background) and histapp.py::
+#. Run the HMI VM Sample Application userApp (in the background)::
 
-     ./userApp &
+     sudo /root/userApp &
 
-     python3 histapp.py
+   and then the histapp.py application::
+
+     sudo python3 /root/histapp.py
 
    At this point, the HMI_VM is running and we've started the HMI parts of
    the sample application. Next, we will launch the RT_VM and its parts of
@@ -607,11 +609,13 @@ Install and Run ACRN on the Target System
       (acrn-guest)root@ubuntu:~#
 
 
-#. Run the cyclictest (in the background) and then the rtApp in this RT_VM::
+#. Run the cyclictest in this RT_VM (in the background)::
 
      cyclictest -p 80 --fifo="./data_pipe" -q &
 
-     ./rtApp
+   and then the rtApp in this RT_VM::
+
+     sudo /root/rtApp
 
 Now the two parts of the sample application are running:
 


### PR DESCRIPTION
Previously the sample apps needed to be run as root, but with a recent
update they could be run as a normal (acrn) user.  Update the sample app
to use sudo for running these sample app components in case the user
doesn't login as root.  Also, split running the background app and the
foreground app into two commands to eliminate some confusion.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>