### PR TITLE
misc: add assert to check the total memory size of User VMs

### DIFF
--- a/misc/config_tools/schema/checks/vm_memory.xsd
+++ b/misc/config_tools/schema/checks/vm_memory.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2022 Intel Corporation. -->
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<xs:schema xml:id="root"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:acrn="https://projectacrn.org">
+
+  <xs:assert test="sum(//memory/range[not(@id)]/@size) &gt; (sum(/acrn-config//vm[load_order != 'SERVICE_VM']//memory/size) + sum(/acrn-config//vm[load_order != 'SERVICE_VM']//size_hpa)) * 1024 * 1024">
+    <xs:annotation acrn:severity="warning" acrn:report-on="/acrn-config//vm[load_order != 'SERVICE_VM']//memory">
+      <xs:documentation>The total memory size applied by all VMs large then the host memory ({(sum(/acrn-config//vm[load_order != 'SERVICE_VM']//memory/size) + sum(/acrn-config//vm[load_order != 'SERVICE_VM']//size_hpa)) * 1024 * 1024} > {sum(//memory/range[not(@id)]/@size)}).</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+</xs:schema>

--- a/misc/config_tools/schema/datachecks.xsd
+++ b/misc/config_tools/schema/datachecks.xsd
@@ -19,6 +19,7 @@
       <xi:include href="checks/ivsh_memory.xsd" xpointer="xpointer(id('root')/*)" />
       <xi:include href="checks/rdt_support.xsd" xpointer="xpointer(id('root')/*)" />
       <xi:include href="checks/pci_config.xsd" xpointer="xpointer(id('root')/*)" />
+      <xi:include href="checks/vm_memory.xsd" xpointer="xpointer(id('root')/*)" />
 
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
The current code does not detect the memory applied by all VMs, if it
exceeds the native memory, there will be an allocate failed and these
VMs can't run.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>
Reviewed-by: Junjie Mao junjie.mao@intel.com