### PR TITLE
doc: update GSG and sample app guide

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -53,10 +53,11 @@ Before you begin, make sure your machines have the following prerequisites:
   - USB keyboard and mouse
   - Monitor
   - Ethernet cable and Internet access
-  - A second USB disk with minimum 1GB capacity to copy files between the
-    development computer and target system (this guide offers steps for
-    copying via USB disk, but you can use another method, such as using ``scp``
-    to copy files over the local network, if you prefer)
+  - A second USB disk with minimum 16GB capacity. Format your USB disk with a
+    files system that supports files greater than 4GB: extFAT or NTFS, but not
+    FAT32. We'll use this USB disk to copy files between the development
+    computer and target system. Instead of a USB drive, you can copy files
+    between systems over the network using the ``scp`` command.)
   - Local storage device (NVMe or SATA drive, for example).  We recommend having
     40GB or more of free space.
 
@@ -110,7 +111,7 @@ To set up the ACRN build environment on the development computer:
 
    .. code-block:: bash
 
-      mkdir ~/acrn-work
+      mkdir -p ~/acrn-work
 
 #. Install the necessary ACRN build tools:
 
@@ -202,7 +203,7 @@ Install OS on the Target
 
 The target system needs Ubuntu Desktop 20.04 LTS to run the Board Inspector
 tool. You can read the full instructions to download, create a bootable USB
-stick, and `Install Ubuntu desktop
+drive, and `Install Ubuntu desktop
 <https://ubuntu.com/tutorials/install-ubuntu-desktop#1-overview>`_ on the Ubuntu
 site.  We'll provide a summary here:
 
@@ -335,7 +336,7 @@ Generate a Board Configuration File
              cp -r acrn-hypervisor/build/acrn-board-inspector*.deb "$disk"/
              sync && sudo umount "$disk"
 
-       #. Remove the USB stick from the development computer and insert it into the target system.
+       #. Remove the USB disk from the development computer and insert it into the target system.
 
        #. Copy the Board Inspector Debian package from the USB disk to the target:
 

--- a/doc/getting-started/sample-app.rst
+++ b/doc/getting-started/sample-app.rst
@@ -442,7 +442,7 @@ Copy files from the development system to your target system
    HMI_VM and RT_VM images, Debian packages for the Service VM and
    Hypervisor, launch scripts, and the iasl tool built following the
    Getting Started guide. You can use ``scp`` to copy across the local network,
-   or use a USB drive:
+   or use a USB stick:
 
    Option 1: use ``scp`` to copy files over the local network
      Use scp to copy files from your development system to the
@@ -461,20 +461,22 @@ Copy files from the development system to your target system
        sudo ln -s /usr/sbin/iasl /usr/bin/iasl
 
    Option 2: use a USB stick to copy files
-     Insert a USB stick into the development computer
-     and run these commands::
+     Because the VM image files are large, format your USB stick with a file
+     system that supports files greater than 4GB: extFAT or NTFS, but not FAT32.
+
+     Insert a USB stick into the development computer and run these commands::
 
         disk="/media/$USER/"$(ls /media/$USER)
 
         cd ~/acrn-work
-        cp acrn-hypervisor/misc/sample_application/image_builder/*_vm.img rt_vm.img "$disk"
+        cp acrn-hypervisor/misc/sample_application/image_builder/build/*_vm.img rt_vm.img "$disk"
         cp acrn-hypervisor/build/acrn-my_board-MyConfiguration*.deb "$disk"
         cp *acrn-service-vm*.deb "$disk"
         cp MyConfiguration/launch_user_vm_id*.sh "$disk"
         cp acpica-unix-20210105/generate/unix/bin/iasl "$disk"
         sync && sudo umount "$disk"
 
-     Move the USB disk you just used to the target system and run
+     Move the USB stick you just used to the target system and run
      these commands to copy the files locally::
 
         disk="/media/$USER/"$(ls /media/$USER)


### PR DESCRIPTION
* Fix missing /build folder in copy command in GSG
* Mention USB stick needs formatting for large files when used for the
  sample app (but we'll put that into GSG too).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>