### PR TITLE
[config_tool] Configurator creates duplicate VM name

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -232,6 +232,12 @@ export default {
       let haveService = false;
       this.scenario.vm.map((vmConfig) => {
         let vmID = vmConfig['@id'];
+        if (vmConfig['name'] && (/^VM(\d+)$/).test(vmConfig['name'])) {
+          let temp = vmConfig['name'].replace(/\D/g, ' ')
+          if (maxVMID < parseInt(temp)) {
+            maxVMID = parseInt(temp)
+          }
+        }
         if (vmID > maxVMID) {
           maxVMID = vmID
         }


### PR DESCRIPTION
1.add condition to recalculate maxVMID from saved VM name,  so that vm name could be update correctly
if there is VM names "service VM" "real-time VM" "VM11", the new VM will be named "VM12"
2. support calculate VM name when changing any VM name.
if there is VM names "service VM" "real-time VM" , the new VM will be named "VM2",count from 0.

Tracked-On: #8046
Signed-off-by: Chuang-Ke <chuangx.ke@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>