### PR TITLE
config_tools/upgrader: keep cache allocation policies properly

### DIFF
--- a/misc/config_tools/scenario_config/upgrader.py
+++ b/misc/config_tools/scenario_config/upgrader.py
@@ -660,6 +660,13 @@ class ScenarioUpgrader(ScenarioTransformer):
                 n.text = "n"
         return ret
 
+    def move_hierarchy(self, xsd_element_node, xml_parent_node, new_nodes):
+        element_tag = xsd_element_node.get("name")
+        for n in self.get_from_old_data(xml_parent_node, f"//{element_tag}"):
+            new_nodes.append(n)
+            for child in n.iter():
+                self.old_data_nodes.discard(child)
+
     def move_data_by_xpath(self, xpath, xsd_element_node, xml_parent_node, new_nodes, scenario_xml_only = False, launch_xml_only = False):
         element_tag = xsd_element_node.get("name")
 
@@ -781,6 +788,8 @@ class ScenarioUpgrader(ScenarioTransformer):
         "os_type": move_os_type,
         "virtio_devices": move_virtio_devices,
         "memory": move_memory,
+
+        "CACHE_REGION": move_hierarchy,
 
         "default": move_data_by_same_tag,
     }


### PR DESCRIPTION
The current generic data moving policy in the upgrader do not work well
with complex nodes having multiple-occurred descendants. That causes the
lost of cache allocation policies in scenario XMLs when upgrading a v3.0
scenario XML to the coming v3.1.

This patch adds another generic-purpose mover that simply copies a whole
subtree unchanged.

Most nodes of this kind are handled by special movers as their formats
changed dramatically in v3.0, which is why that issue is not identified
earlier.

Tracked-On: #6690
Signed-off-by: Junjie Mao <junjie.mao@intel.com>