### PR TITLE
[config_tool] Imported scenarios not populating CAT widget

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -198,6 +198,7 @@ export default {
       this.updateCurrentFormSchema()
       this.updateCurrentFormData()
       configurator.cat.scenarioLoaded()
+      this.switchTab(-1)
     },
     getSchemaData() {
       return this.schemas


### PR DESCRIPTION
fix CAT widget data doesn't refresh after import another scenario

the focus will go to "Basic Parameters" tab after import a scenario everytime. so that data could be refresh.

Tracked-On: #8068
Signed-off-by: Chuang-Ke <chuangx.ke@intel.com>