### PR TITLE
config_tools: UC_LOCK_DETECTION_ENABLED default value

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -63,7 +63,7 @@
         <xs:documentation>Enable detection of split locks. A split lock can negatively affect an application's real-time performance. If a lock is detected, an alignment check exception #AC occurs.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="UC_LOCK_DETECTION_ENABLED" type="Boolean" default="y">
+    <xs:element name="UC_LOCK_DETECTION_ENABLED" type="Boolean" default="n">
       <xs:annotation acrn:title="Enable UC lock detection" acrn:views="advanced">
         <xs:documentation>Enable detection of uncacheable-memory (UC) locks. A UC lock can negatively affect an application's real-time performance. If a lock is detected, a general-protection exception #GP occurs.</xs:documentation>
       </xs:annotation>


### PR DESCRIPTION
Disable UC lock detection(UC_LOCK_DETECTION_ENABLED) by default.

Tracked-On: #8018
Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>