### PR TITLE
misc: update elementpath to 2.5.0

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pyodide.js
+++ b/misc/config_tools/configurator/packages/configurator/src/pyodide.js
@@ -15,7 +15,7 @@ export default async function () {
         import micropip
         await micropip.install([
             './thirdLib/xmltodict-0.12.0-py2.py3-none-any.whl',
-            './thirdLib/elementpath-2.4.0-py3-none-any.whl',
+            './thirdLib/elementpath-2.5.0-py3-none-any.whl',
             './thirdLib/defusedxml-0.7.1-py2.py3-none-any.whl',
             './thirdLib/xmlschema-1.9.2-py3-none-any.whl',
             './thirdLib/acrn_config_tools-3.0-py3-none-any.whl'

--- a/misc/config_tools/configurator/packages/configurator/thirdLib/library.json
+++ b/misc/config_tools/configurator/packages/configurator/thirdLib/library.json
@@ -78,16 +78,16 @@
       "name": "elementpath@2.5.0",
       "check": {
         "type": "file",
-        "path": "elementpath-2.4.0-py3-none-any.whl"
+        "path": "elementpath-2.5.0-py3-none-any.whl"
       },
       "clean": [
-        "elementpath-2.4.0-py3-none-any.whl"
+        "elementpath-2.5.0-py3-none-any.whl"
       ],
       "install": [
         {
           "type": "download",
-          "from": "https://files.pythonhosted.org/packages/7e/35/55a92f54f018c20e717223a0561bb60bf5053170c86b4b3624368f2da137/elementpath-2.4.0-py3-none-any.whl",
-          "to": "elementpath-2.4.0-py3-none-any.whl"
+          "from": "https://files.pythonhosted.org/packages/db/39/42134fabe580e6c7da7f65e94bd3a41aa6263d887e43214a0f8a5306e701/elementpath-2.5.0-py3-none-any.whl",
+          "to": "elementpath-2.5.0-py3-none-any.whl"
         }
       ]
     },


### PR DESCRIPTION
The current elementpath of ACRN Configurator use 2.4.0 which can's
support some new python interface, this patch update it to 2.5.0 to
fix the above issue.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>