### PR TITLE
config_tool: modify the launchscript template

### DIFF
--- a/misc/config_tools/launch_config/launch_script_template.sh
+++ b/misc/config_tools/launch_config/launch_script_template.sh
@@ -129,7 +129,7 @@ function add_virtual_device() {
         # Create the tap device
         if [[ ${options} =~ tap=([^,]+) ]]; then
             tap_conf="${BASH_REMATCH[1]}"
-            create_tap "${tap_conf}" >> /dev/stderr
+            create_tap "${tap_conf}" >&2
         fi
     fi
 


### PR DESCRIPTION
Change  ">>/dev/stderr" to ">&2"
    Although it seems that the two have the same effects, the way they work is different.
    The ">/dev/stderr" does an open(), it goes to the filesystem look for that file, opens and write to it. The second way, ">&2",just uses file descriptor 2.
    The acrnd deamon outputs the stdin and stderr messages to journal through socket. And the socket cannot be manipulated with open methods.So acrnd cannot open the "/dev/stderr" which has redirected to a socket.
    For successfully excuting the create_tap function in acrnd deamon, We change ">> /dev/stderr" to ">&2".
    For the remain ">> /dev/stderr", they all follow the echo command and will not harm the launchscript functionality.

Tracked-On: #8066

Signed-off-by: Zhang Wei <wei6.zhang@intel.com>