### PR TITLE
misc: refine the vCPU sort for cpu_affinity and CAT

### DIFF
--- a/misc/config_tools/library/rdt.py
+++ b/misc/config_tools/library/rdt.py
@@ -140,7 +140,7 @@ def gen_policy_owner_list(scenario_etree):
         vm_name = common.get_node("./text()", vm)
         vcpu = common.get_node("../VCPU/text()", vm)
         cache_type = common.get_node("../TYPE/text()", vm)
-        policy_owner_list.append(policy_owner(vm_name, vcpu, cache_type))
+        policy_owner_list.append(policy_owner(vm_name, int(vcpu), cache_type))
     return policy_owner_list
 
 def vm_vcat_enable(scenario_etree, vm_name):

--- a/misc/config_tools/static_allocators/clos.py
+++ b/misc/config_tools/static_allocators/clos.py
@@ -35,7 +35,7 @@ def alloc_clos_index(board_etree, scenario_etree, allocation_etree, mask_list):
         vm_name = common.get_node("./name/text()", vm_node)
         vcpu_list = scenario_etree.xpath(f"//POLICY[VM = '{vm_name}']/VCPU/text()")
         index_list = []
-        for vcpu in sorted(list(set(vcpu_list))):
+        for vcpu in sorted([int(x) for x in set(vcpu_list)]):
             if rdt.cdp_enable(scenario_etree):
                 index = get_clos_id(mask_list, rdt.policy_owner(vm_name, vcpu, "Data")) // 2
             else:

--- a/misc/config_tools/static_allocators/cpu_affinity.py
+++ b/misc/config_tools/static_allocators/cpu_affinity.py
@@ -32,5 +32,5 @@ def fn(board_etree, scenario_etree, allocation_etree):
                 allocation_sos_vm_node = common.append_node("/acrn-config/vm", None, allocation_etree, id = vm_id)
             if common.get_node("./load_order", allocation_sos_vm_node) is None:
                 common.append_node("./load_order", "SERVICE_VM", allocation_sos_vm_node)
-        for pcpu_id in cpus_for_sos:
+        for pcpu_id in sorted([int(x) for x in cpus_for_sos]):
             common.append_node("./cpu_affinity/pcpu_id", str(pcpu_id), allocation_sos_vm_node)


### PR DESCRIPTION
The current code sort cpu list by string order, this is an issue when
we want to assign more then 10 vCPUs for some VM.

So this patch rewrite the sort of these list, now the cpu list order
by int type.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>