### PR TITLE
config_tools: enable RDT and CDP after launch scenario

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/lib/acrn.ts
+++ b/misc/config_tools/configurator/packages/configurator/src/lib/acrn.ts
@@ -369,7 +369,7 @@ class CAT {
                     this.switches.VCAT_ENABLED = false
                 }
             }
-        } else if (this.switches.CDP_ENABLED || this.switches.VCAT_ENABLED) {
+        } else if (this.switches.VCAT_ENABLED) {
             if (!this.switches.RDT_ENABLED) {
                 this.switches.RDT_ENABLED = true
             }


### PR DESCRIPTION
Before, the logic automatically sets RDT as y if CDP is y. when the user imports a scenario, the CDP is y and RDT is y, the view will set CDP as y and RDT as y.
After fixing, the logic won't set RDT as y if CDP is y, which means the RDT won't be changed no matter if CDP is y or n(only when import scenario) .

Tracked-On: #8087 
Signed-off-by: Chuang-Ke <chuangx.ke@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>