### PR TITLE
misc: add config for P2SB

### DIFF
--- a/misc/config_tools/board_config/board_c.py
+++ b/misc/config_tools/board_config/board_c.py
@@ -408,8 +408,14 @@ def gen_px_cx(config):
 
 def gen_pci_hide(config):
     """Generate hide pci information for this platform"""
+
+    scenario_etree = lxml.etree.parse(common.SCENARIO_INFO_FILE)
+    hidden_pdev_list = [x.replace('.', ':') for x in scenario_etree.xpath(f"//HIDDEN_PDEV/text()")]
+
     if board_cfg_lib.BOARD_NAME in list(board_cfg_lib.KNOWN_HIDDEN_PDEVS_BOARD_DB.keys()) and board_cfg_lib.KNOWN_HIDDEN_PDEVS_BOARD_DB[board_cfg_lib.BOARD_NAME] != 0:
-        hidden_pdev_list = board_cfg_lib.KNOWN_HIDDEN_PDEVS_BOARD_DB[board_cfg_lib.BOARD_NAME]
+        hidden_pdev_list += board_cfg_lib.KNOWN_HIDDEN_PDEVS_BOARD_DB[board_cfg_lib.BOARD_NAME] + scenario_pdev_list
+
+    if len(hidden_pdev_list) > 0:
         hidden_pdev_num = len(hidden_pdev_list)
         print("const union pci_bdf plat_hidden_pdevs[MAX_HIDDEN_PDEVS_NUM] = {", file=config)
         for hidden_pdev_i in range(hidden_pdev_num):

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -272,6 +272,16 @@ The size is a subset of the VM's total memory size specified on the Basic tab.</
   </xs:all>
 </xs:complexType>
 
+<xs:complexType name="HiddenDevType">
+  <xs:all>
+    <xs:element name="HIDDEN_PDEV" type="VBDFType" minOccurs="0" maxOccurs="unbounded">
+      <xs:annotation acrn:views="">
+        <xs:documentation>Specify the hidden device vBDF</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+  </xs:all>
+</xs:complexType>
+
 <xs:complexType name="PCIDevsConfiguration">
   <xs:sequence>
     <xs:element name="pci_dev" type="xs:string" minOccurs="0" maxOccurs="unbounded">

--- a/misc/config_tools/schema/checks/vbdf_assignment.xsd
+++ b/misc/config_tools/schema/checks/vbdf_assignment.xsd
@@ -24,4 +24,11 @@
     </xs:annotation>
   </xs:assert>
 
+  <xs:assert test="every $vm in /acrn-config//vm[./load_order/text() = 'PRE_LAUNCHED_VM' and ./mmio_resources/p2sb/text() = 'y'] satisfies
+                   count(/acrn-config//HIDDEN_PDEV[./text() = '00:1f.1']) = 0">
+    <xs:annotation acrn:severity="error" acrn:report-on="/acrn-config//p2sb[./text() = 'y']">
+      <xs:documentation>Can't passthrough P2SB to VM {/acrn-config//vm[./load_order/text() = 'PRE_LAUNCHED_VM' and .//p2sb/text() = 'y']/name/text()} because '00:1f.1' is set as a hidden device".</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
 </xs:schema>

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -304,6 +304,13 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
 	<xs:documentation>Miscellaneous options for workarounds.</xs:documentation>
       </xs:annotation>
     </xs:element>
+
+    <xs:element name="HIDDEN_PDEV_REGION" type="HiddenDevType" minOccurs="0">
+      <xs:annotation acrn:views="">
+        <xs:documentation>Specify the hidden devices.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+
     <xs:element name="CACHE_REGION" type="CacheRegionType" minOccurs="0">
       <xs:annotation acrn:views="advanced">
         <xs:documentation>Specify the cache setting.</xs:documentation>

--- a/misc/config_tools/xforms/lib.xsl
+++ b/misc/config_tools/xforms/lib.xsl
@@ -375,6 +375,9 @@
       <xsl:when test="//@board = 'apl-up2'">
         <func:result select="1" />
       </xsl:when>
+      <xsl:when test="count(//HIDDEN_PDEV/text()) > 0">
+        <func:result select="count(//HIDDEN_PDEV/text())" />
+      </xsl:when>
       <xsl:otherwise>
         <func:result select="0" />
       </xsl:otherwise>


### PR DESCRIPTION
Currently we have to use additional patch to change config tool python
code to enable P2SB hidden device.

This patch have add an element, user could config the P2SB device in
the scenario XML.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@linux.intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>