### PR TITLE
doc: remove use of :ref: in tooltips

### DIFF
--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -56,7 +56,8 @@
     </xs:element>
     <xs:element name="real_time_vcpu" type="Boolean" default="n">
       <xs:annotation acrn:title="Real-time vCPU">
-          <xs:documentation>Check "Real-time vCPU" for each vCPU used for real-time workloads. Then configure cache usage in the Hypervisor/Advanced/Cache Allocation Technology (CAT) configuration option. There you'll see Real-time vCPUs separated from vCPUs you allocate to other tasks.  See :ref:`rdt_configuration` for more details.</xs:documentation>
+          <xs:documentation>Check "Real-time vCPU" for each vCPU used for real-time workloads. Then configure cache usage in the Hypervisor/Advanced/Cache Allocation Technology (CAT) configuration option. There you'll see Real-time vCPUs separated from vCPUs you allocate to other tasks.</xs:documentation>
+          <xs:documentation>See :ref:`rdt_configuration` for more details.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:all>
@@ -267,16 +268,6 @@ The size is a subset of the VM's total memory size specified on the Basic tab.</
     <xs:element name="p2sb" type="Boolean" default="n" minOccurs="0">
       <xs:annotation acrn:title="P2SB bridge passthrough" acrn:applicable-vms="pre-launched">
         <xs:documentation>Enable passthrough of the Primary-to-Sideband (P2SB) bridge register access BAR to this VM.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
-  </xs:all>
-</xs:complexType>
-
-<xs:complexType name="HiddenDevType">
-  <xs:all>
-    <xs:element name="HIDDEN_PDEV" type="VBDFType" minOccurs="0" maxOccurs="unbounded">
-      <xs:annotation acrn:views="">
-        <xs:documentation>Specify the hidden device vBDF</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:all>

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -282,8 +282,8 @@ These settings can only be changed at build time.</xs:documentation>
     </xs:element>
     <xs:element name="vuart_connections" type="VuartConnectionsType">
       <xs:annotation acrn:title="Inter-VM virtual UART connection" acrn:views="basic">
-        <xs:documentation>Specify the vUART connection settings.
-Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
+          <xs:documentation>Specify the vUART connection settings.</xs:documentation>
+          <xs:documentation>Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="DEBUG_OPTIONS" type="DebugOptionsType">
@@ -304,13 +304,6 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
 	<xs:documentation>Miscellaneous options for workarounds.</xs:documentation>
       </xs:annotation>
     </xs:element>
-
-    <xs:element name="HIDDEN_PDEV_REGION" type="HiddenDevType" minOccurs="0">
-      <xs:annotation acrn:views="">
-        <xs:documentation>Specify the hidden devices.</xs:documentation>
-      </xs:annotation>
-    </xs:element>
-
     <xs:element name="CACHE_REGION" type="CacheRegionType" minOccurs="0">
       <xs:annotation acrn:views="advanced">
         <xs:documentation>Specify the cache setting.</xs:documentation>
@@ -344,7 +337,8 @@ Refer to :ref:`vuart_config` for detailed vUART settings.</xs:documentation>
     </xs:element>
     <xs:element name="os_type" type="OSType" default="Non-Windows OS">
       <xs:annotation acrn:title="OS type" acrn:applicable-vms="post-launched" acrn:views="basic">
-	<xs:documentation>Select the OS type for this VM. This is required to run Windows in a User VM. See :ref:`acrn-dm_parameters` for how to include this in the Device Model arguments.</xs:documentation>
+          <xs:documentation>Select the OS type for this VM. This is required to run Windows in a User VM.</xs:documentation>
+          <xs:documentation>See :ref:`acrn-dm_parameters` for how to include this in the Device Model arguments.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="vuart0" type="Boolean" default="n">
@@ -475,8 +469,8 @@ This feature enables you to view the VM's GPU output in the Service VM.</xs:docu
             <xs:annotation acrn:title="Virtio console device" acrn:views="basic">
               <xs:documentation>Virtio console device for data input and output.
 The virtio console BE driver copies data from the frontend's transmitting virtqueue when it receives a kick on virtqueue (implemented as a vmexit).
-The BE driver then writes the data to backend, and can be implemented as a PTY, TTY, STDIO, or regular file.
-For details, see :ref:`virtio-console`.</xs:documentation>
+The BE driver then writes the data to backend, and can be implemented as a PTY, TTY, STDIO, or regular file.</xs:documentation>
+              <xs:documentation>For details, see :ref:`virtio-console`.</xs:documentation>
             </xs:annotation>
           </xs:element>
           <xs:element name="network" type="VirtioNetworkConfiguration" minOccurs="0" maxOccurs="unbounded">

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -128,8 +128,8 @@ higher value (lower severity) are discarded.</xs:documentation>
   virtual time-based scheduling algorithm. It dispatches the runnable thread with the
   earliest effective virtual time.
 - ``Priority Based Scheduling``: The priority based scheduler supports vCPU scheduling based on pre-configured priorities.
-
-Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:documentation>
+    </xs:documentation>
+    <xs:documentation>Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="SCHED_NOOP">


### PR DESCRIPTION
The configurator build requires the released documentation to be
published before it normally would so it can resolve :ref: links in
tooltips.  Move these :ref: links into a second xs:documentation tag so
the reference will appear in the option documentation but not in the
tooltip (and break this premature dependency in the configurator build).

Tracked-On: #8098

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>