### PR TITLE
config_tools: fix a typo in cache info extractor

### DIFF
--- a/misc/config_tools/board_inspector/extractors/20-cache.py
+++ b/misc/config_tools/board_inspector/extractors/20-cache.py
@@ -137,7 +137,7 @@ def extract_topology(args, root_node, caches_node):
                 elif cache_level == 3:
                     if args.add_llc_cat:
                         # Inject L3 CAT capability specified by the user
-                        cap = add_child(llc_node, "capability", None, id="CAT")
+                        cap = add_child(n, "capability", None, id="CAT")
                         add_child(cap, "capacity_mask_length", str(args.add_llc_cat.capacity_mask_length))
                         add_child(cap, "clos_number", str(args.add_llc_cat.clos_number))
                         if args.add_llc_cat.has_CDP:


### PR DESCRIPTION
Commit 2a8b80d0c ("config_tools: board_inspector: guess L3 CAT parameters
if not reported via CPUID") refactors the implementation of `--add-llc-cat`
option of the board inspector but does not update the referenced XML nodes
properly. This patch fixes a using-undefined-variable issue introduced by
that commit.

Tracked-On: #7948
Signed-off-by: Junjie Mao <junjie.mao@intel.com>