### PR TITLE
config_tools: handle multiple xs:documentation properly

### DIFF
--- a/misc/config_tools/scenario_config/jsonschema/converter.py
+++ b/misc/config_tools/scenario_config/jsonschema/converter.py
@@ -346,7 +346,9 @@ class XS2JS:
                 js_ele['title'] = annotation.get('@acrn:title', name)
 
                 # documentation
-                documentation: str = annotation.get('xs:documentation', None)
+                documentation = annotation.get('xs:documentation', None)
+                if isinstance(documentation, list):
+                    documentation = documentation[0]
                 if documentation is None or documentation.strip() == '':
                     documentation = ''
                 if documentation:


### PR DESCRIPTION
With multiple xs:documentation nodes under the same xs:annotation, xs2js
will convert the XML into a dict where the key `xs:documentation` maps to a
list rather than a string. This patch enhances the converter.py to handle
such case properly.

Tracked-On: #8098
Signed-off-by: Junjie Mao <junjie.mao@intel.com>