### PR TITLE
misc: add assertion to check the CDP Enable

### DIFF
--- a/misc/config_tools/schema/checks/rdt_support.xsd
+++ b/misc/config_tools/schema/checks/rdt_support.xsd
@@ -11,6 +11,14 @@
     </xs:annotation>
   </xs:assert>
 
+  <xs:assert test="if (//RDT_ENABLED = 'y' and //CDP_ENABLED = 'y')
+                   then (count(//capability[./@id = 'CDP']) = count(//cache[./@level = '2' or ./@level = '3']))
+                   else true()">
+    <xs:annotation acrn:severity="error" acrn:report-on="//CDP_ENABLED">
+      <xs:documentation>Code and Data Prioritization can only be opened when all L2 and L3 cache region has 'CDP' capability.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
   <xs:assert test="if (count(//virtual_cat_support[text() = 'y']) > 0)
                    then (//RDT_ENABLED = 'y' and //VCAT_ENABLED = 'y')
                    else true()">


### PR DESCRIPTION
The current code have not check whether all cache region has "Code and
Data Prioritization", it's an issue for some platform which have only
L2 or L3 "Code and Data Prioritization" capability.

This patch add assertion to check whether all L2, L3 cache could be set
CDP_ENABLE.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@intel.com>