### PR TITLE
[config_tool] Duplicate error for vUART connection

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -415,6 +415,7 @@ export default {
           if (errorType === 'semantic') {
             formErrors[vmid].push(error)
           }
+          formErrors[vmid] = _.uniq(formErrors[vmid])
         })
       }
 


### PR DESCRIPTION
improve the translateError function by adding a condition: if there are errors describing the same error and same paths, remove the repeat one.

Tracked-On: #8117
Signed-off-by: Chuang-Ke <chuangx.ke@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>