### PR TITLE
[doc]remove some decription about hvlog

### DIFF
--- a/doc/user-guides/kernel-parameters.rst
+++ b/doc/user-guides/kernel-parameters.rst
@@ -206,12 +206,6 @@ relevant for configuring or debugging ACRN-based systems.
        A ``memmap`` parameter is also required to reserve the specified memory
        from the guest VM.
 
-       If hypervisor relocation is disabled, verify that
-       :option:`hv.MEMORY.HV_RAM_START` and the hypervisor RAM size computed by
-       the linker
-       do not overlap with the hypervisor's reserved buffer space allocated
-       in the Service VM. Service VM GPA and HPA are a 1:1 mapping.
-
        If hypervisor relocation is enabled, reserve the memory below 256MB,
        since the hypervisor could be relocated anywhere between 256MB and 4GB.
 


### PR DESCRIPTION
to avoid misleading for users, delete the description about hypervisor relocation disabling, since it is not officially supported by ACRN configurator now.

Tracked-On: #8133
Signed-off-by: hangliu1 <hang1.liu@linux.intel.com>