### PR TITLE
config-tools: fix typos of UI and README

### DIFF
--- a/misc/config_tools/configurator/README.md
+++ b/misc/config_tools/configurator/README.md
@@ -105,5 +105,5 @@ acrn-configurator
 #### Windows
 
 You can find installer under the
-`misc\config_tools\configurator\src-tauri\target\release\bundle\msi`
+`misc\config_tools\configurator\packages\configurator\src-tauri\target\release\bundle\msi`
 directory, the installer in the folder.

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/Scenario/NewScenario.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/Scenario/NewScenario.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-modal id="newScenarioModal" size="xl" title="Create a new Scenario" fade no-close-on-backdrop
+  <b-modal id="newScenarioModal" size="xl" title="Create a New Scenario" fade no-close-on-backdrop
            v-model="showModal"
            @cancel="cancel"
            @abort="cancel"


### PR DESCRIPTION
1. In the title "Create a new Scenario", capitalize the "N" in "new".
2. Fix the file path to the installer.

Tracked-On: #8137
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>