### PR TITLE
doc: update vUART tutorials

### DIFF
--- a/doc/tutorials/vuart_configuration.rst
+++ b/doc/tutorials/vuart_configuration.rst
@@ -86,9 +86,9 @@ connection. Or click **-** to delete a connection.
 
    .. note::
 
-      The release v3.0 ACRN Configurator assigns COM2 (I/O address ``0x2F8``) to
+      The release v3.0+ ACRN Configurator assigns COM2 (I/O address ``0x2F8``) to
       the S5 feature. A conflict will occur if you assign ``0x2F8`` to another
-      connection. In our example, we'll use COM3 (I/O address ``0x3F8``).
+      connection. In our example, we'll use COM3 (I/O address ``0x3E8``).
 
 .. image:: images/configurator-vuartconn01.png
    :align: center


### PR DESCRIPTION
The ACRN Configurator release 3.1 following the release 3.0 logic, so the COM2 still used for S5.

This patch modify the "The release v3.0 ACRN Configurator assigns… …" to "The release v3.0+ ACRN Configurator assigns… …" and refine a typo issue.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@intel.com>