### PR TITLE
misc: add assertion to check the BDF value

### DIFF
--- a/misc/config_tools/schema/checks/vbdf_assignment.xsd
+++ b/misc/config_tools/schema/checks/vbdf_assignment.xsd
@@ -31,4 +31,22 @@
     </xs:annotation>
   </xs:assert>
 
+  <xs:assert test="every $ivshmem in /acrn-config//IVSHMEM_VM satisfies
+                   if (/acrn-config//vm[./name/text() = $ivshmem/VM_NAME/text()]/load_order/text() = 'POST_LAUNCHED_VM')
+                   then (substring-before(substring-after($ivshmem/VBDF/text(), ':'), '.') &gt; '02') and (substring-before(substring-after($ivshmem/VBDF/text(), ':'), '.') &lt; '1f')
+	           else true()">
+    <xs:annotation acrn:severity="error" acrn:report-on="$ivshmem">
+      <xs:documentation>For post launched VM, the "device" value of a virtual BDF, which is used by {$ivshmem/VM_NAME/text()}, shall not be '00', '01', '02' or '1f', i.e., the allowed values are between 03 and 1e, inclusive.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $endpoint in /acrn-config//endpoint satisfies
+                   if (/acrn-config//vm[./name/text() = $endpoint/vm_name/text()]/load_order/text() = 'POST_LAUNCHED_VM')
+                   then (substring-before(substring-after($endpoint/vbdf/text(), ':'), '.') &gt; '02') and (substring-before(substring-after($endpoint/VBDF/text(), ':'), '.') &lt; '1f')
+	           else true()">
+    <xs:annotation acrn:severity="error" acrn:report-on="$endpoint">
+      <xs:documentation>For post launched VM, the "device" value of a virtual BDF, which is used by {$endpoint/vm_name/text()}, shall not be '00', '01', '02' or '1f', i.e., the allowed values are between 03 and 1e, inclusive.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
 </xs:schema>


### PR DESCRIPTION
The BDF of user setting should skip the slot '00', '01', '02', '1f', all these slots should select one of the 03~1e.

This patch add an assertion to check the above policy.

Tracked-On: #6690
Signed-off-by: Chenli Wei <chenli.wei@intel.com>