### PR TITLE
config-tools: diable real_time_vcpu for non real-time VM

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -86,6 +86,7 @@
               @deleteVM="deleteVM"
               @scenarioConfigFormDataUpdate="scenarioConfigFormDataUpdate"
               @vmNameChange="vmNameChange"
+              @updateCpuAffinity="updateCpuAffinity"
           />
         </div>
       </div>
@@ -343,6 +344,15 @@ export default {
           }
         }
       }
+    },
+    updateCpuAffinity(vmid) {
+      this.scenario.vm.map((vmConfig, vmIndex) => {
+          if (vmConfig['@id'] === vmid) {
+            for (let i = 0; i < vmConfig['cpu_affinity']['pcpu'].length; i++) {
+              this.scenario.vm[vmIndex]['cpu_affinity']['pcpu'][i]['real_time_vcpu'] = 'n'
+            }
+          }
+        })
     },
     assignVMID() {
       let vm_priority = {

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
@@ -60,7 +60,7 @@ i18n.useLocal(localizeEn);
 export default {
   name: "ConfigForm",
   components: {Icon, Minus, VueForm, CAT, VUART, cpu_affinity, IVSHMEM_REGION},
-  emits: ['scenarioConfigFormDataUpdate', 'deleteVM', 'vmNameChange'],
+  emits: ['scenarioConfigFormDataUpdate', 'deleteVM', 'vmNameChange', 'updateCpuAffinity'],
   props: {
     currentActiveVMID: {type: Number},
     currentFormSchema: {type: Object},
@@ -125,6 +125,7 @@ export default {
     dataChange({newValue, oldValue}) {
       let newID = newValue.hasOwnProperty('@id') ? newValue['@id'] : -1;
       let oldID = oldValue.hasOwnProperty('@id') ? oldValue['@id'] : -1;
+      let vmType = newValue.hasOwnProperty('vm_type') ? newValue['vm_type'] : "";
 
       if (newID === oldID) {
         // skip hv settings
@@ -132,6 +133,9 @@ export default {
           if (this.vmNameCache !== newValue.name) {
             this.$emit('vmNameChange', newValue.name, this.vmNameCache)
             this.vmNameCache = newValue.name;
+          }
+          if (vmType != 'RTVM') {
+            this.$emit('updateCpuAffinity', newID)
           }
         }
         this.$emit('scenarioConfigFormDataUpdate', newID, newValue)


### PR DESCRIPTION
Reset the real_time_vcpu to 'n' if the VM is not a real-time VM.

Tracked-On: #8145
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>