### PR TITLE
add ACRN CPU performance management

### DIFF
--- a/debian/grub/25_linux_acrn
+++ b/debian/grub/25_linux_acrn
@@ -63,6 +63,8 @@ ACRN_BOOTARGS=$(for arg in ${ACRN_BOOTARGS}; do if [ "${arg##root=}" = "${arg}" 
 # special handling for memmap: make sure $ is escaped to \$. This is a GRUB requirement
 ACRN_BOOTARGS="$(echo "${ACRN_BOOTARGS}" | sed 's/\(.*memmap=[^\$]*\)\$\(.*\)/\1\\\$\2/')"
 
+GRUB_CMDLINE_ACRN="cpu_perf_policy=$(xmllint --xpath '//CPU_PERFORMANCE_POLICY/text()' ${ACRN_SCENARIO_FILE} 2>/dev/null || true) "$GRUB_CMDLINE_ACRN
+
 if [ "x${GRUB_DISTRIBUTOR}" = "x" ] ; then
   OS=GNU/Linux
 else

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -24,6 +24,7 @@
 #include <version.h>
 #include <asm/vmx.h>
 #include <asm/msr.h>
+#include <asm/host_pm.h>
 #include <ptdev.h>
 #include <logmsg.h>
 #include <asm/rdt.h>
@@ -155,6 +156,8 @@ void init_pcpu_pre(bool is_bsp)
 		init_pcpu_model_name();
 
 		load_pcpu_state_data();
+
+		init_frequency_policy();
 
 		init_e820();
 
@@ -314,6 +317,8 @@ void init_pcpu_post(uint16_t pcpu_id)
 	if (!init_software_sram(pcpu_id == BSP_CPU_ID)) {
 		panic("failed to initialize software SRAM!");
 	}
+
+	apply_frequency_policy();
 
 	init_sched(pcpu_id);
 

--- a/hypervisor/include/arch/x86/asm/board.h
+++ b/hypervisor/include/arch/x86/asm/board.h
@@ -34,6 +34,7 @@ extern struct rdt_type res_cap_info[RDT_NUM_RESOURCES];
 #endif
 
 extern const struct cpu_state_table board_cpu_state_tbl;
+extern struct acrn_cpufreq_limits cpufreq_limits[MAX_PCPU_NUM];
 extern const union pci_bdf plat_hidden_pdevs[MAX_HIDDEN_PDEVS_NUM];
 extern const struct vmsix_on_msi_info vmsix_on_msi_devs[MAX_VMSIX_ON_MSI_PDEVS_NUM];
 

--- a/hypervisor/include/arch/x86/asm/host_pm.h
+++ b/hypervisor/include/arch/x86/asm/host_pm.h
@@ -39,5 +39,7 @@ extern void restore_s3_context(void);
 struct cpu_state_info *get_cpu_pm_state_info(void);
 struct acpi_reset_reg *get_host_reset_reg_data(void);
 void reset_host(void);
+void init_frequency_policy(void);
+void apply_frequency_policy(void);
 
 #endif	/* HOST_PM_H */

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -522,6 +522,21 @@ struct acrn_pstate_data {
 	uint64_t status;		/* success indicator */
 };
 
+enum acrn_cpufreq_policy_type {
+	CPUFREQ_POLICY_PERFORMANCE,
+	CPUFREQ_POLICY_NOMINAL,
+};
+
+struct acrn_cpufreq_limits {
+	/* Performance levels for HWP */
+	uint8_t guaranteed_hwp_lvl;
+	uint8_t highest_hwp_lvl;
+	uint8_t lowest_hwp_lvl;
+	/* Index for the p-state table _PSS */
+	uint8_t nominal_pstate;
+	uint8_t performance_pstate;
+};
+
 struct acpi_sx_pkg {
 	uint8_t		val_pm1a;
 	uint8_t		val_pm1b;

--- a/misc/config_tools/board_config/board_c.py
+++ b/misc/config_tools/board_config/board_c.py
@@ -455,6 +455,31 @@ def gen_known_caps_pci_devs(config):
                 if i == (bdf_list_len - 1):
                     print("};", file=config)
 
+def gen_cpufreq_limits(config):
+    allocation_dir = os.path.split(common.SCENARIO_INFO_FILE)[0] + "/configs/allocation.xml"
+    allocation_etree = lxml.etree.parse(allocation_dir)
+    cpu_list = board_cfg_lib.get_processor_info()
+    max_cpu_num = len(cpu_list)
+
+    print("\nstruct acrn_cpufreq_limits cpufreq_limits[MAX_PCPU_NUM] = {", file=config)
+    for cpu_id in range(max_cpu_num):
+        limit_node = common.get_node(f"//cpufreq/CPU[@id='{cpu_id}']/limits", allocation_etree)
+        if limit_node != None:
+            limit_guaranteed_lvl = common.get_node("./limit_guaranteed_lvl/text()", limit_node)
+            limit_highest_lvl = common.get_node("./limit_highest_lvl/text()", limit_node)
+            limit_lowest_lvl = common.get_node("./limit_lowest_lvl/text()", limit_node)
+            limit_nominal_pstate = common.get_node("./limit_nominal_pstate/text()", limit_node)
+            limit_highest_pstate = common.get_node("./limit_highest_pstate/text()", limit_node)
+            limit_lowest_pstate = common.get_node("./limit_lowest_pstate/text()", limit_node)
+
+            print("\t{", file=config)
+            print(f"\t\t.guaranteed_hwp_lvl = {limit_guaranteed_lvl},", file=config)
+            print(f"\t\t.highest_hwp_lvl = {limit_highest_lvl},", file=config)
+            print(f"\t\t.lowest_hwp_lvl = {limit_lowest_lvl},", file=config)
+            print(f"\t\t.nominal_pstate = {limit_nominal_pstate},", file=config)
+            print(f"\t\t.performance_pstate = {limit_highest_pstate},", file=config)
+            print("\t},", file=config)
+    print("};", file=config)
 
 def generate_file(config):
     """
@@ -484,5 +509,7 @@ def generate_file(config):
 
     # gen known caps of pci dev info for platform
     gen_known_caps_pci_devs(config)
+
+    gen_cpufreq_limits(config)
 
     return err_dic

--- a/misc/config_tools/board_inspector/cpuparser/cpuids.py
+++ b/misc/config_tools/board_inspector/cpuparser/cpuids.py
@@ -286,11 +286,87 @@ class LEAF_6(CPUID):
     pln_supported = cpuidfield(EAX, 4, 4, doc = "Power limit notification controls are supported if set")
     ecmd_supported = cpuidfield(EAX, 5, 5, doc = "Clock modulation duty cycle extension is supported if set")
     package_thermal_management_supported = cpuidfield(EAX, 6, 6, doc = "Package thermal management is supported if set")
+    hwp_supported = cpuidfield(EAX, 7, 7, doc = "HWP base registers (IA32_PM_ENABLE[bit 0], IA32_HWP_CAPABILITIES, IA32_HWP_REQUEST, IA32_HWP_STATUS) are supported if set")
+    hwp_notification = cpuidfield(EAX, 8, 8, doc = "HWP_Notification. IA32_HWP_INTERRUPT MSR is supported if set.")
+    hwp_activity_window = cpuidfield(EAX, 9, 9, doc = "HWP_Activity_Window. IA32_HWP_REQUEST[bits 41:32] is supported if set.")
+    hwp_energy_performance_preference = cpuidfield(EAX, 10, 10, doc = "HWP_Energy_Performance_Preference. IA32_HWP_REQUEST[bits 31:24] is supported if set.")
+    hwp_package_level_request = cpuidfield(EAX, 11, 11, doc = "HWP_Package_Level_Request. IA32_HWP_REQUEST_PKG MSR is supported if set.")
+    hdc = cpuidfield(EAX, 13, 13, doc = "HDC. HDC base registers IA32_PKG_HDC_CTL, IA32_PM_CTL1, IA32_THREAD_STALL MSRs are supported if set.")
+    turbo_boost_30 = cpuidfield(EAX, 14, 14, doc = "Intel® Turbo Boost Max Technology 3.0 available.")
+    hwp_capabilities = cpuidfield(EAX, 15, 15, doc = "HWP Capabilities. Highest Performance change is supported if set.")
+    hwp_peci_override = cpuidfield(EAX, 16, 16, doc = "HWP PECI override is supported if set.")
+    flexible_hwp = cpuidfield(EAX, 17, 17, doc = "Flexible HWP is supported if set.")
+    fast_hwp_request = cpuidfield(EAX, 18, 18, doc = "Fast access mode for the IA32_HWP_REQUEST MSR is supported if set.")
+    hw_feedback = cpuidfield(EAX, 19, 19, doc = "HW_FEEDBACK. IA32_HW_FEEDBACK_PTR MSR, IA32_HW_FEEDBACK_CONFIG MSR, IA32_PACKAGE_THERM_STATUS MSR bit 26, and IA32_PACKAGE_THERM_INTERRUPT MSR bit 25 are supported if set.")
+    ignoring_idle_hwp = cpuidfield(EAX, 20, 20, doc = "Ignoring Idle Logical Processor HWP request is supported if set.")
+    thread_director = cpuidfield(EAX, 23, 23, doc = "Intel® Thread Director supported if set. IA32_HW_FEEDBACK_CHAR and IA32_HW_FEEDBACK_THREAD_CONFIG MSRs are supported if set.")
 
     num_interrupt_thresholds = cpuidfield(EBX, 3, 0, doc="Number of interrupt thresholds in digital thermal sensor")
 
     hardware_coordination_feedback_capability = cpuidfield(ECX, 0, 0, doc="Hardware coordination feedback capability")
     performance_energy_bias = cpuidfield(ECX, 3, 3, doc="Performance-energy bias preference support")
+    num_thread_director_classes = cpuidfield(ECX, 15, 8, "Number of Intel® Thread Director classes supported by the processor. Information for that many classes is written into the Intel Thread Director Table by the hardware.")
+
+    hardware_feedback_interface_bitmap = cpuidfield(EDX, 7, 0, doc = "Bitmap of supported hardware feedback interface capabilities.")
+    hardware_feedback_interface_structure_size = cpuidfield(EDX, 11, 8, doc = "Enumerates the size of the hardware feedback interface structure in number of 4 KB pages.")
+    hardware_feedback_index = cpuidfield(EDX, 31, 16, doc = "Index (starting at 0) of this logical processor's row in the hardware feedback interface structure.")
+
+    capability_bits = [
+        "digital_temperature_sensor_supported",
+        "turbo_boost_available",
+        "arat_supported",
+        "pln_supported",
+        "ecmd_supported",
+        "package_thermal_management_supported",
+        "hwp_supported",
+        "hwp_notification",
+        "hwp_activity_window",
+        "hwp_energy_performance_preference",
+        "hwp_package_level_request",
+        "hdc",
+        "turbo_boost_30",
+        "hwp_capabilities",
+        "hwp_peci_override",
+        "flexible_hwp",
+        "fast_hwp_request",
+        "hw_feedback",
+        "ignoring_idle_hwp",
+        "thread_director",
+        "num_interrupt_thresholds",
+        "hardware_coordination_feedback_capability",
+        "performance_energy_bias",
+        "num_thread_director_classes",
+        "hardware_feedback_interface_bitmap",
+        "hardware_feedback_interface_structure_size",
+        "hardware_feedback_index",
+        "digital_temperature_sensor_supported",
+        "turbo_boost_available",
+        "arat_supported",
+        "pln_supported",
+        "ecmd_supported",
+        "package_thermal_management_supported",
+        "hwp_supported",
+        "hwp_notification",
+        "hwp_activity_window",
+        "hwp_energy_performance_preference",
+        "hwp_package_level_request",
+        "hdc",
+        "turbo_boost_30",
+        "hwp_capabilities",
+        "hwp_peci_override",
+        "flexible_hwp",
+        "fast_hwp_request",
+        "hw_feedback",
+        "ignoring_idle_hwp",
+        "thread_director",
+        "num_interrupt_thresholds",
+        "hardware_coordination_feedback_capability",
+        "performance_energy_bias",
+        "num_thread_director_classes",
+        "hardware_feedback_interface_bitmap",
+        "hardware_feedback_interface_structure_size",
+        "hardware_feedback_index",
+    ]
 
 class LEAF_7(CPUID):
     """Structured Extended Feature Flags Enumeration Leaf

--- a/misc/config_tools/board_inspector/cpuparser/msr.py
+++ b/misc/config_tools/board_inspector/cpuparser/msr.py
@@ -270,3 +270,35 @@ def MSR_IA32_L3_MASK_n(n):
         bit_mask = msrfield(32, 0, doc="Capacity bit mask")
 
     return IA32_L3_MASK_n
+
+class MSR_IA32_PM_ENABLE(MSR):
+    addr = 0x00000770
+    hwp_enable = msrfield(0, 0, doc=None)
+
+class MSR_IA32_HWP_CAPABILITIES(MSR):
+    addr = 0x00000771
+    highest_performance_lvl = msrfield(7, 0, doc=None)
+    guaranteed_performance_lvl = msrfield(15, 8, doc=None)
+    lowest_performance_lvl = msrfield(31, 24, doc=None)
+
+    attribute_bits = [
+        "highest_performance_lvl",
+        "guaranteed_performance_lvl",
+        "lowest_performance_lvl",
+    ]
+
+class MSR_TURBO_RATIO_LIMIT(MSR):
+    addr = 0x000001ad
+    max_ratio_1core = msrfield(7, 0, doc=None)
+
+    attribute_bits = [
+        "max_ratio_1core",
+    ]
+
+class MSR_TURBO_ACTIVATION_RATIO(MSR):
+    addr = 0x0000064c
+    max_none_turbo_ratio = msrfield(7, 0, doc=None)
+
+    attribute_bits = [
+        "max_none_turbo_ratio",
+    ]

--- a/misc/config_tools/board_inspector/extractors/10-processors.py
+++ b/misc/config_tools/board_inspector/extractors/10-processors.py
@@ -4,6 +4,7 @@
 #
 
 import logging
+import subprocess
 import lxml.etree
 import re
 
@@ -47,7 +48,7 @@ def extract_model(processors_node, cpu_id, family_id, model_id, core_type, nativ
             brandstring += leaf_data.brandstring
         n.set("description", re.sub('[^!-~]+', ' ', brandstring.decode()).strip())
 
-        leaves = [(1, 0), (7, 0), (0x80000001, 0), (0x80000007, 0)]
+        leaves = [(1, 0), (6, 0), (7, 0), (0x80000001, 0), (0x80000007, 0)]
         for leaf in leaves:
             leaf_data = parse_cpuid(leaf[0], leaf[1], cpu_id)
             for cap in leaf_data.capability_bits:
@@ -69,6 +70,12 @@ def extract_model(processors_node, cpu_id, family_id, model_id, core_type, nativ
             leaf_data = parse_cpuid(leaf[0], leaf[1], cpu_id)
             for cap in leaf_data.attribute_bits:
                 add_child(n, "attribute", str(getattr(leaf_data, cap)), id=cap)
+
+        msr_regs = [MSR_TURBO_RATIO_LIMIT, MSR_TURBO_ACTIVATION_RATIO]
+        for msr_reg in msr_regs:
+            msr_data = msr_reg.rdmsr(cpu_id)
+            for attr in msr_data.attribute_bits:
+                add_child(n, "attribute", str(getattr(msr_data, attr)), id=attr)
 
 def extract_topology(processors_node):
     cpu_ids = get_online_cpu_ids()
@@ -130,6 +137,41 @@ def extract_topology(processors_node):
             last_shift = leaf_topo.num_bit_shift
             subleaf += 1
 
+def extract_hwp_info(processors_node):
+    if processors_node.xpath("//capability[@id = 'hwp_supported']") is None:
+        return
+
+    # SDM Vol3 14.4.2: Additional MSRs associated with HWP may only be accessed after HWP is enabled
+    msr_hwp_en = MSR_IA32_PM_ENABLE()
+    msr_hwp_en.hwp_enable = 1
+    msr_hwp_en.wrmsr(0)
+
+    threads = processors_node.xpath("//thread")
+    for thread in threads:
+        cpu_id = get_node(thread, "cpu_id/text()")
+        msr_regs = [MSR_IA32_HWP_CAPABILITIES,]
+        for msr_reg in msr_regs:
+            msr_data = msr_reg.rdmsr(cpu_id)
+            for attr in msr_data.attribute_bits:
+                add_child(thread, attr, str(getattr(msr_data, attr)))
+
+def extract_psd_info(processors_node):
+    sysnode = '/sys/devices/system/cpu/'
+    threads = processors_node.xpath("//thread")
+    for thread in threads:
+        cpu_id = get_node(thread, "cpu_id/text()")
+        try:
+            with open(sysnode + "cpu{cpu_id}/cpufreq/freqdomain_cpus", 'r') as f_node:
+                freqdomain_cpus = f_node.read()
+        except IOError:
+            logging.info("No _PSD info for cpu {cpu_id}")
+            freqdomain_cpus = cpu_id
+
+        freqdomain_cpus.replace('\n','')
+        add_child(thread, "freqdomain_cpus", freqdomain_cpus)
+
 def extract(args, board_etree):
     processors_node = get_node(board_etree, "//processors")
     extract_topology(processors_node)
+    extract_hwp_info(processors_node)
+    extract_psd_info(processors_node)

--- a/misc/config_tools/library/board_cfg_lib.py
+++ b/misc/config_tools/library/board_cfg_lib.py
@@ -349,6 +349,44 @@ def get_pci_info(board_info):
 
     return (pci_desc, pci_bdf_vpid)
 
+def get_p_state_count():
+    """
+    Get cpu p-state count
+    :return: p-state count
+    """
+    px_info = get_info(common.BOARD_INFO_FILE, "<PX_INFO>", "</PX_INFO>")
+    if px_info != None:
+        for line in px_info:
+            if re.search("{.*}", line) == None:
+                px_info.remove(line)
+
+    return len(px_info)
+
+def get_p_state_index_from_ratio(ratio):
+    """
+    Get the closest p-state index that is lesser than or equel to given ratio
+    :return: p-state index; If no px_info found in board file, return 0;
+    """
+    closest_index = 0
+    px_info = get_info(common.BOARD_INFO_FILE, "<PX_INFO>", "</PX_INFO>")
+    if px_info != None:
+        for line in px_info:
+            if re.search("{.*}", line) == None:
+                px_info.remove(line)
+
+        i = 0
+        closest_index = 1
+        for line in px_info:
+            l = re.search("0x(\w*)UL}", line)
+            if l != None:
+                state_ratio = int(l.group(1), 16) >> 8
+                if state_ratio <= ratio:
+                    closest_index = i
+                    break
+            i += 1
+
+    return closest_index
+
 HI_MMIO_OFFSET = 0
 
 class Bar_Mem:

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -129,6 +129,14 @@ If your VM is not a security VM, leave this option unchecked. </xs:documentation
         <xs:documentation>Configure Software SRAM. This feature reserves memory buffers as always-cached memory to improve an application's real-time performance.</xs:documentation>
       </xs:annotation>
     </xs:element>
+    <xs:element name="CPU_PERFORMANCE_POLICY" type="policyType" default="Performance">
+      <xs:annotation acrn:title="CPU performance policy type" acrn:views="advanced">
+        <xs:documentation>Select the default performance policy type for all CPUs. The hypervisor will set up CPU frequency based on the policy type.
+
+- ``Performance``: CPU runs at its maximum frequency. Enable hardware autonomous frequency selection if the system supports Hardware-Controlled Performance States (HWP).
+- ``Nominal``: CPU runs at its guaranteed frequency.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:all>
 </xs:complexType>
 

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -147,6 +147,24 @@ higher value (lower severity) are discarded.</xs:documentation>
   </xs:restriction>
 </xs:simpleType>
 
+<xs:simpleType name="policyType">
+  <xs:annotation>
+    <xs:documentation>A string specifying the CPU frequency policy type:
+
+- ``Performance``: CPU runs at its maximum frequency. Enable hardware autonomous frequency selection if the system supports Hardware-Controlled Performance States (HWP).
+- ``Nominal``: CPU runs at its guaranteed frequency.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="Performance">
+      <xs:annotation acrn:title="Performance" />
+    </xs:enumeration>
+    <xs:enumeration value="Nominal">
+      <xs:annotation acrn:title="Nominal" />
+    </xs:enumeration>
+  </xs:restriction>
+</xs:simpleType>
+
 <xs:simpleType name="PriorityType">
   <xs:annotation>
     <xs:documentation>Two priorities are supported for priority based scheduler:

--- a/misc/config_tools/static_allocators/cpu_freq.py
+++ b/misc/config_tools/static_allocators/cpu_freq.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 Intel Corporation.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import common, board_cfg_lib
+
+# CPU frequency dependency
+# Some CPU cores may share the same clock domain/group with others, which makes them always run at
+# the same frequency of the highest on in the group. Including those known conditions:
+#   1. CPU in the clock domain described in ACPI _PSD.
+#      Like _PSS, board_inspector extracted this data from Linux cpufreq driver
+#      (see Linux document 'sysfs-devices-system-cpu' about freqdomain_cpus)
+#   2. CPU hyper threads sharing the same physical core.
+#      The data is extracted form apic id.
+#   3. E-cores residents in the same topological group.
+#      The data is extracted form CPU model type and apic id.
+# CPU frequency dependency may have some impacts on our frequency limits.
+#
+# Returns a list that contains each CPU's "dependency data". The "dependency data" is also a list
+# containing CPU_IDs that share frequency with the current one.
+# e.g. CPU 8 is sharing with CPU 9,10,11, so dependency_data[8] = ['8', '9', '10', '11']
+def get_dependency(board_etree):
+    cpus = board_etree.xpath("//processors//thread")
+    dep_ret = []
+    for cpu in cpus:
+        cpu_id = common.get_node("./cpu_id/text()", cpu)
+        psd_cpus = [cpu_id]
+        psd_cpus_list = common.get_node("./freqdomain_cpus/text()", cpu)
+        if psd_cpus_list != None:
+            psd_cpus = psd_cpus_list.split(' ')
+        apic_id = int(common.get_node("./apic_id/text()", cpu)[2:], base=16)
+        is_hybrid = (len(board_etree.xpath("//processors//capability[@id='hybrid']")) != 0)
+        core_type = common.get_node("./core_type/text()", cpu)
+        for other_cpu in cpus:
+            other_cpu_id = common.get_node("./cpu_id/text()", other_cpu)
+            if cpu_id != other_cpu_id:
+                other_apic_id = int(common.get_node("./apic_id/text()", other_cpu)[2:], base=16)
+                other_core_type = common.get_node("./core_type/text()", other_cpu)
+                # threads at same core
+                if (apic_id & ~1) == (other_apic_id & ~1):
+                    psd_cpus.append(other_cpu_id)
+                # e-cores in the same group. Infered from Atom cores share the same L2 cache
+                share_cache = 0
+                if is_hybrid and core_type == 'Atom' and other_core_type == 'Atom':
+                    l2cache_nodes = board_etree.xpath("//caches/cache[@level='2']")
+                    for l2cache in l2cache_nodes:
+                        processors = l2cache.xpath("./processors/processor/text()")
+                        if '{:#x}'.format(apic_id) in processors and '{:#x}'.format(other_apic_id) in processors:
+                            share_cache = 1
+                if share_cache == 1:
+                    psd_cpus.append(other_cpu_id)
+
+        if psd_cpus != None:
+            psd_cpus = list(set(psd_cpus))
+            psd_cpus.sort()
+            dep_ret.insert(int(cpu_id), psd_cpus)
+        else:
+            dep_ret.insert(int(cpu_id), None)
+    return dep_ret
+
+# CPU frequency limits:
+#
+# Frequency limits is a per CPU data type. Hypervisor uses this data to quickly decide what performance
+# level/p-state range it should apply.
+#
+# Those limits are decided by hardware and scenario config.
+#
+# When the CPU is assigned to a RTVM, we want to set its frequency fixed.(to get more certainty
+# in latency). To do this, we just let highest_lvl = lowest_lvl.
+# Some CPU cores' frequency may be linked to each other in a frequency domain or group(eg. e-cores in a group).
+# In this condition, RTVM's CPU frequency might be influenced by other VMs. So we fix all of them to the value of
+# the RTVM's CPU frequence.
+#
+# Both HWP and ACPI p-state are supported in ACRN CPU performance management. So here we generate two sets of
+# data:
+#
+#   - 'limit_guaranteed_lvl', 'limit_highest_lvl' and 'limit_lowest_lvl' are for HWP. The values represent
+#     HWP performance level used in IA32_HWP_CAPABILITIES and IA32_HWP_REQUEST.
+#
+#   - 'limit_nominal_pstate', 'limit_highest_pstate' and 'limit_lowest_pstate' are for ACPI p-state.
+#     Those values represent the performance state's index P(x).
+#     ACPI p-state does not define a 'guaranteed p-state' or a 'base p-state'. Here the 'nominal p-state' refers
+#     to a state whose frequency is closest to the max none-turbo frequency.
+def alloc_limits(board_etree, scenario_etree, allocation_etree):
+    cpu_has_eist = (len(board_etree.xpath("//processors//capability[@id='est']")) != 0)
+    cpu_has_hwp = (len(board_etree.xpath("//processors//capability[@id='hwp_supported']")) != 0)
+    cpu_has_turbo = (len(board_etree.xpath("//processors//capability[@id='turbo_boost_available']")) != 0)
+    rtvm_cpus = scenario_etree.xpath(f"//vm[vm_type = 'RTVM']//cpu_affinity//pcpu_id/text()")
+    cpus = board_etree.xpath("//processors//thread")
+
+    for cpu in cpus:
+        cpu_id = common.get_node("./cpu_id/text()", cpu)
+        if cpu_has_hwp:
+            guaranteed_performance_lvl = common.get_node("./guaranteed_performance_lvl/text()", cpu)
+            highest_performance_lvl = common.get_node("./highest_performance_lvl/text()", cpu)
+            lowest_performance_lvl = common.get_node("./lowest_performance_lvl/text()", cpu)
+            if cpu_id in rtvm_cpus:
+                # for CPUs in RTVM, fix to base performance
+                limit_lowest_lvl = guaranteed_performance_lvl
+                limit_highest_lvl = guaranteed_performance_lvl
+                limit_guaranteed_lvl = guaranteed_performance_lvl
+            elif cpu_has_turbo:
+                limit_lowest_lvl = lowest_performance_lvl
+                limit_highest_lvl = highest_performance_lvl
+                limit_guaranteed_lvl = guaranteed_performance_lvl
+            else:
+                limit_lowest_lvl = lowest_performance_lvl
+                limit_highest_lvl = guaranteed_performance_lvl
+                limit_guaranteed_lvl = guaranteed_performance_lvl
+        else:
+                limit_lowest_lvl = 1
+                limit_highest_lvl = 0xff
+                limit_guaranteed_lvl = 0xff
+
+        cpu_node = common.append_node(f"//hv/cpufreq/CPU", None, allocation_etree, id = cpu_id)
+        limit_node = common.append_node("./limits", None, cpu_node)
+        common.append_node("./limit_guaranteed_lvl", limit_guaranteed_lvl, limit_node)
+        common.append_node("./limit_highest_lvl", limit_highest_lvl, limit_node)
+        common.append_node("./limit_lowest_lvl", limit_lowest_lvl, limit_node)
+
+        limit_highest_pstate = 0
+        limit_nominal_pstate = 0
+        limit_lowest_pstate = 0
+        if cpu_has_eist:
+            mntr = board_etree.xpath("//processors//attribute[@id='max_none_turbo_ratio']/text()")
+            none_turbo_p = 0
+            p_count = board_cfg_lib.get_p_state_count()
+            if len(mntr) != 0:
+                none_turbo_p = board_cfg_lib.get_p_state_index_from_ratio(int(mntr[0]))
+            if p_count != 0:
+                # P0 is the highest stat
+                if cpu_id in rtvm_cpus:
+                    # for CPUs in RTVM, fix to nominal performance(max none turbo frequency if turbo on)
+                    if cpu_has_turbo:
+                        limit_highest_pstate = none_turbo_p
+                        limit_nominal_pstate = none_turbo_p
+                        limit_lowest_pstate = none_turbo_p
+                    else:
+                        limit_highest_pstate = 0
+                        limit_nominal_pstate = 0
+                        limit_lowest_pstate = 0
+                else:
+                    if cpu_has_turbo:
+                        limit_highest_pstate = 0
+                        limit_nominal_pstate = none_turbo_p
+                        limit_lowest_pstate = p_count -1
+                    else:
+                        limit_highest_pstate = 0
+                        limit_nominal_pstate = 0
+                        limit_lowest_pstate = p_count -1
+
+        common.append_node("./limit_nominal_pstate", str(limit_nominal_pstate), limit_node)
+        common.append_node("./limit_highest_pstate", str(limit_highest_pstate), limit_node)
+        common.append_node("./limit_lowest_pstate", str(limit_lowest_pstate), limit_node)
+
+    # Let CPUs in the same frequency dependency group have the same limits. So that RTVM's frequency can be fixed
+    dep_info = get_dependency(board_etree)
+    for alloc_cpu in allocation_etree.xpath("//cpufreq/CPU"):
+        dependency_cpus = dep_info[int(alloc_cpu.attrib['id'])]
+        if common.get_node("./limits", alloc_cpu) != None:
+            highest_lvl = int(common.get_node(".//limit_highest_lvl/text()", alloc_cpu))
+            lowest_lvl = int(common.get_node(".//limit_lowest_lvl/text()", alloc_cpu))
+            highest_pstate = int(common.get_node(".//limit_highest_pstate/text()", alloc_cpu))
+            lowest_pstate = int(common.get_node(".//limit_lowest_pstate/text()", alloc_cpu))
+
+            for dep_cpu_id in dependency_cpus:
+                dep_highest_lvl = int(common.get_node(f"//cpufreq/CPU[@id={dep_cpu_id}]//limit_highest_lvl/text()", allocation_etree))
+                dep_lowest_lvl = int(common.get_node(f"//cpufreq/CPU[@id={dep_cpu_id}]//limit_lowest_lvl/text()", allocation_etree))
+                if highest_lvl > dep_highest_lvl:
+                    highest_lvl = dep_highest_lvl
+                if lowest_lvl < dep_lowest_lvl:
+                    lowest_lvl = dep_lowest_lvl
+                dep_highest_pstate = int(common.get_node(f"//cpufreq/CPU[@id={dep_cpu_id}]//limit_highest_pstate/text()", allocation_etree))
+                dep_lowest_pstate = int(common.get_node(f"//cpufreq/CPU[@id={dep_cpu_id}]//limit_lowest_pstate/text()", allocation_etree))
+                if highest_pstate < dep_highest_pstate:
+                    highest_pstate = dep_highest_pstate
+                if lowest_pstate > dep_lowest_pstate:
+                    lowest_pstate = dep_lowest_pstate
+
+            common.update_text("./limits/limit_highest_lvl", str(highest_lvl), alloc_cpu, True)
+            common.update_text("./limits/limit_lowest_lvl", str(lowest_lvl), alloc_cpu, True)
+            common.update_text("./limits/limit_highest_pstate", str(highest_pstate), alloc_cpu, True)
+            common.update_text("./limits/limit_lowest_pstate", str(lowest_pstate), alloc_cpu, True)
+
+def fn(board_etree, scenario_etree, allocation_etree):
+    common.append_node("/acrn-config/hv/cpufreq", None, allocation_etree)
+    alloc_limits(board_etree, scenario_etree, allocation_etree)

--- a/misc/packaging/acrn-hypervisor.postinst
+++ b/misc/packaging/acrn-hypervisor.postinst
@@ -13,6 +13,13 @@ BOARD=(nuc11tnbi5)
 
 #Build info End
 
+
+#ACRN parameters Start
+
+GENERATED_PARAMS=(cpu_perf_policy=Performance)
+
+#ACRN parameters End
+
 ACRNBIN="/boot/acrn.${SCENARIO}.${BOARD}.bin"
 type=$(lsblk -l |awk '$NF == "/" {print $1}')
 
@@ -45,7 +52,7 @@ menuentry 'ACRN multiboot2 ' --id ACRN_deb_multiboot2 {
     insmod part_gpt
     insmod ext2
     search --no-floppy --fs-uuid  --set $uuid
-multiboot2 $ACRNBIN root=PARTUUID=$partuuid
+multiboot2 $ACRNBIN root=PARTUUID=$partuuid $GENERATED_PARAMS
 $kernelimg
 module2 /boot/zephyr64.elf Zephyr_ElfImage
 module2 /boot/ACPI_VM0.bin ACPI_VM0
@@ -64,7 +71,7 @@ menuentry 'ACRN multiboot2 ' --id ACRN_deb_multiboot2 {
     insmod part_gpt
     insmod ext2
     search --no-floppy --fs-uuid  --set $uuid
-multiboot2 $ACRNBIN root=PARTUUID=$partuuid
+multiboot2 $ACRNBIN root=PARTUUID=$partuuid $GENERATED_PARAMS
 $kernelimg
 module2 /boot/bzImage_RT RT_bzImage
 module2 /boot/ACPI_VM0.bin ACPI_VM0
@@ -82,7 +89,7 @@ menuentry 'ACRN multiboot2 ' --id ACRN_deb_multiboot2 {
     insmod ext2
     search --no-floppy --fs-uuid  --set $uuid
     echo 'loading ACRN...'
-multiboot2 $ACRNBIN root=PARTUUID=$partuuid
+multiboot2 $ACRNBIN root=PARTUUID=$partuuid $GENERATED_PARAMS
 $kernelimg
 module2 /boot/ACPI_VM0.bin ACPI_VM0
 module2 /boot/ACPI_VM1.bin ACPI_VM1
@@ -99,7 +106,7 @@ menuentry 'ACRN multiboot2 ' --id ACRN_deb_multiboot2 {
     insmod part_gpt
     insmod ext2
     search --no-floppy --fs-uuid  --set $uuid
-multiboot2 $ACRNBIN root=PARTUUID=$partuuid
+multiboot2 $ACRNBIN root=PARTUUID=$partuuid $GENERATED_PARAMS
 $kernelimg
 
 }

--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -13,6 +13,7 @@ import shlex
 import shutil
 import subprocess
 import argparse
+import re
 
 from pathlib import Path
 
@@ -81,6 +82,20 @@ def create_acrn_deb(board, scenario, version, build_dir):
     del lines[(start + 1):(end - 1)]
     lines.insert(start + 1, "\nSCENARIO=(%s)\n" % scenario)
     lines.insert(start + 2, "\nBOARD=(%s)\n" % board)
+
+    a_f = open(build_dir + "/hypervisor/.scenario.xml", 'r')
+    for a_line in a_f:
+        l = re.search("<CPU_PERFORMANCE_POLICY>(\w*)</CPU_PERFORMANCE_POLICY>", a_line)
+        if l != None:
+            break;
+    start = lines.index('#ACRN parameters Start\n')
+    end = lines.index('#ACRN parameters End\n')
+    del lines[(start + 1):(end - 1)]
+    if l == None:
+        lines.insert(start + 1, "\nGENERATED_PARAMS=(cpu_perf_policy=%s)\n" % "Performance")
+    else:
+        lines.insert(start + 1, "\nGENERATED_PARAMS=(cpu_perf_policy=%s)\n" % l.group(1))
+
     with open(cur_dir + "/misc/packaging/acrn-hypervisor.postinst", "w") as f:
         for line in lines:
             f.write(line)


### PR DESCRIPTION
1. Background:

Customers of the industry segment are asking for more computation power
in WaaG. Currently there are two ways to manage CPU frequency when
running ACRN:
  - Pass through HWP/p-state to guest. This doesn't work for Windows
    because Windows running in a VM relies on Hyper-V to manage the
    frequency. So it does not load frequency driver.
  - Or rely on service VM's Linux HWP driver, which can set the
    frequency policy to hardware autonomous selection. But it does not
    work either because when a CPU is set to offline, that driver
    sets HWP autonomous frequency selection range to minimal. Also we
    don't want the RTVM's frequency been changed by autonomous selection.

So we have to let ACRN manage CPU frequency.

2. The design:

The design of ACRN CPU performance management is to let hardware do the
autonomous frequency selection(or set to a fixed value), and remove all
guests' capability to control CPU frequency.

If the platform supports HWP, we can use HWP to do the hardware
autonomous selection. The hypervisor just need to setup HWP_REQUEST at
start up, and no need to be governing the frequency after this. But for
ACPI p-state, the CPU frequency can only be fixed.

Cores running RTVMs are always fixed to nominal/guaranteed frequency, to
get more certainty in latency.

Users may have preference on how the CPU frequency is managed. So we
provide two performance policy types for users to choose from:
  - 'Performance': CPU runs at its CPU runs at its maximum
    frequency. Enable hardware autonomous frequency selection if HWP is
    presented.
  - 'Nominal': CPU runs at its guaranteed frequency.
(*Note: The performance 'policy' was called 'governor' in the first
edition of this patch series. But ACRN don't actually 'govern' the
frequency. It just apply the policy at start up. So the word 'policy'
might be more appropriate.)

The policy type is passed to hypervisor through boot parameter, as
either 'cpu_perf_policy=Nominal' or 'cpu_perf_policy=Performance'.
The default type is 'Performance'.

An configurate item is provided to user to choose the policy.
Config-tool will then generate the boot parameter automatically.
But it can always be changed by editting the grub cfg.
3. The implementation:
  - Add a config item and automatically generate policy parameter.
    (1/6, 2/6)
  - Extract CPU frequency info and generate frequency limits from
    config-tools. This could save hypervisor code. (3/6, 4/6)
  - Implement CPU frequency initializer. (5/6)
  - Remove guest's ability to control CPU frequency by removing the
    guests' HWP/EIST CPUIDs and blocking the related MSR accesses.
    Also removed hypercall cmds for getting px info, so that DM do
    not generate _PSS/_PPC for post-launched VMs anymore. (6/6)


Tracked-On: #8168
Signed-off-by: Wu Zhou <wu.zhou@intel.com>
