### PR TITLE
improve kick-pcpu with INIT/IPI and SMP call 

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -415,7 +415,7 @@ void make_pcpu_offline(uint16_t pcpu_id)
 {
 	bitmap_set_lock(NEED_OFFLINE, &per_cpu(pcpu_flag, pcpu_id));
 	if (get_pcpu_id() != pcpu_id) {
-		send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);
+		kick_pcpu(pcpu_id);
 	}
 }
 

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -21,6 +21,7 @@
 #include <lib/sprintf.h>
 #include <asm/lapic.h>
 #include <asm/irq.h>
+#include <console.h>
 
 /* stack_frame is linked with the sequence of stack operation in arch_switch_to() */
 struct stack_frame {
@@ -526,11 +527,13 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 		vcpu->vcpu_id = vcpu_id;
 		per_cpu(ever_run_vcpu, pcpu_id) = vcpu;
 
-		if (is_lapic_pt_configured(vm)) {
+		if (is_lapic_pt_configured(vm) || is_using_init_ipi()) {
 			per_cpu(mode_to_kick_pcpu, pcpu_id) = DEL_MODE_INIT;
 		} else {
 			per_cpu(mode_to_kick_pcpu, pcpu_id) = DEL_MODE_IPI;
 		}
+		pr_info("pcpu=%d, kick-mode=%d, use_init_flag=%d", pcpu_id,
+			per_cpu(mode_to_kick_pcpu, pcpu_id), is_using_init_ipi());
 
 		/* Initialize the parent VM reference */
 		vcpu->vm = vm;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -255,9 +255,6 @@ static void vcpu_reset_internal(struct acrn_vcpu *vcpu, enum reset_mode mode)
 			sizeof(struct run_context));
 	}
 
-	/* TODO: we may need to add one scheduler->reset_data to reset the thread_obj */
-	vcpu->thread_obj.notify_mode = SCHED_NOTIFY_IPI;
-
 	vlapic = vcpu_vlapic(vcpu);
 	vlapic_reset(vlapic, apicv_ops, mode);
 
@@ -529,6 +526,12 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 		vcpu->vcpu_id = vcpu_id;
 		per_cpu(ever_run_vcpu, pcpu_id) = vcpu;
 
+		if (is_lapic_pt_configured(vm)) {
+			per_cpu(mode_to_kick_pcpu, pcpu_id) = DEL_MODE_INIT;
+		} else {
+			per_cpu(mode_to_kick_pcpu, pcpu_id) = DEL_MODE_IPI;
+		}
+
 		/* Initialize the parent VM reference */
 		vcpu->vm = vm;
 
@@ -790,14 +793,8 @@ void kick_vcpu(struct acrn_vcpu *vcpu)
 {
 	uint16_t pcpu_id = pcpuid_from_vcpu(vcpu);
 
-	if ((get_pcpu_id() != pcpu_id) &&
-		(per_cpu(vmcs_run, pcpu_id) == vcpu->arch.vmcs)) {
-		if (is_lapic_pt_enabled(vcpu)) {
-			/* For lapic-pt vCPUs */
-			send_single_init(pcpu_id);
-		} else {
-			send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);
-		}
+	if ((get_pcpu_id() != pcpu_id) && (per_cpu(vmcs_run, pcpu_id) == vcpu->arch.vmcs)) {
+		kick_pcpu(pcpu_id);
 	}
 }
 
@@ -970,7 +967,6 @@ int32_t prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id)
 		vcpu->thread_obj.sched_ctl = &per_cpu(sched_ctl, pcpu_id);
 		vcpu->thread_obj.thread_entry = vcpu_thread;
 		vcpu->thread_obj.pcpu_id = pcpu_id;
-		/* vcpu->thread_obj.notify_mode is initialized in vcpu_reset_internal() when create vcpu */
 		vcpu->thread_obj.host_sp = build_stack_frame(vcpu);
 		vcpu->thread_obj.switch_out = context_switch_out;
 		vcpu->thread_obj.switch_in = context_switch_in;

--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -388,6 +388,11 @@ int32_t acrn_handle_pending_request(struct acrn_vcpu *vcpu)
 			if (bitmap_test_and_clear_lock(ACRN_REQUEST_EOI_EXIT_BITMAP_UPDATE, pending_req_bits)) {
 				vcpu_set_vmcs_eoi_exit(vcpu);
 			}
+
+			if (bitmap_test_and_clear_lock(ACRN_REQUEST_SMP_CALL, pending_req_bits)) {
+				handle_smp_call();
+			}
+
 		}
 	}
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -1245,7 +1245,7 @@ void make_shutdown_vm_request(uint16_t pcpu_id)
 {
 	bitmap_set_lock(NEED_SHUTDOWN_VM, &per_cpu(pcpu_flag, pcpu_id));
 	if (get_pcpu_id() != pcpu_id) {
-		send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);
+		kick_pcpu(pcpu_id);
 	}
 }
 

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -631,12 +631,6 @@ void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu)
 
 		update_msr_bitmap_x2apic_passthru(vcpu);
 
-		/*
-		 * After passthroughing lapic to guest, we should use INIT signal to
-		 * notify vcpu thread instead of IPI. Because the IPI will be delivered
-		 * the guest directly without vmexit.
-		 */
-		vcpu->thread_obj.notify_mode = SCHED_NOTIFY_INIT;
 	} else {
 		value32 = exec_vmread32(VMX_PROC_VM_EXEC_CONTROLS2);
 		value32 &= ~VMX_PROCBASED_CTLS2_VAPIC;

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -12,6 +12,7 @@
 #include <asm/cpu_caps.h>
 #include <asm/lapic.h>
 #include <asm/apicreg.h>
+#include <asm/irq.h>
 #include <delay.h>
 
 /* intr_lapic_icr_delivery_mode */
@@ -293,4 +294,13 @@ void send_single_init(uint16_t pcpu_id)
 
 	msr_write(MSR_IA32_EXT_APIC_ICR, icr.value);
 
+}
+
+void kick_pcpu(uint16_t pcpu_id)
+{
+	if (per_cpu(mode_to_kick_pcpu, pcpu_id) == DEL_MODE_INIT) {
+		send_single_init(pcpu_id);
+	} else {
+		send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);
+	}
 }

--- a/hypervisor/common/sched_bvt.c
+++ b/hypervisor/common/sched_bvt.c
@@ -139,11 +139,11 @@ static void sched_tick_handler(void *param)
 		if (!is_idle_thread(current)) {
 			data->run_countdown -= 1U;
 			if (data->run_countdown == 0U) {
-				make_reschedule_request(pcpu_id, DEL_MODE_IPI);
+				make_reschedule_request(pcpu_id);
 			}
 		} else {
 			if (!list_empty(&bvt_ctl->runqueue)) {
-				make_reschedule_request(pcpu_id, DEL_MODE_IPI);
+				make_reschedule_request(pcpu_id);
 			}
 		}
 	}

--- a/hypervisor/common/sched_iorr.c
+++ b/hypervisor/common/sched_iorr.c
@@ -94,7 +94,7 @@ static void sched_tick_handler(void *param)
 			}
 			/* make reschedule request if current ran out of its cycles */
 			if (is_idle_thread(current) || data->left_cycles <= 0) {
-				make_reschedule_request(pcpu_id, DEL_MODE_IPI);
+				make_reschedule_request(pcpu_id);
 			}
 		}
 	}

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -25,6 +25,14 @@ struct hv_timer console_timer;
 #define GUEST_CONSOLE_TO_HV_SWITCH_KEY      0       /* CTRL + SPACE */
 uint16_t console_vmid = ACRN_INVALID_VMID;
 
+/* if use INIT to kick pcpu only, if not notification IPI still is used for sharing CPU */
+static bool use_init_ipi = false;
+
+bool is_using_init_ipi(void)
+{
+	return use_init_ipi;
+}
+
 static void parse_hvdbg_cmdline(void)
 {
 	const char *start = NULL;
@@ -43,6 +51,9 @@ static void parse_hvdbg_cmdline(void)
 
 			if (!handle_dbg_cmd(start, (int32_t)(end - start))) {
 				/* if not handled by handle_dbg_cmd, it can be handled further */
+				if (strncmp(start, "USE_INIT_IPI", (size_t)(end - start)) == 0) {
+					use_init_ipi = true;
+				}
 			}
 			start = end;
 		}

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -105,6 +105,8 @@
  */
 #define ACRN_REQUEST_SPLIT_LOCK			10U
 
+#define ACRN_REQUEST_SMP_CALL			11U
+
 /**
  * @}
  */

--- a/hypervisor/include/arch/x86/asm/lapic.h
+++ b/hypervisor/include/arch/x86/asm/lapic.h
@@ -126,4 +126,6 @@ void send_single_ipi(uint16_t pcpu_id, uint32_t vector);
  */
 void send_single_init(uint16_t pcpu_id);
 
+void kick_pcpu(uint16_t pcpu_id);
+
 #endif /* ARCH_X86_LAPIC_H */

--- a/hypervisor/include/arch/x86/asm/notify.h
+++ b/hypervisor/include/arch/x86/asm/notify.h
@@ -17,6 +17,7 @@ struct acrn_vm;
 void smp_call_function(uint64_t mask, smp_call_func_t func, void *data);
 
 void setup_notification(void);
+void handle_smp_call(void);
 void setup_pi_notification(void);
 
 #endif

--- a/hypervisor/include/arch/x86/asm/per_cpu.h
+++ b/hypervisor/include/arch/x86/asm/per_cpu.h
@@ -54,6 +54,7 @@ struct per_cpu_region {
 	uint32_t lapic_id;
 	uint32_t lapic_ldr;
 	uint32_t softirq_servicing;
+	uint32_t mode_to_kick_pcpu;
 	struct smp_call_info_data smp_call_info;
 	struct list_head softirq_dev_entry_list;
 #ifdef PROFILING_ON

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -23,11 +23,6 @@ enum thread_object_state {
 	THREAD_STS_BLOCKED
 };
 
-enum sched_notify_mode {
-	SCHED_NOTIFY_INIT,
-	SCHED_NOTIFY_IPI
-};
-
 /* Tools can configure a VM to use PRIO_LOW or PRIO_HIGH */
 enum thread_priority {
 	PRIO_IDLE = 0,
@@ -46,7 +41,6 @@ struct thread_object {
 	thread_entry_t thread_entry;
 	volatile enum thread_object_state status;
 	bool be_blocking;
-	enum sched_notify_mode notify_mode;
 
 	uint64_t host_sp;
 	switch_t switch_out;
@@ -126,7 +120,7 @@ void release_schedule_lock(uint16_t pcpu_id, uint64_t rflag);
 void init_thread_data(struct thread_object *obj);
 void deinit_thread_data(struct thread_object *obj);
 
-void make_reschedule_request(uint16_t pcpu_id, uint16_t delmode);
+void make_reschedule_request(uint16_t pcpu_id);
 bool need_reschedule(uint16_t pcpu_id);
 
 void run_thread(struct thread_object *obj);

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -41,5 +41,6 @@ void console_vmexit_callback(struct acrn_vcpu *vcpu);
 void suspend_console(void);
 void resume_console(void);
 struct acrn_vuart *vm_console_vuart(struct acrn_vm *vm);
+bool is_using_init_ipi(void);
 
 #endif /* CONSOLE_H */

--- a/hypervisor/release/console.c
+++ b/hypervisor/release/console.c
@@ -29,5 +29,7 @@ void resume_console(void) {}
 bool handle_dbg_cmd(__unused const char *cmd, __unused int32_t len) { return false; }
 void console_vmexit_callback(__unused struct acrn_vcpu *vcpu) {}
 
+bool is_using_init_ipi(void) { return false; }
+
 void shell_init(void) {}
 void shell_kick(void) {}


### PR DESCRIPTION
hv: use kick-mode in per-cpu to control kick pCPU
hv: add param to control INIT used to kick pCPU
hv: improve smp call to support debugging RTVM


Tracked-On: #8207
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
