### PR TITLE
config-tools: check if the cpu_affinity is null

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -347,7 +347,7 @@ export default {
     },
     updateCpuAffinity(vmid) {
       this.scenario.vm.map((vmConfig, vmIndex) => {
-          if (vmConfig['@id'] === vmid) {
+          if (vmConfig['@id'] === vmid && vmConfig['cpu_affinity'] != null) {
             for (let i = 0; i < vmConfig['cpu_affinity']['pcpu'].length; i++) {
               this.scenario.vm[vmIndex]['cpu_affinity']['pcpu'][i]['real_time_vcpu'] = 'n'
             }


### PR DESCRIPTION
The cpu_affinity is null when creating a new scenario. Do not update the pcpu properties if the cpu_affinity is null.

Tracked-On: #8145
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>