### PR TITLE
config_tools: determine SSRAM_ENABLED automatically

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/lib/acrn.ts
+++ b/misc/config_tools/configurator/packages/configurator/src/lib/acrn.ts
@@ -92,7 +92,6 @@ class CAT {
     private CAT_REGION_INFO: any;
 
     private switches: {
-        SSRAM_ENABLED: boolean,
         RDT_ENABLED: boolean,
         CDP_ENABLED: boolean,
         VCAT_ENABLED: boolean
@@ -141,7 +140,6 @@ class CAT {
 
     formDataProxy(name, data = null, update = false) {
         let path = {
-            'SSRAM_ENABLED': 'FEATURES.SSRAM.SSRAM_ENABLED',
             'RDT_ENABLED': 'FEATURES.RDT.RDT_ENABLED',
             'CDP_ENABLED': 'FEATURES.RDT.CDP_ENABLED',
             'VCAT_ENABLED': 'FEATURES.RDT.VCAT_ENABLED',
@@ -165,27 +163,19 @@ class CAT {
             // if data is not empty, set value as expected and update CAT_INFO
             if (update) {
                 switch (name) {
-                    case 'SSRAM_ENABLED':
-                        this.formDataProxy('RDT_ENABLED', 'n');
-                        this.formDataProxy('CDP_ENABLED', 'n');
-                        this.formDataProxy('VCAT_ENABLED', 'n');
-                        break;
                     case 'RDT_ENABLED':
-                        this.formDataProxy('SSRAM_ENABLED', 'n');
                         if (data === 'n') {
                             this.formDataProxy('CDP_ENABLED', 'n');
                             this.formDataProxy('VCAT_ENABLED', 'n');
                         }
                         break;
                     case 'CDP_ENABLED':
-                        this.formDataProxy('SSRAM_ENABLED', 'n');
                         if (data === 'y') {
                             this.formDataProxy('RDT_ENABLED', 'y');
                             this.formDataProxy('VCAT_ENABLED', 'n');
                         }
                         break;
                     case 'VCAT_ENABLED':
-                        this.formDataProxy('SSRAM_ENABLED', 'n');
                         if (data === 'y') {
                             this.formDataProxy('RDT_ENABLED', 'y');
                             this.formDataProxy('CDP_ENABLED', 'n');
@@ -353,17 +343,7 @@ class CAT {
     }
 
     correctSwitches() {
-        if (this.switches.SSRAM_ENABLED) {
-            if (this.switches.RDT_ENABLED) {
-                this.switches.RDT_ENABLED = false
-            }
-            if (this.switches.CDP_ENABLED) {
-                this.switches.CDP_ENABLED = false
-            }
-            if (this.switches.VCAT_ENABLED) {
-                this.switches.VCAT_ENABLED = false
-            }
-        } else if (this.switches.RDT_ENABLED) {
+        if (this.switches.RDT_ENABLED) {
             if (this.switches.CDP_ENABLED) {
                 if (this.switches.VCAT_ENABLED) {
                     this.switches.VCAT_ENABLED = false

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/CAT.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/CAT.vue
@@ -2,24 +2,10 @@
   <div class="py-3">
     <b>Memory Isolation for Performance</b>
 
-    <div class="py-3">
-      <b-form-checkbox
-          v-model="SSRAM_ENABLED" :value="'y'" :uncheckedValue="'n'"
-          :disabled="RDT_ENABLED==='y'">
-        <n-popover trigger="hover" placement="top-start">
-          <template #trigger>
-            <IconInfo/>
-          </template>
-          <span v-html="this.SSRAMInfo.properties.SSRAM_ENABLED.description"></span>
-        </n-popover>
-        Software SRAM (for real-time apps)
-      </b-form-checkbox>
-    </div>
     <div class="d-flex gap-2 flex-column">
       <text>Intel Resource Director Technology</text>
       <b-form-checkbox
           v-model="RDT_ENABLED" :value="'y'" :uncheckedValue="'n'"
-          :disabled="SSRAM_ENABLED==='y'"
           @click="(event)=>checkboxController('RDT_ENABLED',event)">
         <n-popover trigger="hover" placement="top-start">
           <template #trigger>
@@ -32,7 +18,7 @@
       <div class="d-flex flex-column gap-2 ps-3 pb-3">
         <b-form-checkbox
             v-model="CDP_ENABLED" :value="'y'" :uncheckedValue="'n'"
-            :disabled="SSRAM_ENABLED==='y'||VCAT_ENABLED==='y'"
+            :disabled="VCAT_ENABLED==='y'"
             @click="(event)=>checkboxController('CDP_ENABLED',event)">
           <n-popover trigger="hover" placement="top-start">
             <template #trigger>
@@ -44,7 +30,7 @@
         </b-form-checkbox>
         <b-form-checkbox
             v-model="VCAT_ENABLED" :value="'y'" :uncheckedValue="'n'"
-            :disabled="SSRAM_ENABLED==='y'||CDP_ENABLED==='y'"
+            :disabled="CDP_ENABLED==='y'"
             @click="(event)=>checkboxController('VCAT_ENABLED',event)">
           <n-popover trigger="hover" placement="top-start">
             <template #trigger>
@@ -181,14 +167,6 @@ export default {
     }
   },
   computed: {
-    SSRAM_ENABLED: {
-      get() {
-        return this.formDataProxy('SSRAM_ENABLED');
-      },
-      set(value) {
-        return this.formDataProxy('SSRAM_ENABLED', value, true);
-      }
-    },
     RDT_ENABLED: {
       get() {
         return this.formDataProxy('RDT_ENABLED');
@@ -217,7 +195,6 @@ export default {
   data() {
     return {
       CAT_INFO: {errorMsg: null, regions: [], summary: {}},
-      SSRAMInfo: this.rootSchema.definitions['SSRAMInfo'],
       RDTType: this.rootSchema.definitions['RDTType'],
       InstructionLocation: {},
     }
@@ -260,7 +237,6 @@ export default {
     },
     formDataProxy(name, data = null, update = false) {
       let path = {
-        'SSRAM_ENABLED': 'FEATURES.SSRAM.SSRAM_ENABLED',
         'RDT_ENABLED': 'FEATURES.RDT.RDT_ENABLED',
         'CDP_ENABLED': 'FEATURES.RDT.CDP_ENABLED',
         'VCAT_ENABLED': 'FEATURES.RDT.VCAT_ENABLED',
@@ -284,27 +260,19 @@ export default {
         // if data is not empty, set value as expected and update CAT_INFO
         if (update) {
           switch (name) {
-            case 'SSRAM_ENABLED':
-              this.formDataProxy('RDT_ENABLED', 'n');
-              this.formDataProxy('CDP_ENABLED', 'n');
-              this.formDataProxy('VCAT_ENABLED', 'n');
-              break;
             case 'RDT_ENABLED':
-              this.formDataProxy('SSRAM_ENABLED', 'n');
               if (data === 'n') {
                 this.formDataProxy('CDP_ENABLED', 'n');
                 this.formDataProxy('VCAT_ENABLED', 'n');
               }
               break;
             case 'CDP_ENABLED':
-              this.formDataProxy('SSRAM_ENABLED', 'n');
               if (data === 'y') {
                 this.formDataProxy('RDT_ENABLED', 'y');
                 this.formDataProxy('VCAT_ENABLED', 'n');
               }
               break;
             case 'VCAT_ENABLED':
-              this.formDataProxy('SSRAM_ENABLED', 'n');
               if (data === 'y') {
                 this.formDataProxy('RDT_ENABLED', 'y');
                 this.formDataProxy('CDP_ENABLED', 'n');

--- a/misc/config_tools/schema/checks/rdt_support.xsd
+++ b/misc/config_tools/schema/checks/rdt_support.xsd
@@ -33,13 +33,7 @@
     </xs:annotation>
   </xs:assert>
 
-  <xs:assert test="not (//hv//RDT/RDT_ENABLED = 'y' and //hv//SSRAM/SSRAM_ENABLED = 'y')">
-    <xs:annotation acrn:severity="error" acrn:report-on="//hv//SSRAM/SSRAM_ENABLED">
-      <xs:documentation>The hypervisor Intel Resource Director Technology and Software SRAM settings may not be enabled at the same time.</xs:documentation>
-    </xs:annotation>
-  </xs:assert>
-
-  <xs:assert test="hv//SSRAM_ENABLED = 'n' or empty(vm[load_order ='PRE_LAUNCHED_VM' and vm_type='RTVM']) or
+  <xs:assert test="empty(vm[load_order ='PRE_LAUNCHED_VM' and vm_type='RTVM']) or
 		   every $cap in caches/cache[@level=3]/capability[@id='Software SRAM'] satisfies
 		   (compare($cap/end, '0x80000000') &lt; 0 or compare($cap/start, '0xf8000000') &gt;= 0)">
     <xs:annotation acrn:severity="warning" acrn:report-on="hv//SSRAM_ENABLED">
@@ -58,6 +52,15 @@ This error cannot be fixed by adjusting the configuration. Report a `GitHub issu
                    $needed &lt; $capacity">
     <xs:annotation acrn:severity="error" acrn:report-on="/acrn-config/hv/CACHE_REGION">
       <xs:documentation>The current CAT configuration requires {string($needed)} CLOS IDs, which exceeds the capacity of the platform which supports {string($capacity)} at most.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $cache in //CACHE_ALLOCATION satisfies
+                   every $ssram in //caches/cache[@level=$cache/CACHE_LEVEL and @id=$cache/CACHE_ID]/capability[@id='Software SRAM'] satisfies
+                   every $policy in $cache/POLICY satisfies
+                   bitwise-and($policy/CLOS_MASK, $ssram/waymask) = 0">
+    <xs:annotation acrn:severity="error" acrn:report-on="/acrn-config/hv/CACHE_REGION">
+      <xs:documentation>VM '{$policy/VM}' vCPU '{$policy/VCPU}' cannot use chunk(s) {bits-of($ssram/waymask)} of L{$cache/CACHE_LEVEL} cache (cache ID: {$cache/CACHE_ID}) as those chunks are consumed by software SRAM. </xs:documentation>
     </xs:annotation>
   </xs:assert>
 

--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -140,7 +140,7 @@
 
     <xsl:call-template name="boolean-by-key-value">
       <xsl:with-param name="key" select="'SSRAM_ENABLED'" />
-      <xsl:with-param name="value" select="SSRAM/SSRAM_ENABLED" />
+      <xsl:with-param name="value" select="count(//cache/capability[@id='Software SRAM']) > 0" />
     </xsl:call-template>
 
     <xsl:call-template name="boolean-by-key-value">


### PR DESCRIPTION
Today users are able to tweak whether the hypervisor includes support to software SRAM (SSRAM). This, however, gives rise to potential functional incorrectness when the hypervisor is not built with such support but a service VM attempts to assign SSRAM to a post-launched VM (which is possible as the service VM can still see the SSRAM-related ACPI tables). In such cases the SSRAM assigned to a post-launched VM is not properly initialized and thus not locked in cache.

As makes little sense for a user to configure the SSRAM support in the hypervisor in a different way as the presence of SSRAM on hardware, this patch removes the "SSRAM support" option from the configurator. The config tools will now automatically enable the SSRAM support if the hardware supports the feature and disable that otherwise.

Tracked-On: #8231
Signed-off-by: Junjie Mao <junjie.mao@intel.com>