### PR TITLE
doc: prep for Ubuntu 22.04

### DIFF
--- a/doc/.known-issues/doc/pdf.conf
+++ b/doc/.known-issues/doc/pdf.conf
@@ -24,3 +24,7 @@
 ^  pdflatex: Command for 'pdflatex' gave return code 1
 ^      Refer to 'acrn.log' for details
 #
+^Rc files read:
+^  /etc/LatexMk
+^  latexmkrc
+#

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,7 +13,7 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = "Project ACRN"
 BUILDDIR      ?= _build
 SOURCEDIR     = $(BUILDDIR)/rst
-LATEXMKOPTS   = -silent
+LATEXMKOPTS   = "-silent -f"
 
 # should the config option doc show hidden config options?
 XSLTPARAM     ?= --stringparam showHidden 'n'

--- a/doc/acrn.doxyfile
+++ b/doc/acrn.doxyfile
@@ -246,7 +246,7 @@ ALIASES += "endrst=\endverbatim"
 # A mapping has the form "name=value". For example adding "class=itcl::class"
 # will allow you to use the command class in the itcl::class meaning.
 
-TCL_SUBST              =
+# TCL_SUBST              =
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -1104,7 +1104,7 @@ ALPHABETICAL_INDEX     = YES
 # Minimum value: 1, maximum value: 20, default value: 5.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-COLS_IN_ALPHA_INDEX    = 5
+# COLS_IN_ALPHA_INDEX    = 5
 
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag

--- a/doc/custom-doxygen/mainpage.md
+++ b/doc/custom-doxygen/mainpage.md
@@ -1,4 +1,4 @@
-# API Documentation   {#index}
+# API Documentation   {#mainpage}
 
 Project ACRN is a flexible and lighweight hypervisor, built with
 real-time and safety-criticality in mind. It streamlines


### PR DESCRIPTION
These changes are compatible with both the Ubuntu 20.04 and 22.04 documentation build processes.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>