### PR TITLE
Issue8246 debianization improvement

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -32,8 +32,8 @@ rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(su
 unquote = $(subst $\",,$1)
 
 # set these variables to define build of certain boards/scenarios, e.g.
-ACRN_BOARDLIST := whl-ipc-i5 nuc11tnbi5 cfl-k700-i7 tgl-vecow-spc-7100-Corei7
-ACRN_SCENARIOLIST := partitioned shared hybrid hybrid_rt
+ACRN_BOARDLIST ?= whl-ipc-i5 nuc11tnbi5 cfl-k700-i7 tgl-vecow-spc-7100-Corei7
+ACRN_SCENARIOLIST ?= partitioned shared hybrid hybrid_rt
 
 # for now build the debug versions
 # set to 1 for RELEASE build

--- a/debian/rules
+++ b/debian/rules
@@ -44,10 +44,6 @@ export RELEASE ?= 0
 debian/configs/configurations.mk:
 	@:
 
-ifeq ($(ACRN_SCENARIOLIST),)
-$(error No scenarios defined. Please set ACRN_SCENARIOLIST)
-endif
-
 # misc/config_tools/data: contains ACRN supported configuration
 # debian/configs: add additional, unsupported configurations here!
 CONFIGDIRS ?= misc/config_tools/data debian/configs
@@ -81,13 +77,22 @@ endef
 # get all XML data
 $(foreach xml,$(CONFIGXMLS),$(call get-xml-data,$(xml)))
 
-# honor variable ACRN_BOARDLIST
+# honor variable ACRN_BOARDLIST by filtering the discovered board configurations accordingly
 ifneq ($(ACRN_BOARDLIST),)
-boardlist := $(sort $(ACRN_BOARDLIST))
+boardlist := $(sort $(filter $(boardlist),$(ACRN_BOARDLIST)))
 endif
 
-# honor variable ACRN_SCENARIOLIST
+# honor variable ACRN_SCENARIOLIST by filtering the discovered scenario configurations
+ifneq ($(ACRN_SCENARIOLIST),)
 $(foreach b,$(boardlist),$(eval scenariolist_$(b) := $(filter $(scenariolist_$(b)),$(ACRN_SCENARIOLIST))))
+endif
+
+# only keep boards with at least one valid scenario configuration
+boardlist := $(foreach b,$(boardlist),$(if $(scenariolist_$(b)),$b))
+# assert nonempty boardlist
+ifeq ($(boardlist),)
+$(error No valid board/scenario configurations specified/found)
+endif
 
 # board config name -> board config file
 bfile = $(abspath $(config_$1))

--- a/debian/rules
+++ b/debian/rules
@@ -365,6 +365,14 @@ override_dh_auto_clean:
 	@$(foreach b,$(boardlist),echo "  $b: $(bold)$(call commasep,$(scenariolist_$b))$(sgr0)";)
 	@$(call echo-verbose)
 	@$(call echo-silent,CLEAN)
+	$(Q)rm -rf .pybuild/
+	$(Q)find . -type d -name __pycache__ | xargs rm -rf
+	$(Q)rm -f debian/acrn-hypervisor.config
+	$(Q)rm -f debian/acrn-hypervisor.postinst
+	$(Q)rm -f debian/acrn-hypervisor.postrm
+	$(Q)rm -f debian/acrn-hypervisor.prerm
+	$(Q)rm -f debian/acrn-hypervisor.templates
+	$(Q)rm -rf debian/acrn-board-inspector/build
 	$(Q)dh_auto_clean $(devnull)
 
 ### others ###################################################################


### PR DESCRIPTION
This patch series fixes issues with configuration file detection when using ACRN_BOARDLIST, ACRN_SCENARIOLIST and CONFIGDIRS other than the default settings in debian/rules, e.g. using

`debuild -eACRN_BOARDLIST= -eACRN_SCENARIOLIST= -eCONFIGDIRS=<custom config path> -- binary`

to build all custom board/scenario configurations from  <custom config path>.
Remember: `-eACRN_BOARDLIST=` means detecting all available boards, whereas not setting `ACRN_BOARDLIST` means using the debian/rules default settings. The same applies to `ACRN_SCENARIOLIST`.