### PR TITLE
config_tools: fix the issue for debuild on tgl-rvp with hybrid scenario

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -246,16 +246,15 @@ override_dh_auto_install-arch:
 		fi;                                                                 \
 		cp $(call sfile,$b,$s) $(DESTDIR)$(libdir)/acrn/$b/$s/scenario.xml; \
 		vmids=$$(xmllint --xpath '//vm[load_order="POST_LAUNCHED_VM"]/@id' $(call sfile,$b,$s) 2>/dev/null || true); \
-		for vmid in $${vmids}; do                                           \
-		    mkdir -p $(DESTDIR)$(datadir)/acrn/launch-scripts/$b/$s/;       \
-		    id=$$(echo "$${vmid}" | sed -e 's/[[:space:]]*id="\(.*\)"/\1/g'); \
-		    $(call echo-silent,CREATE $(datadir)/acrn/launch-scripts/$b/$s/launch_user_vm_id$${id}.sh); \
-		    misc/config_tools/launch_config/launch_cfg_gen.py               \
-		        --board $(call bfile,$b) --scenario $(call sfile,$b,$s)     \
-		        --out $(DESTDIR)$(datadir)/acrn/launch-scripts/$b/$s        \
-			--user_vmid $${id} $(devnull) 2>&1;                         \
-		    chmod a+x $(DESTDIR)$(datadir)/acrn/launch-scripts/$b/$s/*;     \
-		done;                                                               \
+		if [ -n "$${vmids}" ]; then                                         \
+			$(call echo-silent,CREATE launch scripts in $(datadir)/acrn/launch-scripts/$b/$s/); \
+			mkdir -p $(DESTDIR)$(datadir)/acrn/launch-scripts/$b/$s/;   \
+			misc/config_tools/launch_config/launch_cfg_gen.py           \
+			    --board $(call bfile,$b) --scenario $(call sfile,$b,$s) \
+			    --out $(DESTDIR)$(datadir)/acrn/launch-scripts/$b/$s    \
+			    $(devnull) 2>&1;                          \
+			chmod a+x $(DESTDIR)$(datadir)/acrn/launch-scripts/$b/$s/*; \
+		fi;                                                                 \
 	) cp $(call bfile,$b) $(DESTDIR)$(libdir)/acrn/$b/board.xml;)
 	@:
 	@# install devicemodel & tools


### PR DESCRIPTION
The debian build rule of calculating method for post launch vm ids when generating launch scripts should not be reading //vm/@id in scenario xmls directly but reading //vm/@id in scenario xml and then plus vm id for service vm.
Since the objective here is to generate the launch scripts for all VMs, change the debian rule to invoking the launch_cfg_gen.py script without parameter user_vmid when there are post launch vms to achieve the objective.

Tracked-On: #8245

Signed-off-by: szhen11 <shuang.zheng@intel.com>
Signed-off-by: Helmut Buchsbaum <helmut.buchsbaum@opensource.tttech-industrial.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>