### PR TITLE
vpci: fix pass-thru pcie device may access MSI-X BAR

### DIFF
--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -179,24 +179,10 @@ static uint32_t pci_mmcfg_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t 
 {
 	uint32_t addr = mmcfg_off_to_address(bdf, offset);
 	void *hva = hpa2hva(addr);
-	uint32_t val;
-
 
 	ASSERT(pci_is_valid_access(offset, bytes), "the offset should be aligned with 2/4 byte\n");
 
-	switch (bytes) {
-	case 1U:
-		val = (uint32_t)mmio_read8(hva);
-		break;
-	case 2U:
-		val = (uint32_t)mmio_read16(hva);
-		break;
-	default:
-		val = mmio_read32(hva);
-		break;
-	}
-
-	return val;
+	return (uint32_t)mmio_read(hva, bytes);
 }
 
 /*
@@ -211,17 +197,8 @@ static void pci_mmcfg_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t byt
 	void *hva = hpa2hva(addr);
 
 	ASSERT(pci_is_valid_access(offset, bytes), "the offset should be aligned with 2/4 byte\n");
-	switch (bytes) {
-	case 1U:
-		mmio_write8((uint8_t)val, hva);
-		break;
-	case 2U:
-		mmio_write16((uint16_t)val, hva);
-		break;
-	default:
-		mmio_write32(val, hva);
-		break;
-	}
+
+	mmio_write(hva, bytes, val);
 }
 
 static const struct pci_cfg_ops pci_mmcfg_cfg_ops = {

--- a/hypervisor/include/arch/x86/asm/io.h
+++ b/hypervisor/include/arch/x86/asm/io.h
@@ -166,4 +166,42 @@ static inline uint8_t mmio_read8(const void *addr)
 	return *((volatile const uint8_t *)addr);
 }
 
+static inline uint64_t mmio_read(const void *addr, uint64_t sz)
+{
+	uint64_t val;
+	switch (sz) {
+	case 1U:
+		val = (uint64_t)mmio_read8(addr);
+		break;
+	case 2U:
+		val = (uint64_t)mmio_read16(addr);
+		break;
+	case 4U:
+		val = (uint64_t)mmio_read32(addr);
+		break;
+	default:
+		val = mmio_read64(addr);
+		break;
+	}
+	return val;
+}
+
+static inline void mmio_write(void *addr, uint64_t sz, uint64_t val)
+{
+	switch (sz) {
+	case 1U:
+		mmio_write8((uint8_t)val, addr);
+		break;
+	case 2U:
+		mmio_write16((uint16_t)val, addr);
+		break;
+	case 4U:
+		mmio_write32((uint32_t)val, addr);
+		break;
+	default:
+		mmio_write64(val, addr);
+		break;
+	}
+}
+
 #endif /* _IO_H defined */


### PR DESCRIPTION
    Now ACRN would traps MSI-X Table Structure access and does MSI-X interrupt
    remapping for pass-thru PCIe devices. ACRN does this trap by unmmapping the
    address ranges where the MSI-X Table Structure locates in granularity of 4K
    pages. So there may have other registers (non-MSI-X structures) in these
    trapped pages

    However, the guest may access these registers (non-MSI-X structures) in these
    trapped pages, which needs to be forwarded to the physical device. This patch
    forwards the access to real hardware for pass-thru PCIe devices.

    Tracked-On: #8255
    Signed-off-by: Fei Li <fei1.li@intel.com>
