### PR TITLE
Makefile: sort out dependencies among targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ configurator:
 	  echo -e "'yarn' or 'cargo' utility is not available. Unable to create Debian package for configurator."; \
 	fi
 
-hypervisor: hvdefconfig
+hypervisor:
 	$(MAKE) $(HV_MAKEOPTS)
 	@echo -e "ACRN Configuration Summary:" > $(HV_CFG_LOG)
 	@$(MAKE) showconfig $(HV_MAKEOPTS) -s >> $(HV_CFG_LOG)

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -433,7 +433,7 @@ $(HV_ACPI_TABLE_TIMESTAMP): $(HV_CONFIG_TIMESTAMP)
 	python3 ../misc/config_tools/acpi_gen/bin_gen.py --board $(HV_BOARD_XML) --scenario $(HV_SCENARIO_XML) --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR) --iasl_path $(ASL_COMPILER) --iasl_min_ver $(IASL_MIN_VER)
 	@touch $(HV_ACPI_TABLE_TIMESTAMP)
 
-$(SERIAL_CONF): $(HV_CONFIG_TIMESTAMP)
+$(SERIAL_CONF): $(HV_CONFIG_TIMESTAMP) $(HV_ALLOCATION_XML)
 	@echo "generate the serial configuration file for service VM ..."
 	python3 ../misc/config_tools/service_vm_config/serial_config.py --allocation $(HV_ALLOCATION_XML) --scenario $(HV_SCENARIO_XML) --out $(SERIAL_CONF)
 

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -40,9 +40,6 @@ ARCH_ASFLAGS :=
 ARCH_ARFLAGS :=
 ARCH_LDFLAGS :=
 
-.PHONY: default
-default: all
-
 include scripts/makefile/config.mk
 
 BOARD_INFO_DIR := $(HV_CONFIG_DIR)/boards
@@ -566,3 +563,5 @@ $(VM_CFG_C_OBJS): %.o: %.c header
 $(HV_OBJDIR)/%.o: %.S header
 	[ ! -e $@ ] && mkdir -p $(dir $@) && mkdir -p $(HV_MODDIR); \
 	$(CC) $(patsubst %, -I%, $(INCLUDE_PATH)) -I. $(ASFLAGS) $(ARCH_ASFLAGS) -c $< -o $@ -MMD -MT $@
+
+.DEFAULT_GOAL := all

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -393,11 +393,15 @@ MODULES += $(SYS_INIT_MOD)
 
 DISTCLEAN_OBJS := $(shell find $(BASEDIR) -name '*.o')
 VERSION := $(HV_OBJDIR)/include/version.h
+HEADERS := $(VERSION) $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)
 
 PRE_BUILD_DIR := ../misc/hv_prebuild
+PRE_BUILD_CHECKER := $(HV_OBJDIR)/hv_prebuild_check.out
+HV_ACPI_TABLE_TIMESTAMP := $(HV_OBJDIR)/acpi.timestamp
+SERIAL_CONF = $(HV_OBJDIR)/serial.conf
 
 .PHONY: all
-all: env_check pre_build $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
+all: env_check $(HV_ACPI_TABLE_TIMESTAMP) $(SERIAL_CONF) $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
 
 install: $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
 	install -D $(HV_OBJDIR)/$(HV_FILE).32.out $(DESTDIR)$(libdir)/acrn/$(HV_FILE).$(BOARD).$(SCENARIO).32.out
@@ -419,18 +423,19 @@ ifndef ASL_COMPILER
 $(error Please either install "iasl" or provide the path to "iasl" by using the ASL_COMPILER variable)
 endif
 
-.PHONY: pre_build
-pre_build: $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)
+$(PRE_BUILD_CHECKER): $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)
 	@echo "Start pre-build static check ..."
-	$(MAKE) -C $(PRE_BUILD_DIR) BOARD=$(BOARD) SCENARIO=$(SCENARIO) TARGET_DIR=$(HV_CONFIG_DIR)
-	@$(HV_OBJDIR)/hv_prebuild_check.out
-	@echo "generate the binary of ACPI tables for pre-launched VMs ..."
-	python3 ../misc/config_tools/acpi_gen/bin_gen.py --board $(HV_OBJDIR)/.board.xml --scenario $(HV_OBJDIR)/.scenario.xml --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR) --iasl_path $(ASL_COMPILER) --iasl_min_ver $(IASL_MIN_VER)
-	@echo "generate the serial configuration file for service VM ..."
-	python3 ../misc/config_tools/service_vm_config/serial_config.py --allocation $(HV_OBJDIR)/configs/allocation.xml --scenario $(HV_OBJDIR)/.scenario.xml --out $(HV_OBJDIR)/serial.conf
+	$(MAKE) -C $(PRE_BUILD_DIR) BOARD=$(BOARD) SCENARIO=$(SCENARIO) CHECKER_OUT=$(PRE_BUILD_CHECKER)
+	@$(PRE_BUILD_CHECKER)
 
-.PHONY: header
-header: $(VERSION) $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)
+$(HV_ACPI_TABLE_TIMESTAMP): $(HV_CONFIG_TIMESTAMP)
+	@echo "generate the binary of ACPI tables for pre-launched VMs ..."
+	python3 ../misc/config_tools/acpi_gen/bin_gen.py --board $(HV_BOARD_XML) --scenario $(HV_SCENARIO_XML) --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR) --iasl_path $(ASL_COMPILER) --iasl_min_ver $(IASL_MIN_VER)
+	@touch $(HV_ACPI_TABLE_TIMESTAMP)
+
+$(SERIAL_CONF): $(HV_CONFIG_TIMESTAMP)
+	@echo "generate the serial configuration file for service VM ..."
+	python3 ../misc/config_tools/service_vm_config/serial_config.py --allocation $(HV_ALLOCATION_XML) --scenario $(HV_SCENARIO_XML) --out $(SERIAL_CONF)
 
 .PHONY: lib-mod boot-mod hw-mod vp-base-mod vp-dm-mod vp-trusty-mod vp-x86tee-mod vp-hcall-mod sys-init-mod
 $(LIB_MOD): $(LIB_C_OBJS) $(LIB_S_OBJS)
@@ -480,7 +485,7 @@ sys-init-mod: $(SYS_INIT_MOD)
 
 .PHONY: lib
 
-$(LIB_BUILD): header
+$(LIB_BUILD): $(HEADERS)
 	$(MAKE) -f $(LIB_MK) MKFL_NAME=$(LIB_MK)
 
 lib: $(LIB_BUILD)
@@ -550,17 +555,17 @@ $(VERSION): $(HV_CONFIG_H)
 -include $(C_OBJS:.o=.d)
 -include $(S_OBJS:.o=.d)
 
-$(HV_OBJDIR)/%.o: %.c header
+$(HV_OBJDIR)/%.o: %.c $(HEADERS) $(PRE_BUILD_CHECKER)
 	[ ! -e $@ ] && mkdir -p $(dir $@) && mkdir -p $(HV_MODDIR); \
 	$(CC) $(patsubst %, -I%, $(INCLUDE_PATH)) -I. -c $(CFLAGS) $(ARCH_CFLAGS) $< -o $@ -MMD -MT $@
 
 $(VM_CFG_C_SRCS): %.c: $(HV_CONFIG_TIMESTAMP)
 
-$(VM_CFG_C_OBJS): %.o: %.c header
+$(VM_CFG_C_OBJS): %.o: %.c $(HEADERS) $(PRE_BUILD_CHECKER)
 	[ ! -e $@ ] && mkdir -p $(dir $@) && mkdir -p $(HV_MODDIR); \
 	$(CC) $(patsubst %, -I%, $(INCLUDE_PATH)) -I. -c $(CFLAGS) $(ARCH_CFLAGS) $< -o $@ -MMD -MT $@
 
-$(HV_OBJDIR)/%.o: %.S header
+$(HV_OBJDIR)/%.o: %.S $(HEADERS) $(PRE_BUILD_CHECKER)
 	[ ! -e $@ ] && mkdir -p $(dir $@) && mkdir -p $(HV_MODDIR); \
 	$(CC) $(patsubst %, -I%, $(INCLUDE_PATH)) -I. $(ASFLAGS) $(ARCH_ASFLAGS) -c $< -o $@ -MMD -MT $@
 

--- a/hypervisor/scripts/genconf.sh
+++ b/hypervisor/scripts/genconf.sh
@@ -22,12 +22,11 @@ apply_patch () {
 tool_dir=${base_dir}/../misc/config_tools
 diffconfig_list=${out}/.diffconfig
 
-python3 ${tool_dir}/scenario_config/validator.py ${board_xml} ${scenario_xml} &&
 python3 ${tool_dir}/board_config/board_cfg_gen.py --board ${board_xml} --scenario ${scenario_xml} --out ${out} &&
 python3 ${tool_dir}/acpi_gen/asl_gen.py --board ${board_xml} --scenario ${scenario_xml} --out ${out}
-
-if [ $? -ne 0 ]; then
-    exit $?
+exitcode=$?
+if [ $exitcode -ne 0 ]; then
+    exit $exitcode
 fi
 
 if ! which xsltproc ; then

--- a/hypervisor/scripts/makefile/config.mk
+++ b/hypervisor/scripts/makefile/config.mk
@@ -150,10 +150,6 @@ ifdef RELEASE
   endif
 endif
 
-ifeq ($(findstring $(MAKECMDGOALS),distclean),)
--include $(HV_CONFIG_MK)
-endif
-
 # BOARD/SCENARIO/BOARD_FILE/SCENARIO_FILE parameters sanity check.
 #
 # 1. Raise an error if BOARD/SCENARIO (or BOARD_FILE/SCENARIO_FILE) are partially given.
@@ -188,9 +184,12 @@ endif
 # file. SCENARIO/SCENARIO_FILE are used in the same way. The following block translates the user-visible BOARD/SCENARIO
 # (which is multiplexed) to the internal representation.
 
+ifeq ($(findstring $(MAKECMDGOALS),distclean),)
+-include $(HV_CONFIG_MK)
 $(eval $(call determine_config,BOARD))
 $(eval $(call determine_config,SCENARIO))
 $(eval $(call determine_build_type,n))
+endif
 
 $(HV_BOARD_XML): $(BOARD_FILE)
 	@echo "Board XML is fetched from $(realpath $(BOARD_FILE))"

--- a/misc/hv_prebuild/Makefile
+++ b/misc/hv_prebuild/Makefile
@@ -14,8 +14,8 @@ ifeq ($(SCENARIO),)
     $(error please specify SCENARIO for the build!)
 endif
 
-ifeq ($(TARGET_DIR),)
-    $(error please specify VM configs directory! )
+ifeq ($(CHECKER_OUT),)
+    $(error please specify the path to the generated checker! )
 endif
 
 BOARD_INFO_DIR := $(HV_OBJDIR)/configs/boards
@@ -52,4 +52,4 @@ default: $(PRE_BUILD_SRCS)
 	else \
 		echo "Found $(BOARD) configuration for SCENARIO $(SCENARIO) under $(BOARD_CFG_DIR)"; \
 	fi;
-	$(CC) $(PRE_BUILD_SRCS) $(PRE_BUILD_INCLUDE) $(PRE_BUILD_CFLAGS) -o $(HV_OBJDIR)/hv_prebuild_check.out
+	$(CC) $(PRE_BUILD_SRCS) $(PRE_BUILD_INCLUDE) $(PRE_BUILD_CFLAGS) -o $(CHECKER_OUT)


### PR DESCRIPTION
Dependencies among targets in Makefiles today have the following issues:

  1. Phony targets are used for intermediate files. That causes unnecessary
     rebuilds of almost all sources even no source file is changed. As an
     example, invoke `make hypervisor-install` after `make hypervisor` will
     rebuild the hypervisor before the installation steps are carried out.

  2. Dependencies on validated XMLs are not stated explicitly. That causes
     random error messages (mostly Python stack traces) to be shown when
     invalid board or scenario XML is given in addition to the validation
     errors, which confuses users.

  3. Copied XMLs do not explicitly depend on user-given ones (when user
     specifies them) though they actually are. That prevents users from
     updating the board and/or scenario XMLs for an existing build without
     a fresh rebuild.

This patch series aims at solving the issues above by sorting out the
dependencies in the Makefile:

  * Patch 1 to 3 focuses on cleaning up unnecessary phony targets.

  * Patch 4 makes dependency on validated XMLs explicit.

  * Patch 5 updates dependency of board and scenario XMLs that are copied
    into the build directory.

  * Patch 6 cleans up unnecessary dependency of `clean`/`distclean` on the generated config files.