### PR TITLE
doc: grammar fixes

### DIFF
--- a/doc/developer-guides/hld/hld-devicemodel.rst
+++ b/doc/developer-guides/hld/hld-devicemodel.rst
@@ -567,7 +567,7 @@ MMIO Handler Register
 ---------------------
 
 An MMIO range structure is defined below. As with PIO, it's the
-parameter needed to register a MMIO handler for a special MMIO range:
+parameter needed to register an MMIO handler for a special MMIO range:
 
 .. code-block:: c
 

--- a/doc/developer-guides/hld/hv-dev-passthrough.rst
+++ b/doc/developer-guides/hld/hv-dev-passthrough.rst
@@ -255,7 +255,7 @@ MMIO Remapping
 
 For PCI MMIO BAR, the hypervisor builds EPT mapping between the virtual BAR and
 physical BAR, then the VM can access MMIO directly. There is one exception: an
-MSI-X table is also in a MMIO BAR. The hypervisor needs to trap the accesses to
+MSI-X table is also in an MMIO BAR. The hypervisor needs to trap the accesses to
 the MSI-X table. So the pages that have an MSI-X table should not be accessed by
 the VM directly. EPT mapping is not built for pages that have an MSI-X table.
 

--- a/doc/developer-guides/hld/hv-io-emulation.rst
+++ b/doc/developer-guides/hld/hv-io-emulation.rst
@@ -135,13 +135,13 @@ There are four types of I/O requests:
      - A port I/O access.
 
    * - MMIO
-     - A MMIO access to a GPA with no mapping in EPT.
+     - An MMIO access to a GPA with no mapping in EPT.
 
    * - PCI
      - A PCI configuration space access.
 
    * - WP
-     - A MMIO access to a GPA with a read-only mapping in EPT.
+     - An MMIO access to a GPA with a read-only mapping in EPT.
 
 
 For port I/O accesses, the hypervisor will always deliver an I/O request
@@ -293,7 +293,7 @@ The following structure represents a port I/O handler:
 .. doxygenstruct:: vm_io_handler_desc
    :project: Project ACRN
 
-The following structure represents a MMIO handler.
+The following structure represents an MMIO handler.
 
 .. doxygenstruct:: mem_io_node
    :project: Project ACRN

--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -254,7 +254,7 @@ Here are descriptions for each of these ``acrn-dm`` command-line parameters:
 
       --mmiodev_pt 0xFED40000,0x00005000
 
-   to pass through a MMIO device to a User VM.  The MMIO device has a MMIO
+   to pass through an MMIO device to a User VM.  The MMIO device has an MMIO
    region.  The base address of this region is 0xFED40000 and the size of the
    region is 0x00005000.
 


### PR DESCRIPTION
fixing some grammar issues in documentation

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>