### PR TITLE
hv: vPCI: fix large bar base update

### DIFF
--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -38,6 +38,7 @@
 
 struct pci_vbar {
 	bool is_mem64hi;	/* this is to indicate the high part of 64 bits MMIO bar */
+	bool sizing;		/* this is to indicate the guest is sizing this BAR */
 	uint64_t size;		/* BAR size */
 	uint64_t base_gpa;	/* BAR guest physical address */
 	uint64_t base_hpa;	/* BAR host physical address */


### PR DESCRIPTION
The current code would write 'BAR address & size_maks' into PCIe virtual BAR before updating the virtual BAR's base address when guest writing a PCIe device's BAR. If the size of a PCIe device's BAR is larger than 4G, the low 32 bits size_mask for this 64 bits BAR is zero. When ACRN updating the virtual BAR's base address, the low 32 bits sizing information would be lost.

This patch saves whether a BAR writing is sizing or not before updating the virtual BAR's base address.

Tracked-On: #8267
Signed-off-by: Fei Li <fei1.li@intel.com>