### PR TITLE
config-tools: clean up the vm names which do not exist

### DIFF
--- a/misc/config_tools/configurator/pyodide/populateDefaultValues.py
+++ b/misc/config_tools/configurator/pyodide/populateDefaultValues.py
@@ -37,6 +37,15 @@ def main(scenario):
             schema_path=scenario_xml_schema_path,
         )
         pipeline.run(obj)
+
+        # Clean up the VM_NAME and/or vm_name which does not exist
+        etree = obj.get("scenario_etree").getroot()
+        vmNames = [name.text for name in etree.findall(".//vm/name")]
+        for name in etree.findall(".//IVSHMEM_VM/VM_NAME") + \
+            etree.findall(".//vuart_connection/endpoint/vm_name"):
+            if name.text not in vmNames:
+                name.text = ""
+
         result = tostring(obj.get("scenario_etree").getroot())
         result = result.decode()
     result = convert_result({


### PR DESCRIPTION
Clean up vm_name of vuart and/or VM_NAME of IVSHMEM which is not defined in //vm/name while loading scenario XML.

Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>
Rviewed-by: Junjie Mao <junjie.mao@intel.com>
Tracked-On: #8270