### PR TITLE
doc: handle anonymous complex types in XML schema

### DIFF
--- a/doc/scripts/configdoc.xsl
+++ b/doc/scripts/configdoc.xsl
@@ -61,7 +61,7 @@
     <xsl:choose>
       <!-- don't document elements if not viewable -->
       <xsl:when test="$views='' and $showHidden='n'"/>
-      <xsl:when test="//xs:complexType[@name=$ty]">
+      <xsl:when test="//xs:complexType[@name=$ty] or ./xs:complexType">
         <!-- The section header -->
           <xsl:if test="$level &lt;= 4">
               <xsl:if test="$dxnamePure!=''">
@@ -81,7 +81,7 @@
                   </xsl:if>
         </xsl:if>
         <!-- Visit the complex type to generate menus and/or entries -->
-        <xsl:apply-templates select="//xs:complexType[@name=$ty]">
+        <xsl:apply-templates select="//xs:complexType[@name=$ty] | ./xs:complexType">
           <xsl:with-param name="level" select="$level"/>
           <xsl:with-param name="name" select="concat($prefix, $dxname)"/>
           <xsl:with-param name="views-of-parent" select="$views"/>
@@ -189,7 +189,7 @@
         <xsl:otherwise><xsl:value-of select="$level + 1"/></xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
-    <xsl:apply-templates select="descendant::xs:element">
+    <xsl:apply-templates select="./*/xs:element">
       <xsl:with-param name="level" select="$newLevel"/>
       <xsl:with-param name="prefix" select="concat($name, '.')"/>
       <xsl:with-param name="views-of-parent" select="$views-of-parent"/>


### PR DESCRIPTION
The schema of scenario XMLs uses both named and anonymous complex types, but the configdoc.xsl today only works for named complex types. That causes improper rendering of config items related to virtio devices (whose schema uses anonymous types) as well as wrong applicable VM icons which states that virtio devices apply to not only post-launched VMs but also pre-launched and service VM, which does not make sense.

This patch improves configdoc.xsl by adding support of anonymous complex types so that they are walked through in the same way as named ones.

Signed-off-by: Junjie Mao <junjie.mao@intel.com>