### PR TITLE
config-tools: optional VirtioGPUConfiguration

### DIFF
--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -373,7 +373,7 @@ def generate_for_one_vm(board_etree, hv_scenario_etree, vm_scenario_etree, vm_id
             script.add_virtual_device("virtio-blk", options=os.path.join(f"${{{var}}}", rootfs_img))
             script.add_deinit_command(f"unmount_partition ${{{var}}}")
 
-    for gpu_etree in eval_xpath_all(vm_scenario_etree, ".//virtio_devices/gpu"):
+    for gpu_etree in eval_xpath_all(vm_scenario_etree, ".//virtio_devices/gpu[./display_type]"):
         display_type = eval_xpath(gpu_etree, "./display_type[text() != '']/text()")
         params = list()
         for display_etree in eval_xpath_all(gpu_etree, "./displays/display"):

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -440,12 +440,12 @@ The size is a subset of the VM's total memory size specified on the Basic tab.</
 
 <xs:complexType name="VirtioGPUConfiguration">
   <xs:all>
-    <xs:element name="display_type" type="VirtioGPUDisplayType">
+    <xs:element name="display_type" type="VirtioGPUDisplayType" minOccurs="0">
       <xs:annotation acrn:title="Display type">
         <xs:documentation>Display type provide virtual display for user vm with either full screen mode or virtual window mode.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="displays" type="DisplaysConfiguration"/>
+    <xs:element name="displays" type="DisplaysConfiguration" minOccurs="0"/>
   </xs:all>
 </xs:complexType>
 

--- a/misc/config_tools/schema/checks/virtio_devices.xsd
+++ b/misc/config_tools/schema/checks/virtio_devices.xsd
@@ -14,6 +14,14 @@
     </xs:annotation>
   </xs:assert>
 
+  <xs:assert test="every $vm in /acrn-config/vm[./virtio_devices/gpu/display_type] satisfies
+                   $vm/virtio_devices/gpu/display_type/text() != ''
+                   ">
+    <xs:annotation acrn:severity="error" acrn:report-on="$vm">
+      <xs:documentation>Select a display type of VM "{$vm/name}".</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
   <xs:assert test="every $vm in /acrn-config/vm[./virtio_devices/gpu[display_type = 'Full screen']] satisfies
                    $vm/virtio_devices/gpu/displays/display/monitor_id/text() != ''
                    ">


### PR DESCRIPTION
Any required elements in VMtypes.xsd will be present in first time generated scenario XML. However, not every vm needs gpu configuraition. Add minOccurs="0" to all VirtioGPUConfiguration elements and assertion to check if the essential elements are configurated properly.

Signed-off-by: yuchuyang <yu-chu.yang@intel.com>
Tracked-On: #7970