### PR TITLE
hv: hide mwait from guest.

### DIFF
--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -545,6 +545,9 @@ int32_t set_vcpuid_entries(struct acrn_vm *vm)
 					}
 				}
 				break;
+			/* MONITOR/MWAIT */
+			case 0x05U:
+				break;
 			case 0x07U:
 				init_vcpuid_entry(i, 0U, CPUID_CHECK_SUBLEAF, &entry);
 				if (entry.eax != 0U) {
@@ -554,6 +557,7 @@ int32_t set_vcpuid_entries(struct acrn_vm *vm)
 				if (is_vsgx_supported(vm->vm_id)) {
 					entry.ebx |= CPUID_EBX_SGX;
 				}
+				entry.ecx &= ~CPUID_ECX_WAITPKG;
 
 #ifdef CONFIG_VCAT_ENABLED
 				if (is_vcat_configured(vm)) {
@@ -618,7 +622,6 @@ int32_t set_vcpuid_entries(struct acrn_vm *vm)
 static void guest_cpuid_01h(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx, uint32_t *ecx, uint32_t *edx)
 {
 	uint32_t apicid = vlapic_get_apicid(vcpu_vlapic(vcpu));
-	uint64_t guest_ia32_misc_enable = vcpu_get_guest_msr(vcpu, MSR_IA32_MISC_ENABLE);
 	uint64_t cr4_reserved_mask = get_cr4_reserved_bits();
 
 	cpuid_subleaf(0x1U, 0x0U, eax, ebx, ecx, edx);
@@ -651,15 +654,10 @@ static void guest_cpuid_01h(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx
 		*ecx &= ~CPUID_ECX_PCID;
 	}
 
-	/* guest monitor/mwait is supported only if it is allowed('vm_mwait_cap' is true)
-	 * and MSR_IA32_MISC_ENABLE_MONITOR_ENA bit of guest MSR_IA32_MISC_ENABLE is set,
-	 * else clear cpuid.01h[3].
+	/*
+	 * Hide MONITOR/MWAIT.
 	 */
 	*ecx &= ~CPUID_ECX_MONITOR;
-	if (vcpu->vm->arch_vm.vm_mwait_cap &&
-		((guest_ia32_misc_enable & MSR_IA32_MISC_ENABLE_MONITOR_ENA) != 0UL)) {
-		*ecx |= CPUID_ECX_MONITOR;
-	}
 
 	*ecx &= ~CPUID_ECX_OSXSAVE;
 	if ((*ecx & CPUID_ECX_XSAVE) != 0U) {

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -738,7 +738,6 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 		spinlock_init(&vm->arch_vm.iwkey_backup_lock);
 
 		vm->arch_vm.vlapic_mode = VM_VLAPIC_XAPIC;
-		vm->arch_vm.vm_mwait_cap = has_monitor_cap();
 		vm->intr_inject_delay_delta = 0UL;
 		vm->nr_emul_mmio_regions = 0U;
 		vm->vcpuid_entry_nr = 0U;

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -40,6 +40,7 @@ static int32_t hlt_vmexit_handler(struct acrn_vcpu *vcpu);
 static int32_t mtf_vmexit_handler(struct acrn_vcpu *vcpu);
 static int32_t loadiwkey_vmexit_handler(struct acrn_vcpu *vcpu);
 static int32_t init_signal_vmexit_handler(__unused struct acrn_vcpu *vcpu);
+static int32_t mwait_monitor_vmexit_handler (struct acrn_vcpu *vcpu);
 
 /* VM Dispatch table for Exit condition handling */
 static const struct vm_exit_dispatch dispatch_table[NR_VMX_EXIT_REASONS] = {
@@ -151,11 +152,11 @@ static const struct vm_exit_dispatch dispatch_table[NR_VMX_EXIT_REASONS] = {
 	[VMX_EXIT_REASON_ENTRY_FAILURE_MSR_LOADING] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_MWAIT] = {
-		.handler = unhandled_vmexit_handler},
+		.handler = mwait_monitor_vmexit_handler},
 	[VMX_EXIT_REASON_MONITOR_TRAP] = {
 		.handler = mtf_vmexit_handler},
 	[VMX_EXIT_REASON_MONITOR] = {
-		.handler = unhandled_vmexit_handler},
+		.handler = mwait_monitor_vmexit_handler},
 	[VMX_EXIT_REASON_PAUSE] = {
 		.handler = pause_vmexit_handler},
 	[VMX_EXIT_REASON_ENTRY_FAILURE_MACHINE_CHECK] = {
@@ -285,6 +286,16 @@ int32_t vmexit_handler(struct acrn_vcpu *vcpu)
 	console_vmexit_callback(vcpu);
 
 	return ret;
+}
+
+static int32_t mwait_monitor_vmexit_handler (struct acrn_vcpu *vcpu)
+{
+	pr_fatal("Error: Unsupported mwait option from guest at 0x%016lx ",
+		exec_vmread(VMX_GUEST_RIP));
+
+	vcpu_inject_ud(vcpu);
+
+	return 0;
 }
 
 static int32_t unhandled_vmexit_handler(struct acrn_vcpu *vcpu)

--- a/hypervisor/include/arch/x86/asm/cpuid.h
+++ b/hypervisor/include/arch/x86/asm/cpuid.h
@@ -42,6 +42,8 @@
 #define CPUID_ECX_OSXSAVE       (1U<<27U)
 #define CPUID_ECX_AVX           (1U<<28U)
 #define CPUID_ECX_HV            (1U<<31U)
+#define CPUID_ECX_MWAIT	(1U<<0U)
+#define CPUID_ECX_MWAIT_INT	(1U<<1U)
 #define CPUID_EDX_FPU           (1U<<0U)
 #define CPUID_EDX_VME           (1U<<1U)
 #define CPUID_EDX_DE            (1U<<2U)
@@ -100,6 +102,8 @@
 #define CPUID_ECX_UMIP		(1U<<2U)
 /* CPUID.07H:ECX.PKE */
 #define CPUID_ECX_PKE		(1U<<3U)
+/* CPUID.07H:ECX.WAITPKG */
+#define CPUID_ECX_WAITPKG		(1U<<5U)
 /* CPUID.07H:ECX.CET_SS */
 #define CPUID_ECX_CET_SS        (1U<<7U)
 /* CPUID.07H:ECX.LA57 */

--- a/hypervisor/include/arch/x86/asm/guest/vm.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm.h
@@ -131,8 +131,6 @@ struct vm_arch {
 	spinlock_t iwkey_backup_lock;	/* Spin-lock used to protect internal key backup/restore */
 	struct iwkey iwkey_backup;
 
-	/* reference to virtual platform to come here (as needed) */
-	bool vm_mwait_cap;
 } __aligned(PAGE_SIZE);
 
 struct acrn_vm {


### PR DESCRIPTION
When CPU support MONITOR/MWAIT, OS prefer to use it enter deeper C-state.

Now ACRN pass through MONITOR/MWAIT to guest.

For vCPUs (ie vCPU A and vCPU B) share a pCPU, if vCPU A uses MWait to enter C state, vCPU B could run only after the time slice of vCPU A is expired. This time slice of vCPU A is gone to waste.

For Local APIC pass-through (used for RTVM), the guest pay more attention to timeliness than power saving.

So this patch hides MONITOR/MWAIT by:
    1. Clear vCPUID.05H, vCPUID.01H:ECX.[bit 3] and
    MSR_IA32_MISC_ENABLE_MONITOR_ENA to tell the guest VM's vCPU
    does not support MONITOR/MAIT.
    2. Enable MSR_IA32_MISC_ENABLE_MONITOR_ENA bit for
    MSR_IA32_MISC_ENABLE inject 'GP'.
    3. Trap instruction 'MONITOR' and 'MWAIT' and inject 'UD'.
    4. Clear vCPUID.07H:ECX.[bit 5] to hide 'UMONITOR/UMWAIT'.
    5. Clear  "enable user wait and pause" VM-execution control, so
    UMONITOR/MWAIT causes an 'UD'.

Tracked-On: #8253
Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>
Reviewed-by: Fei Li <fei1.li@intel.com>