### PR TITLE
misc: Update CODEOWNER for doc reviewer changed.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,7 @@
 Makefile                                 @terryzouhao @NanlinXie
 /hypervisor/                             @dongyaozu @lifeix
 /devicemodel/                            @ywan170
-/doc/                                    @dbkinder @amyreye @NanlinXie
+/doc/                                    @dbkinder @NanlinXie
 /misc/debug_tools/acrn_crashlog/         @ywan170 @lifeix
 /misc/debug_tools/acrn_log/              @ywan170 @lifeix
 /misc/debug_tools/acrn_trace/            @ywan170 @lifeix
@@ -27,4 +27,4 @@ Makefile                                 @terryzouhao @NanlinXie
 /misc/packaging/                         @terryzouhao @NanlinXie
 /misc/hv_prebuild/                       @terryzouhao @NanlinXie
 
-*.rst                                    @dbkinder @amyreye @NanlinXie
+*.rst                                    @dbkinder @NanlinXie


### PR DESCRIPTION
misc: Update CODEOWNER for doc reviewer changed.

Tracked-On: #5581
Signed-off-by: Xie, nanlin <nanlin.xie@intel.com>