### PR TITLE
doc: update doc build requirements

### DIFF
--- a/doc/scripts/requirements.txt
+++ b/doc/scripts/requirements.txt
@@ -1,5 +1,5 @@
 breathe>=4.23
 sphinx>=3.2.1,<6.0
-docutils>=0.16,<=0.17.1
-sphinx_rtd_theme==1.0.0
+docutils>=0.16,<0.18
+sphinx_rtd_theme>=1.0.0,<=1.1.0
 sphinx-tabs>=1.3.0,<=3.4.0


### PR DESCRIPTION
Verified that the newly released RTD theme is OK to use with the doc build process, so update the requirements.txt with that and tweak the acceptable docutils versions.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>