### PR TITLE
config-tools: re-rendering the data after importing different board XML

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -173,6 +173,7 @@ export default {
       this.schemas = scenarioJSONSchema
       this.updateCurrentFormSchema()
       this.updateCurrentBoardInfo()
+      this.switchTab(-1)
     },
     updateCurrentFormSchema() {
       if (this.activeVMID === -1) {


### PR DESCRIPTION
Switch tag in order to trigger the component re-rendering after importing different board XML.

Tracked-On: #8288
Signed-off-by: Yang, Yu-chu <yu-chu.yang@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>