### PR TITLE
config_tools: add own_pcpu widget

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/cpu_affinity.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/cpu_affinity.vue
@@ -3,6 +3,26 @@
     <b>{{ uiOptions.title }}</b>
     <div class="p-4">
       <div v-if="defaultVal.pcpu && defaultVal.pcpu.length>0">
+        <b-row v-if="is_std_vm">
+          <label>
+            <n-popover trigger="hover" placement="top-start" style="width: 500px">
+              <template #trigger>
+                <IconInfo/>
+              </template>
+              <span> Enable a VM exclusively owns the physical CPUs assigned to it. </span>
+            </n-popover>
+          Exclusively owns physical CPUs: </label>
+          <b-col>own_pcpu</b-col>
+          <b-col>
+            <b-form-checkbox v-model="pcpu_owned" :value="'y'" :uncheckedValue="'n'"
+              @click="click_own_pcpu"
+            >
+            </b-form-checkbox>
+          </b-col>
+          <b-col></b-col>
+          <b-col></b-col>
+          <b-col></b-col>
+        </b-row>
         <b-row>
           <b-col></b-col>
           <b-col></b-col>
@@ -119,8 +139,14 @@ export default {
     isRTVM() {
       return vueUtils.getPathVal(this.rootFormData, 'vm_type') === 'RTVM'
     },
+    is_std_vm() {
+      return vueUtils.getPathVal(this.rootFormData, 'vm_type') === 'STANDARD_VM'
+    },
     pcpuid_enum() {
       return window.getCurrentFormSchemaData().BasicConfigType.definitions.CPUAffinityConfiguration.properties.pcpu_id
+    },
+    pcpu_owned() {
+      return vueUtils.getPathVal(this.rootFormData, 'own_pcpu')
     },
     uiOptions() {
       return formUtils.getUiOptions({
@@ -150,6 +176,10 @@ export default {
     },
     addPCPU(index) {
       this.defaultVal.pcpu.splice(index + 1, 0, {pcpu_id: null, real_time_vcpu: "n"})
+    },
+    click_own_pcpu() {
+      let newValue = this.pcpu_owned === 'y' ? 'n' : 'y';
+      vueUtils.setPathVal(this.rootFormData, 'own_pcpu', newValue)
     },
     removePCPU(index) {
       if (this.defaultVal.pcpu.length === 1) {

--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -260,6 +260,7 @@ def generate_for_one_vm(board_etree, hv_scenario_etree, vm_scenario_etree, vm_id
         script.add_plain_dm_parameter("--windows")
     script.add_vm_descriptor("vm_type", f"'{eval_xpath(vm_scenario_etree, './/vm_type/text()', 'STANDARD_VM')}'")
     script.add_vm_descriptor("scheduler", f"'{eval_xpath(hv_scenario_etree, './/SCHEDULER/text()')}'")
+    script.add_vm_descriptor("own_pcpu", f"'{eval_xpath(vm_scenario_etree, './/own_pcpu/text()')}'")
 
     ###
     # CPU and memory resources

--- a/misc/config_tools/launch_config/launch_script_template.sh
+++ b/misc/config_tools/launch_config/launch_script_template.sh
@@ -19,11 +19,15 @@ function offline_cpus() {
         if [ -z ${processor_id} ]; then
             continue
         fi
+        if [ "${processor_id}" = "0" ]; then
+            echo "Warning: processor 0 can't be offline, there may be unexpect error!" >> /dev/stderr
+            continue
+        fi
         cpu_path="/sys/devices/system/cpu/cpu${processor_id}"
         if [ -f ${cpu_path}/online ]; then
             online=`cat ${cpu_path}/online`
             echo cpu${processor_id} online=${online} >> /dev/stderr
-            if [ "${online}" = "1" ] && [ "${processor_id}" != "0" ]; then
+            if [ "${online}" = "1" ]; then
                 echo 0 > ${cpu_path}/online
                 online=`cat ${cpu_path}/online`
                 # during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
@@ -90,7 +94,7 @@ function add_cpus() {
     # Each parameter of this function is considered the apicid of processor (as is reported in /proc/cpuinfo) of
     # a CPU assigned to a post-launched RTVM.
 
-    if [ "${vm_type}" = "RTVM" ] || [ "${scheduler}" = "SCHED_NOOP" ]; then
+    if [ "${vm_type}" = "RTVM" ] || [ "${scheduler}" = "SCHED_NOOP" ] || [ "${own_pcpu}" = "y" ]; then
         offline_cpus $*
     fi
 

--- a/misc/config_tools/schema/checks/cpu_assignment.xsd
+++ b/misc/config_tools/schema/checks/cpu_assignment.xsd
@@ -25,6 +25,13 @@
     </xs:annotation>
   </xs:assert>
 
+  <xs:assert test="every $pcpu in /acrn-config/vm[own_pcpu = 'y']//cpu_affinity//pcpu_id satisfies
+                   count(/acrn-config/vm[@id != $pcpu/ancestor::vm//companion_vmid]//cpu_affinity[.//pcpu_id = $pcpu]) &lt;= 1">
+    <xs:annotation acrn:severity="error" acrn:report-on="//vm//cpu_affinity[.//pcpu_id = $pcpu]">
+      <xs:documentation>Physical CPU {$pcpu} is assigned to a VM "[{$pcpu/ancestor::vm/name}]" exclusively owns the physical CPUs assigned to it. Look for, and probably remove, any affinity assignments to CPU {$pcpu} in these VMs {//vm[cpu_affinity//pcpu_id = $pcpu and name != $pcpu/ancestor::vm/name]/name} settings.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
   <xs:assert test="every $vm in /acrn-config/vm[load_order != 'SERVICE_VM'] satisfies
                    count($vm/cpu_affinity/pcpu[pcpu_id != '']) > 0">
   <xs:annotation acrn:severity="error" acrn:report-on="$vm/cpu_affinity">

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -370,6 +370,11 @@ These settings can only be changed at build time.</xs:documentation>
       <xs:annotation acrn:title="" acrn:views="basic, advanced" acrn:applicable-vms="pre-launched, post-launched">
       </xs:annotation>
     </xs:element>
+    <xs:element name="own_pcpu" type="Boolean" default="n">
+      <xs:annotation acrn:title="Exclusively owns physical CPUs" acrn:views="">
+        <xs:documentation>Enable a VM exclusively owns the physical CPUs assigned to it.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
     <xs:element name="cpu_affinity" type="CPUAffinityConfigurations" minOccurs="0">
       <xs:annotation acrn:title="Physical CPU affinity" acrn:views="basic" acrn:applicable-vms="pre-launched, post-launched">
         <xs:documentation>Select a subset of physical CPUs that this VM can use. More than one can be selected.</xs:documentation>


### PR DESCRIPTION
Add "exclusively owns physical CPUs" checkbox to pre-launched VMs
and post-launched VMs. RTVM will not display this checkbox.
If this checkbox is set, the VM will use all the pCPUs assigned to
it alone.

Launch script offline SOS vcpu when launch own pCPU VM. 