### PR TITLE
config-tools: fix virio GPU rendering issue

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
@@ -93,7 +93,7 @@ export default {
             'ui:field': Input,
           },
           "gpu": {
-            "ui:title": "Virtio GPU device",
+            "ui:title": "",
             "ui:field": GPU,
           },
         },

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/Virtio/GPU.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/Virtio/GPU.vue
@@ -1,8 +1,8 @@
 <template>
   <div><br><b>Virtio GPU device</b></div>
   <div><br><span v-html="this.GPUDescription" style="color: rgb(153, 153, 153)"></span></div>
-  <div class="virtio_gpu" v-if="defaultVal && defaultVal.displays.display.length !== 0">
-    <div class="virtio_gpu_demo">
+  <div class="virtio_gpu" v-if="defaultVal && defaultVal.length>0">
+    <div class="virtio_gpu_demo" v-for="(virtio_gpu, index) in defaultVal">
       <b style="margin-bottom: 2rem">Virtual displays</b>
       <b-row class="align-items-center my-2 mt-4">
         <b-col md="2">
@@ -17,21 +17,21 @@
           </label>
         </b-col>
         <b-col md="4">
-          <b-form-select v-model="defaultVal.display_type" :options="GPUDisplayType"/>
+          <b-form-select v-model="virtio_gpu.display_type" :options="GPUDisplayType"/>
         </b-col>
       </b-row>
-      <div class="align-items-center my-2 mt-4" v-if="defaultVal.display_type === 'Window'"
-           v-for="(window_display, index) in defaultVal.displays.display">
+      <div class="align-items-center my-2 mt-4" v-if="virtio_gpu.display_type === 'Window'"
+           v-for="(window_display, window_index) in virtio_gpu.displays.display">
         <div style="float: left; text-indent: 2em;">
-          <b>Display {{ index + 1 }}</b>
+          <b>Display {{ window_index + 1 }}</b>
         </div>
         <div class="ToolSet" style="float: right;">
-          <div @click="removeDisplay(defaultVal.displays.display, index)">
+          <div @click="removeDisplay(virtio_gpu.displays.display, window_index)">
             <Icon size="18px">
               <Minus/>
             </Icon>
           </div>
-          <div @click="addWindowDisplay(defaultVal.displays.display, index)">
+          <div @click="addWindowDisplay(virtio_gpu.displays.display, window_index)">
             <Icon size="18px">
               <Plus/>
             </Icon>
@@ -90,18 +90,18 @@
         </div>
       </div>
 
-      <div class="align-items-center my-2 mt-4" v-else-if="defaultVal.display_type === 'Full screen'"
-           v-for="(fullScreen_display, index) in defaultVal.displays.display">
+      <div class="align-items-center my-2 mt-4" v-else-if="virtio_gpu.display_type === 'Full screen'"
+           v-for="(fullScreen_display, fullScreen_display_index) in virtio_gpu.displays.display">
         <div style="float: left; text-indent: 2em;">
           <b>Display {{ index + 1 }}</b>
         </div>
         <div class="ToolSet" style="float: right;">
-          <div @click="removeDisplay(defaultVal.displays.display, index)">
+          <div @click="removeDisplay(virtio_gpu.displays.display, fullScreen_display_index)">
             <Icon size="18px">
               <Minus/>
             </Icon>
           </div>
-          <div @click="addFullScreenDisplay(defaultVal.displays.display, index)">
+          <div @click="addFullScreenDisplay(virtio_gpu.displays.display, fullScreen_display_index)">
             <Icon size="18px">
               <Plus/>
             </Icon>
@@ -213,10 +213,13 @@ export default {
       display.splice(index, 1)
     },
     removeVirtioGPU() {
-      this.defaultVal = null
+      this.defaultVal = []
     },
     addVirtioGPU() {
-      this.defaultVal = {
+      if (!_.isArray(this.defaultVal)) {
+        this.defaultVal = []
+      }
+      this.defaultVal.splice(1, 0, {
         "display_type": "",
         "displays": {
           "display": [
@@ -228,7 +231,7 @@ export default {
             }
           ]
         }
-      }
+      })
     }
   }
 }

--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -373,7 +373,7 @@ def generate_for_one_vm(board_etree, hv_scenario_etree, vm_scenario_etree, vm_id
             script.add_virtual_device("virtio-blk", options=os.path.join(f"${{{var}}}", rootfs_img))
             script.add_deinit_command(f"unmount_partition ${{{var}}}")
 
-    for gpu_etree in eval_xpath_all(vm_scenario_etree, ".//virtio_devices/gpu"):
+    for gpu_etree in eval_xpath_all(vm_scenario_etree, ".//virtio_devices/gpu[./display_type]"):
         display_type = eval_xpath(gpu_etree, "./display_type[text() != '']/text()")
         params = list()
         for display_etree in eval_xpath_all(gpu_etree, "./displays/display"):

--- a/misc/config_tools/schema/checks/virtio_devices.xsd
+++ b/misc/config_tools/schema/checks/virtio_devices.xsd
@@ -23,7 +23,17 @@
   </xs:assert>
 
   <xs:assert test="every $vm in /acrn-config/vm[./virtio_devices/gpu[display_type = 'Window']] satisfies
-                   $vm/virtio_devices/gpu/displays/display/window_resolutions/text() != ''
+                   (count($vm//window_resolutions) = count($vm//horizontal_offset)
+                   and count($vm//window_resolutions) = count($vm//vertical_offset)
+                   and count($vm//horizontal_offset) = count($vm//vertical_offset))
+                   ">
+    <xs:annotation acrn:severity="error" acrn:report-on="$vm">
+      <xs:documentation>VM "{$vm/name}": every display's window resolution, horizontal offset and vertical offset are required.</xs:documentation>
+    </xs:annotation>
+  </xs:assert>
+
+  <xs:assert test="every $vm in /acrn-config/vm[./virtio_devices/gpu[display_type = 'Window']] satisfies
+                   $vm/virtio_devices/gpu/displays/display//window_resolutions/text() != ''
                    ">
     <xs:annotation acrn:severity="error" acrn:report-on="$vm">
       <xs:documentation>VM "{$vm/name}": window resolution is required for "window" virtual display.</xs:documentation>
@@ -31,7 +41,7 @@
   </xs:assert>
 
   <xs:assert test="every $vm in /acrn-config/vm[./virtio_devices/gpu[display_type = 'Window']] satisfies
-                   $vm/virtio_devices/gpu/displays/display/horizontal_offset/text() != ''
+                   $vm/virtio_devices/gpu/displays/display//horizontal_offset/text() != ''
                    ">
     <xs:annotation acrn:severity="error" acrn:report-on="$vm">
       <xs:documentation>VM "{$vm/name}": horizontal offset (pixels) is required for "window" virtual displays.</xs:documentation>
@@ -39,11 +49,10 @@
   </xs:assert>
 
     <xs:assert test="every $vm in /acrn-config/vm[./virtio_devices/gpu[display_type = 'Window']] satisfies
-                     $vm/virtio_devices/gpu/displays/display/vertical_offset/text() != ''
+                     $vm/virtio_devices/gpu/displays/display//vertical_offset/text() != ''
                      ">
     <xs:annotation acrn:severity="error" acrn:report-on="$vm">
-      <xs:documentation>VM "{$vm/name}" support 2 virtual windows at most. 
-Remove some of the virtual displays so that the total number does not exceed that limit.</xs:documentation>
+      <xs:documentation>VM "{$vm/name}": vertical offset (pixels) is required for "window" virtual displays.</xs:documentation>
     </xs:annotation>
   </xs:assert>
 

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -473,7 +473,7 @@ argument and memory.</xs:documentation>
       </xs:annotation>
       <xs:complexType>
         <xs:all>
-          <xs:element name="gpu" type="VirtioGPUConfiguration" minOccurs="0">
+          <xs:element name="gpu" type="VirtioGPUConfiguration" minOccurs="0" maxOccurs="1">
             <xs:annotation acrn:title="Virtio GPU device" acrn:views="basic">
               <xs:documentation>The virtio GPU device presents a GPU device to the VM.
 This feature enables you to view the VM's GPU output in the Service VM.</xs:documentation>


### PR DESCRIPTION
Fix the following issues:
1. <gpu> and <displays> elements are added to scenario XML when they are not configured.
2. Virtio GPU components disappears after switching to another tab and switching back to previous tab.
3. Wrong error message of vertical offset checking.

Improve the error check in virtio_devices.xsd:
1. Every window virtual display need to configure window resolution, horizontal offset and vertical offset.
2. Any display's elements need to be configured. The existing code only check the first window resolution, horizontal offset, vertical offset and monitor id.

v1->v2
1. make gpu an array with maxOccurs="1".

Signed-off-by: yuchuyang <yu-chu.yang@intel.com>
Tracked-On: #8292