### PR TITLE
debian/rules: adapt to configurator-generated work folders

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -64,7 +64,9 @@ $(eval $(if $(board),                                                           
     $(eval boardlist := $(sort $(boardlist) $(board)))                                    \
     $(foreach f,$(wildcard $(addprefix $(dir $1),*)),                                     \
         $(if $(strip $(shell xmllint --xpath '/acrn-config/@board' $f 2>/dev/null)),,     \
-            $(eval scenario = $(basename $(notdir $f)))                                   \
+            $(if $(subst scenario.xml,,$(notdir $f)),                                     \
+                $(eval scenario = $(basename $(notdir $f))),                              \
+                $(eval scenario = $(notdir $(abspath $(dir $f)))))                        \
             $(eval config_$(board)_$(scenario) := $f)                                     \
             $(eval scenariolist_$(board) := $(sort $(scenariolist_$(board)) $(scenario))) \
         )                                                                                 \


### PR DESCRIPTION
When building debian packages using one or more work folders generated by the configurator, the build system will use the name of the work folder as the scenario name because the configurator always names a scenario XML as 'scenario.xml'. Scenario names are important here because:

  1. they are used to name the installed hypervisor binaries and map files, and the postinst scripts will use those names to fetch the right binary to put under /boot.

  2. when multiple work folders defining different scenarios on the same board is given, use the basename of the scenario XMLs leads to a name conflict.

Not following the same scenario name derivation rule in debian/rule will prevent a proper hypervisor binary to be put under /boot and lead to boot-time failure. The potential scenario name collisions can also cause unintended binaries to be installed.

This patch updates debian/rules to follow the same scenario name derivation rules as the build system is using.

Tracked-On: #8301
Signed-off-by: Junjie Mao <junjie.mao@intel.com>