### PR TITLE
 hv: change the version format

### DIFF
--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -738,8 +738,8 @@ static int32_t shell_version(__unused int32_t argc, __unused char **argv)
 {
 	char temp_str[MAX_STR_SIZE];
 
-	snprintf(temp_str, MAX_STR_SIZE, "HV %s-%s-%s %s (daily tag: %s) %s@%s build by %s%s\nAPI %u.%u\r\n",
-		HV_FULL_VERSION, HV_BUILD_TIME, HV_BUILD_VERSION, HV_BUILD_TYPE, HV_DAILY_TAG, HV_BUILD_SCENARIO,
+        snprintf(temp_str, MAX_STR_SIZE, "HV %s-%s-%s %s %s@%s build by %s%s\nAPI %u.%u\r\n",
+		HV_FULL_VERSION, HV_BUILD_TIME, HV_BUILD_VERSION, HV_BUILD_TYPE, HV_BUILD_SCENARIO,
 		HV_BUILD_BOARD, HV_BUILD_USER, HV_CONFIG_TOOL, HV_API_MAJOR_VERSION, HV_API_MINOR_VERSION);
 	shell_puts(temp_str);
 


### PR DESCRIPTION
hv: modify the version info

The daily tag should be the latest git-tag. And this tag name is also showed in the head of version-string. The content of daily tag is redundant, also a wrong daily tag name was fetched in release3.0. This patch won't show the daily tag.

Tracked-On #8303
Signed-off-by: Zhang Wei <wei6.zhang@intel.com>