### PR TITLE
config_tools: add the dummy address to let anonymous trial of ACRN

### DIFF
--- a/debian/debian_build.sh
+++ b/debian/debian_build.sh
@@ -108,10 +108,11 @@ cd $SCRIPT_PATH/../
 source VERSION
 
 rm -rf debian/changelog
-export EMAIL=`git config --get user.email`
-if [ -z $EMAIL ]; then
-    echo "ERROR: please configure git with email address before running the build script: \"git config --global user.email email@address.com\""
-    exit 1
+if [ -z $EMAIL ] && [ -z $DEBEMAIL]; then
+  export DEBEMAIL=$(git config --get user.email)
+  if [ -z $DEBEMAIL ]; then
+    export DEBEMAIL="projectacrn@gmail.com"
+  fi
 fi
 gbp dch -S --git-log="-n 10" --id-length=10 --ignore-branch
 sed -i "s/unknown/$MAJOR_VERSION.$MINOR_VERSION$EXTRA_VERSION/g" debian/changelog


### PR DESCRIPTION
update the debian/debian_build.sh script to let the gbp dch to get the email address for debian/changlog from one of the 3 ways with priority from high to low: using environment variable 'EMAIL' or 'DEBEMAIL' if existed(this is actually gbp dch required), user.email in git config if existed(set user.email to environment variable 'EMAIL' or 'DEBEMAIL' for gbp dch), or using a dummy address "projectacrn@gmail.com".

Tracked-On: #8262
Signed-off-by: szhen11 <shuang.zheng@intel.com>