### PR TITLE
hv: change the version format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ ifneq ($(SCM_VERSION),)
 	SCM_VERSION := "-"$(SCM_VERSION)
 endif
 export FULL_VERSION=$(MAJOR_VERSION).$(MINOR_VERSION)$(EXTRA_VERSION)$(SCM_VERSION)
+ROMOTE_BRANCH := $(shell [ -d .git ] && git rev-parse --abbrev-ref HEAD)
+STABLE_STR := -stable
+ifeq ($(EXTRA_VERSION), -unstable)
+	STABLE_STR := -unstable
+endif
+export BRANCH_VERSION=$(ROMOTE_BRANCH)$(STABLE_STR)
 
 ifdef TARGET_DIR
   $(warning TARGET_DIR is obsoleted because generated configuration files are now stored in the build directory)

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -526,6 +526,12 @@ $(VERSION): $(HV_CONFIG_H)
 		PATCH="$(BUILD_VERSION)"; \
 		DAILY_TAG="$(BUILD_TAG)"; \
 	fi; \
+	COMMIT_ID=`git rev-parse --verify --short HEAD 2>/dev/null`;\
+	DIRTY= `git diff-index --name-only HEAD`;\
+	if [ -n "$$DIRTY" ];then COMMIT_DIRTY="$$COMMIT_ID-dirty";else COMMIT_DIRTY="$$COMMIT_ID";fi;\
+	COMMIT_TAGS=$$(git tag --points-at HEAD|tr -s "\n" " "); \
+	COMMIT_TAGS=$$(eval echo $$COMMIT_TAGS);\
+	COMMIT_TIME=$$(git log -1 --date=format:"%Y-%m-%d %T" --format=%cd); \
 	TIME=$$(date -u -d "@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" "+%F %T"); \
 	USER="$${USER:-$$(id -u -n)}"; \
 	if [ x$(CONFIG_RELEASE) = "xy" ];then BUILD_TYPE="REL";else BUILD_TYPE="DBG";fi;\
@@ -545,6 +551,10 @@ $(VERSION): $(HV_CONFIG_H)
 	echo "#define HV_BUILD_USER "\""$$USER"\""" >> $(VERSION);\
 	echo "#define HV_BUILD_SCENARIO "\"$(SCENARIO)\""" >> $(VERSION);\
 	echo "#define HV_BUILD_BOARD "\"$(BOARD)\""" >> $(VERSION);\
+	echo "#define HV_BRANCH_VERSION "\"$(BRANCH_VERSION)\""" >> $(VERSION);\
+	echo "#define HV_COMMIT_TAGS "\"$$COMMIT_TAGS\""" >> $(VERSION);\
+	echo "#define HV_COMMIT_TIME "\"$$COMMIT_TIME\""" >> $(VERSION);\
+	echo "#define HV_COMMIT_DIRTY "\""$$COMMIT_DIRTY"\""" >> $(VERSION);\
 	if [ "$(CONFIG_XML_ENABLED)" = "true" ]; then \
 		echo "#define HV_CONFIG_TOOL \" with acrn-config\"" >> $(VERSION);\
 	else	\

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -737,10 +737,15 @@ static int32_t shell_cmd_help(__unused int32_t argc, __unused char **argv)
 static int32_t shell_version(__unused int32_t argc, __unused char **argv)
 {
 	char temp_str[MAX_STR_SIZE];
+	char tag_str[TEMP_STR_SIZE] = HV_COMMIT_TAGS;
 
-	snprintf(temp_str, MAX_STR_SIZE, "HV %s-%s-%s %s (daily tag: %s) %s@%s build by %s%s\nAPI %u.%u\r\n",
-		HV_FULL_VERSION, HV_BUILD_TIME, HV_BUILD_VERSION, HV_BUILD_TYPE, HV_DAILY_TAG, HV_BUILD_SCENARIO,
-		HV_BUILD_BOARD, HV_BUILD_USER, HV_CONFIG_TOOL, HV_API_MAJOR_VERSION, HV_API_MINOR_VERSION);
+	if(tag_str[0] != '\0'){
+		snprintf(tag_str, TEMP_STR_SIZE, "(tag: %s)", HV_COMMIT_TAGS);
+		tag_str[TEMP_STR_SIZE-1] = '\0';
+	}
+	snprintf(temp_str, MAX_STR_SIZE, "%s-%s-%s %s%s %s@%s build by %s %s\r\n",
+		HV_BRANCH_VERSION, HV_COMMIT_TIME, HV_COMMIT_DIRTY, HV_BUILD_TYPE, tag_str,
+		HV_BUILD_SCENARIO, HV_BUILD_BOARD, HV_BUILD_USER, HV_BUILD_TIME);
 	shell_puts(temp_str);
 
 	return 0;


### PR DESCRIPTION
hv version info is used to tell the user when and where the hv is compiled and built, this change will make it easy to read and undersatnd.

It follows bellow format:
remote_branch-stable/unstable-acrn-commit_date-commit_id-dirty DBG(tag-current_commit_id) scenario@board build author date.
 An example can be as:
master-unstable-2022-11-14 12:03:51-6d57f8254-dirty DBG(tag: tag1 tag2) scenario3.1@my_desk_3.1 build by my_pc 2022-11-16 18:41:03

Tracked-On #8303
Signed-off-by: Zhang Wei wei6.zhang@intel.com