### PR TITLE
ignore debuild intermediate files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,30 @@ venv
 /misc/config_tools/schema/sliced.xsd
 /misc/config_tools/schema/allchecks.xsd
 
+# ignore debuild intermediate files
+.pybuild
+debian/*.debhelper
+debian/*.substvars
+debian/acrn-dev
+debian/acrn-devicemodel
+debian/acrn-doc
+debian/acrn-hypervisor.config
+debian/acrn-hypervisor.install
+debian/acrn-hypervisor.postinst
+debian/acrn-hypervisor.postrm
+debian/acrn-hypervisor.prerm
+debian/acrn-hypervisor.templates
+debian/acrn-hypervisor
+debian/acrn-lifemngr
+debian/acrn-system
+debian/acrn-tools
+debian/acrnd
+debian/debhelper-build-stamp
+debian/files
+debian/grub-acrn
+debian/python3-acrn-board-inspector
+debian/tmp
+
 # ignore Eclipse project config
 .cproject
 .project


### PR DESCRIPTION
ignore debuild intermediate files in .gitignore to avoid these files pollute acrn-hypervisor repo when using debuild to build acrn.

Tracked-On: #8262
Signed-off-by: szhen11 <shuang.zheng@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>