### PR TITLE
hv: change the version format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,18 @@ T := $(CURDIR)
 include VERSION
 SCM_VERSION := $(shell [ -d .git ] && git describe --exact-match 1>/dev/null 2>&1 || git describe --dirty)
 ifneq ($(SCM_VERSION),)
-	SCM_VERSION := "-"$(SCM_VERSION)
+  SCM_VERSION := "-"$(SCM_VERSION)
 endif
 export FULL_VERSION=$(MAJOR_VERSION).$(MINOR_VERSION)$(EXTRA_VERSION)$(SCM_VERSION)
+STABLE_STR := -stable
+ifeq ($(EXTRA_VERSION), -unstable)
+  STABLE_STR := -unstable
+endif
+REMOTE_BRANCH := $(shell [ -d .git ] && git rev-parse --abbrev-ref HEAD)
+ifneq ($(REMOTE_BRANCH),)
+  REMOTE_BRANCH := "-"$(REMOTE_BRANCH)
+endif
+export BRANCH_VERSION=$(MAJOR_VERSION).$(MINOR_VERSION)$(STABLE_STR)$(REMOTE_BRANCH)
 
 ifdef TARGET_DIR
   $(warning TARGET_DIR is obsoleted because generated configuration files are now stored in the build directory)

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -517,15 +517,16 @@ distclean:
 PHONY: (VERSION)
 $(VERSION): $(HV_CONFIG_H)
 	touch $(VERSION)
-	@if [ "$(BUILD_VERSION)"x = x -o "$(BUILD_TAG)"x = x ];then \
+	@if [ "$(BUILD_VERSION)"x = x ];then \
 		COMMIT=`git rev-parse --verify --short HEAD 2>/dev/null`;\
 		DIRTY=`git diff-index --name-only HEAD`;\
 		if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
-		DAILY_TAG=`git tag --merged HEAD|grep "acrn"|tail -n 1`;\
 	else \
 		PATCH="$(BUILD_VERSION)"; \
-		DAILY_TAG="$(BUILD_TAG)"; \
 	fi; \
+	COMMIT_TAGS=$$(git tag --points-at HEAD|tr -s "\n" " "); \
+	COMMIT_TAGS=$$(eval echo $$COMMIT_TAGS);\
+	COMMIT_TIME=$$(git log -1 --date=format:"%Y-%m-%d-%T" --format=%cd); \
 	TIME=$$(date -u -d "@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" "+%F %T"); \
 	USER="$${USER:-$$(id -u -n)}"; \
 	if [ x$(CONFIG_RELEASE) = "xy" ];then BUILD_TYPE="REL";else BUILD_TYPE="DBG";fi;\
@@ -535,21 +536,17 @@ $(VERSION): $(HV_CONFIG_H)
 	echo "" >> $(VERSION); \
 	echo "#ifndef VERSION_H" >> $(VERSION); \
 	echo "#define VERSION_H" >> $(VERSION); \
-	echo "#define HV_FULL_VERSION "\"$(FULL_VERSION)\""" >> $(VERSION);\
 	echo "#define HV_API_MAJOR_VERSION $(API_MAJOR_VERSION)U" >> $(VERSION);\
 	echo "#define HV_API_MINOR_VERSION $(API_MINOR_VERSION)U" >> $(VERSION);\
-	echo "#define HV_DAILY_TAG "\""$$DAILY_TAG"\""" >> $(VERSION);\
-	echo "#define HV_BUILD_VERSION "\""$$PATCH"\""" >> $(VERSION);\
+	echo "#define HV_BRANCH_VERSION "\"$(BRANCH_VERSION)\""" >> $(VERSION);\
+	echo "#define HV_COMMIT_DIRTY "\""$$PATCH"\""" >> $(VERSION);\
+	echo "#define HV_COMMIT_TAGS "\"$$COMMIT_TAGS\""" >> $(VERSION);\
+	echo "#define HV_COMMIT_TIME "\"$$COMMIT_TIME\""" >> $(VERSION);\
 	echo "#define HV_BUILD_TYPE "\""$$BUILD_TYPE"\""" >> $(VERSION);\
 	echo "#define HV_BUILD_TIME "\""$$TIME"\""" >> $(VERSION);\
 	echo "#define HV_BUILD_USER "\""$$USER"\""" >> $(VERSION);\
 	echo "#define HV_BUILD_SCENARIO "\"$(SCENARIO)\""" >> $(VERSION);\
 	echo "#define HV_BUILD_BOARD "\"$(BOARD)\""" >> $(VERSION);\
-	if [ "$(CONFIG_XML_ENABLED)" = "true" ]; then \
-		echo "#define HV_CONFIG_TOOL \" with acrn-config\"" >> $(VERSION);\
-	else	\
-		echo "#define HV_CONFIG_TOOL \"\"" >> $(VERSION);\
-	fi;\
 	echo "#endif" >> $(VERSION)
 
 -include $(C_OBJS:.o=.d)

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -248,13 +248,11 @@ void init_pcpu_post(uint16_t pcpu_id)
 		/* Calibrate TSC Frequency */
 		calibrate_tsc();
 
-		pr_acrnlog("HV version %s-%s-%s %s (daily tag:%s) %s@%s build by %s%s, start time %luus",
-				HV_FULL_VERSION,
-				HV_BUILD_TIME, HV_BUILD_VERSION, HV_BUILD_TYPE,
-				HV_DAILY_TAG, HV_BUILD_SCENARIO, HV_BUILD_BOARD,
-				HV_BUILD_USER, HV_CONFIG_TOOL, ticks_to_us(start_tick));
-
-		pr_acrnlog("API version %u.%u",	HV_API_MAJOR_VERSION, HV_API_MINOR_VERSION);
+		pr_acrnlog("HV: %s-%s-%s %s%s%s%s %s@%s build by %s, start time %luus",
+				HV_BRANCH_VERSION, HV_COMMIT_TIME, HV_COMMIT_DIRTY, HV_BUILD_TYPE,
+				(sizeof(HV_COMMIT_TAGS) > 1) ? "(tag: " : "", HV_COMMIT_TAGS,
+				(sizeof(HV_COMMIT_TAGS) > 1) ? ")" : "", HV_BUILD_SCENARIO,
+				HV_BUILD_BOARD, HV_BUILD_USER, ticks_to_us(start_tick));
 
 		pr_acrnlog("Detect processor: %s", (get_pcpu_info())->model_name);
 

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -738,9 +738,11 @@ static int32_t shell_version(__unused int32_t argc, __unused char **argv)
 {
 	char temp_str[MAX_STR_SIZE];
 
-	snprintf(temp_str, MAX_STR_SIZE, "HV %s-%s-%s %s (daily tag: %s) %s@%s build by %s%s\nAPI %u.%u\r\n",
-		HV_FULL_VERSION, HV_BUILD_TIME, HV_BUILD_VERSION, HV_BUILD_TYPE, HV_DAILY_TAG, HV_BUILD_SCENARIO,
-		HV_BUILD_BOARD, HV_BUILD_USER, HV_CONFIG_TOOL, HV_API_MAJOR_VERSION, HV_API_MINOR_VERSION);
+	snprintf(temp_str, MAX_STR_SIZE, "HV: %s-%s-%s %s%s%s%s %s@%s build by %s %s\r\n",
+		HV_BRANCH_VERSION, HV_COMMIT_TIME, HV_COMMIT_DIRTY, HV_BUILD_TYPE,
+		(sizeof(HV_COMMIT_TAGS) > 1) ? "(tag: " : "", HV_COMMIT_TAGS, 
+		(sizeof(HV_COMMIT_TAGS) > 1) ? ")" : "",
+		HV_BUILD_SCENARIO, HV_BUILD_BOARD, HV_BUILD_USER, HV_BUILD_TIME);
 	shell_puts(temp_str);
 
 	return 0;


### PR DESCRIPTION
The version info is mainly used to tell the user when and where the binary is compiled and built, this will change the hv version format.

The hv follows the format:
HV: major.minor-stable/unstable-remote_branch-acrn-commit_date-commit_id-dirty DBG/REL(tag-current_commit_id) scenario@board build by author date. 
The '(tag-current_commit_id)' is optional, it exits only when there are tags for current commit.
e.g.
with tag:
ACRN:\>version
HV: 3.1-stable-release_3.1-2022-09-27-11:15:42-7fad37e02-dirty DBG(tag: v3.1) scenario3.1@my_desk_3.1 build by zhangwei 2022-11-16 07:02:37 without tag:
ACRN:\>version
HV: 3.2-unstable-master-2022-11-16-14:34:49-11f53d849-dirty DBG scenario3.1@my_desk_3.1 build by zhangwei 2022-11-16 06:49:44

Tracked-On #8303
Signed-off-by: Zhangwei6 <wei6.zhang@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>