### PR TITLE
ACRN:DM: Fix the vhost register kick fd issue.

### DIFF
--- a/devicemodel/hw/pci/virtio/vhost.c
+++ b/devicemodel/hw/pci/virtio/vhost.c
@@ -196,7 +196,7 @@ vhost_vq_register_eventfd(struct vhost_dev *vdev,
 		irqfd.flags = ACRN_IRQFD_FLAG_DEASSIGN;
 	}
 
-	virtio_register_ioeventfd(base, idx, is_register);
+	virtio_register_ioeventfd(base, idx, is_register, vq->kick_fd);
 	/* register irqfd for notify */
 	mte = &vdev->base->dev->msix.table[vqi->msix_idx];
 	msi.msi_addr = mte->addr;

--- a/devicemodel/include/virtio.h
+++ b/devicemodel/include/virtio.h
@@ -776,5 +776,5 @@ uint32_t virtio_device_cfg_read(
 int virtio_set_modern_pio_bar(
 		struct virtio_base *base, int barnum);
 
-int virtio_register_ioeventfd(struct virtio_base *base, int idx, bool is_register);
+int virtio_register_ioeventfd(struct virtio_base *base, int idx, bool is_register, int fd);
 #endif	/* _VIRTIO_H_ */


### PR DESCRIPTION
Add the new parameter for register ioevent function, let the vhost vq and viothread vq can share the register ioevent common API.

Tracked-On: #8323
Signed-off-by: Liu Long <long.liu@linux.intel.com>
Reviewed-by: Conghui <conghui.chen@intel.com>