### PR TITLE
dm: change the version format

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -229,27 +229,26 @@ distclean:
 $(VERSION_H):
 	mkdir -p $(DM_OBJDIR)/include
 	touch $(VERSION_H)
-	if [ "$(DM_BUILD_VERSION)"x = x -o "$(DM_BUILD_TAG)"x = x ];then\
+	if [ "$(DM_BUILD_VERSION)"x = x ];then\
 		COMMIT=`git rev-parse --verify --short HEAD 2>/dev/null`;\
 		DIRTY=`git diff-index --name-only HEAD`;\
 		if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
-		DAILY_TAG=`git tag --merged HEAD|grep "acrn"|tail -n 1`;\
 	else\
-		PATCH=$(DM_BUILD_VERSION);\
-		DAILY_TAG=$(DM_BUILD_TAG);\
+		PATCH="$(DM_BUILD_VERSION)";\
 	fi;\
+	COMMIT_TAGS=$$(git tag --points-at HEAD|tr -s "\n" " "); \
+	COMMIT_TAGS=$$(eval echo $$COMMIT_TAGS);\
+	COMMIT_TIME=$$(git log -1 --date=format:"%Y-%m-%d-%T" --format=%cd); \
 	TIME=$$(date -u -d "@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" "+%Y-%m-%d %H:%M:%S"); \
 	USER="$${USER:-$$(id -u -n)}"; \
 	echo "/*" > $(VERSION_H); \
 	sed 's/^/ * /' ../LICENSE >> $(VERSION_H);\
 	echo " */" >> $(VERSION_H);\
 	echo "" >> $(VERSION_H);\
-	echo "#define DM_MAJOR_VERSION $(MAJOR_VERSION)" >> $(VERSION_H);\
-	echo "#define DM_MINOR_VERSION $(MINOR_VERSION)" >> $(VERSION_H);\
-	echo "#define DM_EXTRA_VERSION "\"$(EXTRA_VERSION)\""" >> $(VERSION_H);\
-	echo "#define DM_FULL_VERSION "\"$(FULL_VERSION)\""" >> $(VERSION_H);\
-	echo "#define DM_DAILY_TAG "\""$$DAILY_TAG"\""" >> $(VERSION_H);\
-	echo "#define DM_BUILD_VERSION "\""$$PATCH"\""" >> $(VERSION_H);\
+	echo "#define DM_BRANCH_VERSION "\"$(BRANCH_VERSION)\""" >> $(VERSION_H);\
+	echo "#define DM_COMMIT_DIRTY "\""$$PATCH"\""" >> $(VERSION_H);\
+	echo "#define DM_COMMIT_TAGS "\"$$COMMIT_TAGS\""" >> $(VERSION_H);\
+	echo "#define DM_COMMIT_TIME "\"$$COMMIT_TIME\""" >> $(VERSION_H);\
 	echo "#define DM_BUILD_TIME "\""$$TIME"\""" >> $(VERSION_H);\
 	echo "#define DM_BUILD_USER "\""$$USER"\""" >> $(VERSION_H)
 

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -202,9 +202,11 @@ static void outdate(char *msg)
 static void
 print_version(void)
 {
-	fprintf(stdout, "DM version is: %s-%s (daily tag:%s), build by %s@%s\n",
-			DM_FULL_VERSION,
-			DM_BUILD_VERSION, DM_DAILY_TAG, DM_BUILD_USER, DM_BUILD_TIME);
+	fprintf(stdout, "DM: %s-%s-%s%s%s%s build by %s@%s\n",
+			DM_BRANCH_VERSION, DM_COMMIT_TIME, DM_COMMIT_DIRTY,
+			(sizeof(DM_COMMIT_TAGS) > 1) ? "(tag: " : "", DM_COMMIT_TAGS, 
+			(sizeof(DM_COMMIT_TAGS) > 1) ? ")" : "",
+			DM_BUILD_USER, DM_BUILD_TIME);
 
 	exit(0);
 }


### PR DESCRIPTION
The version info is mainly used to tell the user when and where the binary is compiled and built, this will change the dm version format. The dm follows the format:
major.minor-stable/unstable-remote_branch-acrn-commit_date-commit_id-dirty (tag-current_commit_id) build by author date.
Compare to the hv version, which is:
major.minor-stable/unstable-remote_branch-acrn-commit_date-commit_id-dirty DBG/REL(tag-current_commit_id) scenario@board build by author date. 
The dm doesn't contain DBG/REL because it's given in configurator-tool only for hv. also not contain scenario and board info. e.g.
with tag:
$acrn-dm -v
DM: 3.1-stable-release_3.1-2022-09-27-11:15:42-7fad37e02-dirty(tag: v3.1) build by zhangwei@2022-11-16 07:02:35
without tag:
$acrn-dm -v
DM: 3.2-unstable-master-2022-11-16-14:34:49-11f53d849-dirty build by zhangwei@2022-11-16 06:49:43

Tracked-On: #8303 
Signed-off-by: Zhangwei6 <wei6.zhang@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>