### PR TITLE
board_inspector: fix the invocation to rdmsr

### DIFF
--- a/misc/config_tools/board_inspector/legacy/acpi.py
+++ b/misc/config_tools/board_inspector/legacy/acpi.py
@@ -546,8 +546,8 @@ def store_px_data(sysnode, config):
     p_cnt = 0
     for freq in freqs.split():
         if boost != 0 and i == 0:
-            res = external_tools.run(['rdmsr', '0x1ad'])
-            if res.returncode != 0:
+            res = external_tools.run('rdmsr 0x1ad')
+            if res.wait() != 0:
                 logging.debug("MSR 0x1ad not support in this platform!")
                 return
 


### PR DESCRIPTION
Commit 0cbcdbd7c ("board_inspector: use executables found under system paths") unintendedly changes how acpi.py invokes `rdmsr` and that impacts the type of the execution results and causes incompatible method calls when the results are parsed.

Convert the invocation back to shell-style.

Fixes: 0cbcdbd7c ("board_inspector: use executables found under system paths")
Tracked-On: #8315
Signed-off-by: Junjie Mao <junjie.mao@intel.com>