### PR TITLE
asyncio: refine the setup ioctl

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -852,7 +852,7 @@ vm_init_asyncio(struct vmctx *ctx, uint64_t base)
 	sbuf->overrun_cnt = 0;
 	sbuf->head = 0;
 	sbuf->tail = 0;
-	return vm_setup_sbuf(ctx, ACRN_ASYNCIO, base);
+	return vm_setup_asyncio(ctx, base);
 }
 
 int

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -295,19 +295,14 @@ vm_destroy(struct vmctx *ctx)
 }
 
 int
-vm_setup_sbuf(struct vmctx *ctx, uint32_t sbuf_id, uint64_t base)
+vm_setup_asyncio(struct vmctx *ctx, uint64_t base)
 {
 	int error;
-	struct acrn_sbuf sbuf_param;
 
-	bzero(&sbuf_param, sizeof(sbuf_param));
-	sbuf_param.sbuf_id = sbuf_id;
-	sbuf_param.base = base;
-
-	error = ioctl(ctx->fd, ACRN_IOCTL_SETUP_SBUF, &sbuf_param);
+	error = ioctl(ctx->fd, ACRN_IOCTL_SETUP_ASYNCIO, base);
 
 	if (error) {
-		pr_err("ACRN_IOCTL_SBUF_PAGE ioctl() returned an error: %s\n", errormsg(errno));
+		pr_err("ACRN_IOCTL_SETUP_ASYNCIO ioctl() returned an error: %s\n", errormsg(errno));
 	}
 
 	return error;

--- a/devicemodel/include/public/hsm_ioctl_defs.h
+++ b/devicemodel/include/public/hsm_ioctl_defs.h
@@ -107,8 +107,6 @@
 	_IOW(ACRN_IOCTL_TYPE, 0x41, struct acrn_vm_memmap)
 #define ACRN_IOCTL_UNSET_MEMSEG		\
 	_IOW(ACRN_IOCTL_TYPE, 0x42, struct acrn_vm_memmap)
-#define ACRN_IOCTL_SETUP_SBUF	\
-	_IOW(ACRN_IOCTL_TYPE, 0x43, struct acrn_sbuf)
 
 /* PCI assignment*/
 #define ACRN_IOCTL_SET_PTDEV_INTR	\
@@ -138,6 +136,9 @@
 #define ACRN_IOCTL_IRQFD		\
 	_IOW(ACRN_IOCTL_TYPE, 0x71, struct acrn_irqfd)
 
+/* Asynchronous IO */
+#define ACRN_IOCTL_SETUP_ASYNCIO	\
+	_IOW(ACRN_IOCTL_TYPE, 0x90, __u64)
 
 #define	ACRN_MEM_ACCESS_RIGHT_MASK	0x00000007U
 #define	ACRN_MEM_ACCESS_READ		0x00000001U
@@ -250,13 +251,4 @@ struct acrn_irqfd {
        struct acrn_msi_entry msi;
 };
 
-/**
- * @brief data structure to register a share buffer by ioctl
- */
-struct acrn_sbuf {
-	/** Type of the sbuf. */
-	uint32_t sbuf_id;
-	/** Base address of the sbuf. */
-	uint64_t base;
-};
 #endif /* VHM_IOCTL_DEFS_H */

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -107,7 +107,7 @@ int	vm_create_ioreq_client(struct vmctx *ctx);
 int	vm_destroy_ioreq_client(struct vmctx *ctx);
 int	vm_attach_ioreq_client(struct vmctx *ctx);
 int	vm_notify_request_done(struct vmctx *ctx, int vcpu);
-int	vm_setup_sbuf(struct vmctx *ctx, uint32_t sbuf_type, uint64_t base);
+int	vm_setup_asyncio(struct vmctx *ctx, uint64_t base);
 void	vm_clear_ioreq(struct vmctx *ctx);
 const char *vm_state_to_str(enum vm_suspend_how idx);
 void	vm_set_suspend_mode(enum vm_suspend_how how);


### PR DESCRIPTION
Remove the common interface for sbuf setup, as it is not accept by kernel side. Instead, use dedicate setup function for asyncio to init its sbuf.

Tracked-On: #8209
Signed-off-by: Conghui <conghui.chen@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>