### PR TITLE
debian/rules: search for XML files only

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -62,7 +62,7 @@ $(eval $(call unquote,$(shell xmllint --xpath '/acrn-config/@board' $1 2>/dev/nu
 $(eval $(if $(board),                                                                     \
     $(eval config_$(board) := $1)                                                         \
     $(eval boardlist := $(sort $(boardlist) $(board)))                                    \
-    $(foreach f,$(wildcard $(addprefix $(dir $1),*)),                                     \
+    $(foreach f,$(wildcard $(addprefix $(dir $1),*.xml)),                                 \
         $(if $(strip $(shell xmllint --xpath '/acrn-config/@board' $f 2>/dev/null)),,     \
             $(if $(subst scenario.xml,,$(notdir $f)),                                     \
                 $(eval scenario = $(basename $(notdir $f))),                              \


### PR DESCRIPTION
When searching for scenario XMLs that are saved under the same directory as a board XML, debian/rules uses the wildcard `*` which includes other non-XML files. That causes some non-XML files to be considered as scenario XMLs as well and will cause build-time errors when the build system attempts to parse them as XMLs.

Change the wildcard expression to `*.xml` to restrict the found files to be XML.

Tracked-On: #8344
Signed-off-by: Junjie Mao <junjie.mao@intel.com>