### PR TITLE
debian/rules: change default BOARDLIST and SCENARIOLIST to empty

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -32,8 +32,8 @@ rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(su
 unquote = $(subst $\",,$1)
 
 # set these variables to define build of certain boards/scenarios, e.g.
-ACRN_BOARDLIST ?= whl-ipc-i5 nuc11tnbi5 cfl-k700-i7 tgl-vecow-spc-7100-Corei7
-ACRN_SCENARIOLIST ?= partitioned shared hybrid hybrid_rt
+ACRN_BOARDLIST ?=
+ACRN_SCENARIOLIST ?=
 
 # for now build the debug versions
 # set to y for RELEASE build


### PR DESCRIPTION
The variables BOARDLIST and SCENARIOLIST serve as filters of XMLs that are found under the user-given directories, and there is no need to assume any filter if a user does not specify that explicitly.

Update the default filters to none so that all found XMLs will be used if a user does not state otherwise.

Tracked-On: #8246
Signed-off-by: Junjie Mao <junjie.mao@intel.com>