### PR TITLE
config_tools: set 'own_pcpu' of RTVM

### DIFF
--- a/misc/config_tools/configurator/pyodide/populateDefaultValues.py
+++ b/misc/config_tools/configurator/pyodide/populateDefaultValues.py
@@ -46,6 +46,10 @@ def main(scenario):
             if name.text not in vmNames:
                 name.text = ""
 
+        own_pcpus = etree.findall(".//vm[vm_type = 'RTVM']/own_pcpu")
+        for o in own_pcpus:
+            o.text = 'y'
+
         result = tostring(obj.get("scenario_etree").getroot())
         result = result.decode()
     result = convert_result({


### PR DESCRIPTION
For STANDARD_VM 'own_pcpu' default value is 'n'. But RTVM always own pCPUs. So check 'own_pcpu' of RTVM and make sure it's set to 'y'.

Tracked-On: #8253
Signed-off-by: Yuanyua Zhao <yuanyuan.zhao@linux.intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>