### PR TITLE
Update sample app scripts for Ubuntu 22.04

### DIFF
--- a/misc/sample_application/image_builder/create_image.sh
+++ b/misc/sample_application/image_builder/create_image.sh
@@ -227,7 +227,7 @@ function cleanup() {
 mount_point=$(pwd)/mnt
 if [[ ${vm_type} == "hmi-vm" ]]; then
     target_image=${hmi_vm_image}
-    size_modifier="+4G"
+    size_modifier="+5G"
 elif [[ ${vm_type} == "rt-vm" ]]; then
     target_image=${rt_vm_image}
     size_modifier="+1G"
@@ -236,7 +236,7 @@ else
     exit 1
 fi
 
-try_step "Download Ubuntu Focal cloud image" download_image ${cloud_image} ${cloud_image_url}
+try_step "Download Ubuntu cloud image" download_image ${cloud_image} ${cloud_image_url}
 if [[ ${vm_type} == "rt-vm" ]]; then
     try_step "Copy the RT kernel to build directory" copy_rt_kernel
     try_step "Check availability of RT kernel image" check_rt_kernel

--- a/misc/sample_application/image_builder/setup_rt_vm.sh
+++ b/misc/sample_application/image_builder/setup_rt_vm.sh
@@ -35,7 +35,8 @@ function install_rt_kernel() {
     search_dir=$1
     for file in $(ls -r ${search_dir}/*acrn-kernel-*.deb)
     do
-        sudo apt install ${file} -y
+        cp ${file} /tmp
+        sudo apt install /tmp/${file##*/} -y
     done
 }
 


### PR DESCRIPTION
The switch to Ubuntu 22.04 for ACRN v3.2 requires a few changes to the sample application scripts:

- user _apt cannot access debian packages in user directories, so copy them to /tmp to install
- HMI-VM image size needs to be bigger (running out of space during image update)

Tracked-On: #8352

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>