### PR TITLE
doc: fix missing numbered-step icon

### DIFF
--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -291,7 +291,8 @@ body {
    counter-reset: step-count;
 }
 
-div.numbered-step h2::before {
+div.numbered-step h2::before,
+section.numbered-step h2::before {
   counter-increment: step-count;
   content: counter(step-count);
   background: #cccccc;


### PR DESCRIPTION
Sphinx version 5 generates &lt;section&gt; instead of &lt;div&gt; for section headings.  This throws off the custom CSS style for numbered steps so the number icon wasn't showing up.  Tweak the custom CSS to look for both &lt;section&gt; and &lt;div&gt; with class=numbered-step to handle Sphinx 4 and 5-generated content.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>