### PR TITLE
Limit PIO BAR to a valid value range

### DIFF
--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -375,6 +375,10 @@ static void init_bars(struct pci_vdev *vdev, bool is_sriov_bar)
 		}
 		lo = pci_pdev_read_cfg(pbdf, offset, 4U);
 		vbar->bar_type.bits = lo;
+		if (is_pci_io_bar(vbar)) {
+			//For some device, PIO BAR base may bigger than 0xffff
+			lo &= 0xffffUL;
+		}
 
 		if (is_pci_reserved_bar(vbar)) {
 			continue;


### PR DESCRIPTION
For some device, PIO BAR base may bigger than 0xffff, which can cause ACRN create VM failure.

On my device, the BAR2 is IO BAR and read value is 0x81324001. It should be 0x4001.
This cause ACRN boot VM failure and report:
check_pt_dev_pio_bars, PCI:01:00.0 PIO BAR2 isn't identical mapping, host start addr is 0x81324000, while guest start addr is 0x4000

Device config space information for reference:
Read config space from Linux:
00000000: xxxxxxxxxxxxxxxxxxx 0300 0002 0000 0000
00000010: 0000 3081 0000 0000 0140 0000 0000 3281

While read config from Uefi(marked * ):
00000000: xx xx xx xx xx xx xx 00-03 00 00 02 00 00 00 00
00000010: 00 00 30 81 00 00 00 00-01 *40 *32 *81 00 00 32 81

Tracked-On: #8373