### PR TITLE
Ptirq fix for PCIe INTx passthru

### DIFF
--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -382,15 +382,9 @@ static struct ptirq_remapping_info *add_intx_remapping(struct acrn_vm *vm, uint3
 			pr_err("INTX re-add vpin %d", virt_gsi);
 		}
 	} else if (entry->vm != vm) {
-		if (is_service_vm(entry->vm)) {
-			entry->vm = vm;
-			entry->virt_sid.value = virt_sid.value;
-			entry->polarity = 0U;
-		} else {
-			pr_err("INTX gsi%d already in vm%d with vgsi%d, not able to add into vm%d with vgsi%d",
-					phys_gsi, entry->vm->vm_id, entry->virt_sid.intx_id.gsi, vm->vm_id, virt_gsi);
-			entry = NULL;
-		}
+		pr_err("INTX gsi%d already in vm%d with vgsi%d, not able to add into vm%d with vgsi%d",
+				phys_gsi, entry->vm->vm_id, entry->virt_sid.intx_id.gsi, vm->vm_id, virt_gsi);
+		entry = NULL;
 	} else {
 		/* The mapping has already been added to the VM. No action
 		 * required.
@@ -410,15 +404,24 @@ static struct ptirq_remapping_info *add_intx_remapping(struct acrn_vm *vm, uint3
 	return entry;
 }
 
-/* deactive & remove mapping entry of vpin for vm */
-static void remove_intx_remapping(const struct acrn_vm *vm, uint32_t virt_gsi, enum intx_ctlr vgsi_ctlr)
+/* deactivate & remove mapping entry of vpin for vm */
+static void remove_intx_remapping(const struct acrn_vm *vm, uint32_t gsi, enum intx_ctlr gsi_ctlr, bool is_phy_gsi)
 {
 	uint32_t phys_irq;
 	struct ptirq_remapping_info *entry;
 	struct intr_source intr_src;
-	DEFINE_INTX_SID(virt_sid, virt_gsi, vgsi_ctlr);
 
-	entry = find_ptirq_entry(PTDEV_INTR_INTX, &virt_sid, vm);
+	if (is_phy_gsi) {
+		DEFINE_INTX_SID(sid, gsi, INTX_CTLR_IOAPIC);
+		entry = find_ptirq_entry(PTDEV_INTR_INTX, &sid, NULL);
+		if ((entry != NULL) && (entry->vm != vm)) {
+			entry = NULL;
+		}
+	} else {
+		DEFINE_INTX_SID(sid, gsi, gsi_ctlr);
+		entry = find_ptirq_entry(PTDEV_INTR_INTX, &sid, vm);
+	}
+
 	if (entry != NULL) {
 		if (is_entry_active(entry)) {
 			phys_irq = entry->allocated_pirq;
@@ -431,11 +434,11 @@ static void remove_intx_remapping(const struct acrn_vm *vm, uint32_t virt_gsi, e
 
 			dmar_free_irte(&intr_src, entry->irte_idx);
 			dev_dbg(DBG_LEVEL_IRQ,
-				"deactive %s intx entry:pgsi=%d, pirq=%d ",
-				(vgsi_ctlr == INTX_CTLR_PIC) ? "vPIC" : "vIOAPIC",
+				"deactivate %s intx entry:pgsi=%d, pirq=%d ",
+				(entry->virt_sid.intx_id.ctlr == INTX_CTLR_PIC) ? "vPIC" : "vIOAPIC",
 				entry->phys_sid.intx_id.gsi, phys_irq);
 			dev_dbg(DBG_LEVEL_IRQ, "from vm%d vgsi=%d\n",
-				entry->vm->vm_id, virt_gsi);
+				entry->vm->vm_id, entry->virt_sid.intx_id.gsi);
 		}
 
 		ptirq_release_entry(entry);
@@ -735,7 +738,7 @@ int32_t ptirq_intx_pin_remap(struct acrn_vm *vm, uint32_t virt_gsi, enum intx_ct
 						uint32_t phys_gsi = virt_gsi;
 
 						remove_intx_remapping(vm, alt_virt_sid.intx_id.gsi,
-							alt_virt_sid.intx_id.ctlr);
+							alt_virt_sid.intx_id.ctlr, false);
 						entry = add_intx_remapping(vm, virt_gsi, phys_gsi, vgsi_ctlr);
 						if (entry == NULL) {
 							pr_err("%s, add intx remapping failed", __func__);
@@ -806,12 +809,12 @@ int32_t ptirq_add_intx_remapping(struct acrn_vm *vm, uint32_t virt_gsi, uint32_t
 /*
  * @pre vm != NULL
  */
-void ptirq_remove_intx_remapping(const struct acrn_vm *vm, uint32_t virt_gsi, bool pic_pin)
+void ptirq_remove_intx_remapping(const struct acrn_vm *vm, uint32_t gsi, bool pic_pin, bool is_phy_gsi)
 {
 	enum intx_ctlr vgsi_ctlr = pic_pin ? INTX_CTLR_PIC : INTX_CTLR_IOAPIC;
 
 	spinlock_obtain(&ptdev_lock);
-	remove_intx_remapping(vm, virt_gsi, vgsi_ctlr);
+	remove_intx_remapping(vm, gsi, vgsi_ctlr, is_phy_gsi);
 	spinlock_release(&ptdev_lock);
 }
 
@@ -839,6 +842,6 @@ void ptirq_remove_configured_intx_remappings(const struct acrn_vm *vm)
 	uint16_t i;
 
 	for (i = 0; i < vm_config->pt_intx_num; i++) {
-		ptirq_remove_intx_remapping(vm, vm_config->pt_intx[i].virt_gsi, false);
+		ptirq_remove_intx_remapping(vm, vm_config->pt_intx[i].virt_gsi, false, false);
 	}
 }

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1016,6 +1016,7 @@ int32_t hcall_set_ptdev_intr_info(struct acrn_vcpu *vcpu, struct acrn_vm *target
 					if ((((!irq.intx.pic_pin) && (irq.intx.virt_pin < get_vm_gsicount(target_vm)))
 						|| ((irq.intx.pic_pin) && (irq.intx.virt_pin < vpic_pincount())))
 							&& is_gsi_valid(irq.intx.phys_pin)) {
+						ptirq_remove_intx_remapping(get_service_vm(), irq.intx.phys_pin, false, true);
 						ret = ptirq_add_intx_remapping(target_vm, irq.intx.virt_pin,
 								irq.intx.phys_pin, irq.intx.pic_pin);
 					} else {
@@ -1067,7 +1068,7 @@ int32_t hcall_reset_ptdev_intr_info(struct acrn_vcpu *vcpu, struct acrn_vm *targ
 				if ((vdev != NULL) && (vdev->pdev->bdf.value == irq.phys_bdf)) {
 					if (((!irq.intx.pic_pin) && (irq.intx.virt_pin < get_vm_gsicount(target_vm))) ||
 						((irq.intx.pic_pin) && (irq.intx.virt_pin < vpic_pincount()))) {
-						ptirq_remove_intx_remapping(target_vm, irq.intx.virt_pin, irq.intx.pic_pin);
+						ptirq_remove_intx_remapping(target_vm, irq.intx.virt_pin, irq.intx.pic_pin, false);
 						ret = 0;
 					} else {
 						pr_err("%s: Invalid virt pin\n", __func__);

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -22,9 +22,10 @@ struct ptirq_remapping_info ptirq_entries[CONFIG_MAX_PT_IRQ_ENTRIES];
 static uint64_t ptirq_entry_bitmaps[PTIRQ_BITMAP_ARRAY_SIZE];
 spinlock_t ptdev_lock = { .head = 0U, .tail = 0U, };
 
-static struct ptirq_entry_head {
-	struct hlist_head list;
-} ptirq_entry_heads[PTIRQ_ENTRY_HASHSIZE];
+/* lookup mapping info from phyical sid, hashing from sid + acrn_vm structure address (NULL) */
+static struct hlist_head phys_sid_htable[PTIRQ_ENTRY_HASHSIZE];
+/* lookup mapping info from virtual sid within a vm, hashing from sid + acrn_vm structure address */
+static struct hlist_head virt_sid_htable[PTIRQ_ENTRY_HASHSIZE];
 
 static inline uint16_t ptirq_alloc_entry_id(void)
 {
@@ -40,28 +41,52 @@ static inline uint16_t ptirq_alloc_entry_id(void)
 	return (id < CONFIG_MAX_PT_IRQ_ENTRIES) ? id: INVALID_PTDEV_ENTRY_ID;
 }
 
+/*
+ * get the hash key when looking up ptirq_remapping_info from virtual
+ * source id in a VM, or just physical source id (vm == NULL).
+ * Hashing from source id value and acrn_vm structure address can decrease
+ * the probability of hash collisions as different VMs may have equal
+ * virtual source ids.
+ */
+static inline uint64_t ptirq_hash_key(const struct acrn_vm *vm,
+		const union source_id *sid)
+{
+	return hash64(sid->value + (uint64_t)vm, PTIRQ_ENTRY_HASHBITS);
+}
+
+/*
+ * to find ptirq_remapping_info from phyical source id (vm == NULL) or
+ * virtual source id in a vm.
+ */
 struct ptirq_remapping_info *find_ptirq_entry(uint32_t intr_type,
 		const union source_id *sid, const struct acrn_vm *vm)
 {
 	struct hlist_node *p;
+	struct hlist_head *b;
 	struct ptirq_remapping_info *n, *entry = NULL;
-	uint64_t key = hash64(sid->value, PTIRQ_ENTRY_HASHBITS);
-	struct ptirq_entry_head *b = &ptirq_entry_heads[key];
+	uint64_t key = ptirq_hash_key(vm, sid);
 
-	hlist_for_each(p, &b->list) {
-		if (vm == NULL) {
+	if (vm == NULL) {
+		b = &(phys_sid_htable[key]);
+
+		hlist_for_each(p, b) {
 			n = hlist_entry(p, struct ptirq_remapping_info, phys_link);
-		} else {
-			n = hlist_entry(p, struct ptirq_remapping_info, virt_link);
+			if (is_entry_active(n)) {
+				if ((intr_type == n->intr_type) && (sid->value == n->phys_sid.value)) {
+					entry = n;
+					break;
+				}
+			}
 		}
-
-		if (is_entry_active(n)) {
-			if ((intr_type == n->intr_type) &&
-				((vm == NULL) ?
-				(sid->value == n->phys_sid.value) :
-				((vm == n->vm) && (sid->value == n->virt_sid.value)))) {
-				entry = n;
-				break;
+	} else {
+		b = &(virt_sid_htable[key]);
+		hlist_for_each(p, b) {
+			n = hlist_entry(p, struct ptirq_remapping_info, virt_link);
+			if (is_entry_active(n)) {
+				if ((intr_type == n->intr_type) && (sid->value == n->virt_sid.value) && (vm == n->vm)) {
+					entry = n;
+					break;
+				}
 			}
 		}
 	}
@@ -211,10 +236,10 @@ int32_t ptirq_activate_entry(struct ptirq_remapping_info *entry, uint32_t phys_i
 		entry->allocated_pirq = irq;
 		entry->active = true;
 
-		key = hash64(entry->phys_sid.value, PTIRQ_ENTRY_HASHBITS);
-		hlist_add_head(&entry->phys_link, &(ptirq_entry_heads[key].list));
-		key = hash64(entry->virt_sid.value, PTIRQ_ENTRY_HASHBITS);
-		hlist_add_head(&entry->virt_link, &(ptirq_entry_heads[key].list));
+		key = ptirq_hash_key(NULL, &(entry->phys_sid));
+		hlist_add_head(&entry->phys_link, &(phys_sid_htable[key]));
+		key = ptirq_hash_key(entry->vm, &(entry->virt_sid));
+		hlist_add_head(&entry->virt_link, &(virt_sid_htable[key]));
 	}
 
 	return ret;

--- a/hypervisor/include/arch/x86/asm/guest/assign.h
+++ b/hypervisor/include/arch/x86/asm/guest/assign.h
@@ -112,18 +112,20 @@ int32_t ptirq_add_intx_remapping(struct acrn_vm *vm, uint32_t virt_gsi, uint32_t
 /**
  * @brief Remove an interrupt remapping entry for INTx.
  *
- * Deactivate & remove mapping entry of the given virt_pin for given vm.
+ * Deactivate & remove mapping entry of the given virt gsi for given vm or
+ * phys gsi assigned to this vm.
  *
  * @param[in] vm pointer to acrn_vm
- * @param[in] virt_gsi virtual pin number associated with the passthrough device
+ * @param[in] gsi virtual gsi number or physical gsi number associated with the passthrough device
  * @param[in] pic_pin true for pic, false for ioapic
+ * @param[in] is_phy_gsi true if gsi is physical, false if gsi is virtual
  *
  * @return None
  *
  * @pre vm != NULL
  *
  */
-void ptirq_remove_intx_remapping(const struct acrn_vm *vm, uint32_t virt_gsi, bool pic_pin);
+void ptirq_remove_intx_remapping(const struct acrn_vm *vm, uint32_t gsi, bool pic_pin, bool is_phy_gsi);
 
 /**
  * @brief Remove interrupt remapping entry/entries for MSI/MSI-x.


### PR DESCRIPTION
This series fixes hypervisor side PCIe INTx passthru issue occurred
when passthru USB xDCI, SMbus controllers and IPU to Post-launched VM.

The first patch fixes the hash table implementation used to look up
ptirq_remapping_info from physical interrupt or virtual interrupt
in a VM.

The second patch fixes wrong IOAPIC and RTE states when assigning an
INTx interrupt to Post-launched VM.