### PR TITLE
debian: add kernel version to GRUB menuentry

### DIFF
--- a/debian/grub/20_acrn-board-inspector
+++ b/debian/grub/20_acrn-board-inspector
@@ -103,7 +103,7 @@ linux_entry ()
   if [ -z "$boot_device_id" ]; then
       boot_device_id="$(grub_get_device_id "${GRUB_DEVICE}")"
   fi
-  echo "menuentry '$(echo "$os" | grub_quote)' ${CLASS} \$menuentry_id_option 'gnulinux-acrn-board-inspector-$boot_device_id' {"
+  echo "menuentry '$(echo "$os, with ${version}" | grub_quote)' ${CLASS} \$menuentry_id_option 'gnulinux-acrn-board-inspector-$boot_device_id' {"
 
   # Use ELILO's generic "efifb" when it's known to be available.
   # FIXME: We need an interface to select vesafb in case efifb can't be used.

--- a/debian/grub/20_acrn-board-inspector
+++ b/debian/grub/20_acrn-board-inspector
@@ -103,7 +103,7 @@ linux_entry ()
   if [ -z "$boot_device_id" ]; then
       boot_device_id="$(grub_get_device_id "${GRUB_DEVICE}")"
   fi
-  echo "menuentry '$(echo "$os, with ${version}" | grub_quote)' ${CLASS} \$menuentry_id_option 'gnulinux-acrn-board-inspector-$boot_device_id' {"
+  echo "menuentry '$(echo "$os, with Linux ${version}" | grub_quote)' ${CLASS} \$menuentry_id_option 'gnulinux-acrn-board-inspector-$boot_device_id' {"
 
   # Use ELILO's generic "efifb" when it's known to be available.
   # FIXME: We need an interface to select vesafb in case efifb can't be used.

--- a/debian/grub/25_linux_acrn
+++ b/debian/grub/25_linux_acrn
@@ -208,7 +208,7 @@ linux_entry ()
       boot_device_id="$(grub_get_device_id "${GRUB_DEVICE}")"
   fi
   title="$(gettext_printf "%s with ACRN hypervisor" "${os}")"
-  echo "menuentry '$(echo "$title" | grub_quote)' ${CLASS} \$menuentry_id_option 'acrn-gnulinux-$boot_device_id' {"
+  echo "menuentry '$(echo "$title, with ${version}(${acrn_version})" | grub_quote)' ${CLASS} \$menuentry_id_option 'acrn-gnulinux-$boot_device_id' {"
 
   if [ -z "${prepare_boot_cache}" ]; then
     prepare_boot_cache="$(prepare_grub_to_access_device ${GRUB_DEVICE_BOOT} | grub_add_tab)"
@@ -327,7 +327,7 @@ while [ "x${acrn_list}" != "x" ] ; do
         else
             title="$(gettext_printf "%s with ACRN hypervisor %s" "${OS}" "${acrn_version}")"
         fi
-        echo "menuentry '$(echo "$title" | grub_quote)' ${CLASS} \$menuentry_id_option 'acrn-gnulinux-partitioned-${acrn_version}' {"
+	echo "menuentry '$(echo "$title, with ${version}(${acrn_version})" | grub_quote)' ${CLASS} \$menuentry_id_option 'acrn-gnulinux-partitioned-${acrn_version}' {"
         message="$(gettext_printf "Loading ACRN hypervisor %s ..." ${acrn_version})"
         cat << EOF
 	echo	'$(echo "$message" | grub_quote)'

--- a/debian/grub/25_linux_acrn
+++ b/debian/grub/25_linux_acrn
@@ -208,7 +208,7 @@ linux_entry ()
       boot_device_id="$(grub_get_device_id "${GRUB_DEVICE}")"
   fi
   title="$(gettext_printf "%s with ACRN hypervisor" "${os}")"
-  echo "menuentry '$(echo "$title, with ${version}(${acrn_version})" | grub_quote)' ${CLASS} \$menuentry_id_option 'acrn-gnulinux-$boot_device_id' {"
+  echo "menuentry '$(echo "$title, with Linux ${version} (ACRN ${acrn_version})" | grub_quote)' ${CLASS} \$menuentry_id_option 'acrn-gnulinux-$boot_device_id' {"
 
   if [ -z "${prepare_boot_cache}" ]; then
     prepare_boot_cache="$(prepare_grub_to_access_device ${GRUB_DEVICE_BOOT} | grub_add_tab)"
@@ -327,7 +327,7 @@ while [ "x${acrn_list}" != "x" ] ; do
         else
             title="$(gettext_printf "%s with ACRN hypervisor %s" "${OS}" "${acrn_version}")"
         fi
-	echo "menuentry '$(echo "$title, with ${version}(${acrn_version})" | grub_quote)' ${CLASS} \$menuentry_id_option 'acrn-gnulinux-partitioned-${acrn_version}' {"
+        echo "menuentry '$(echo "$title, with Linux ${version} (ACRN ${acrn_version})" | grub_quote)' ${CLASS} \$menuentry_id_option 'acrn-gnulinux-partitioned-${acrn_version}' {"
         message="$(gettext_printf "Loading ACRN hypervisor %s ..." ${acrn_version})"
         cat << EOF
 	echo	'$(echo "$message" | grub_quote)'


### PR DESCRIPTION
1. add kernen version to menuentry "Ubuntu-ACRN Board Inspector"
2. add kernel version and acrn version to menuentry "Ubuntu with ACRN hypervisor"

Tracked-On: #8359