### PR TITLE
config_tools: adapt to elementpath >= 4.0.0

### DIFF
--- a/misc/config_tools/scenario_config/elementpath_overlay.py
+++ b/misc/config_tools/scenario_config/elementpath_overlay.py
@@ -21,16 +21,17 @@ import library.rdt as rdt
 BaseParser = elementpath.XPath2Parser
 
 class CustomParser(BaseParser):
-    SYMBOLS = BaseParser.SYMBOLS | {
-        # Bit-wise operations
-        'bitwise-and',
+    if hasattr(BaseParser, "SYMBOLS"):
+        SYMBOLS = BaseParser.SYMBOLS | {
+            # Bit-wise operations
+            'bitwise-and',
 
-        'bits-of',
-        'has',
-        'duplicate-values',
+            'bits-of',
+            'has',
+            'duplicate-values',
 
-        'number-of-clos-id-needed',
-        }
+            'number-of-clos-id-needed',
+            }
 
 method = CustomParser.method
 function = CustomParser.function


### PR DESCRIPTION
Starting from elementpath 4.0.0, the XPath2Parser class no longer has a SYMBOLS member and completeness checking based on that are removed as well. This patch updates the elementpath_overlay in the config tools to fix the compilation issue when using recent elementpath versions.

Tracked-On: #8368