### PR TITLE
misc: fix the summary issue after update board xml

### DIFF
--- a/misc/config_tools/scenario_config/config_summary.py
+++ b/misc/config_tools/scenario_config/config_summary.py
@@ -100,7 +100,7 @@ class GenerateRst:
 
     # Get all physical CPU information from board.xml
     def get_pcpu(self):
-        pcpu_list = list(map(int, self.board_etree.xpath("processors/die/core/thread/cpu_id/text()")))
+        pcpu_list = list(map(int, self.board_etree.xpath("processors//cpu_id/text()")))
         return pcpu_list
 
     def write_shared_cache(self):


### PR DESCRIPTION
The new board xml have add a "module" node under the "processors/die" which has cause an issue when we run the summary, this patch  use "//" to select all "cpu_id" under the "processors".

Tracked-On: #8385