### PR TITLE
dm: gvt: add bound check in gvt_init_config()

### DIFF
--- a/devicemodel/hw/pci/gvt.c
+++ b/devicemodel/hw/pci/gvt.c
@@ -256,7 +256,7 @@ gvt_init_config(struct pci_gvt *gvt)
 	/* capability */
 	pci_set_cfgdata8(gvt->gvt_pi, PCIR_CAP_PTR, gvt->host_config[0x34]);
 	cap_ptr = gvt->host_config[0x34];
-	while (cap_ptr != 0) {
+	while (cap_ptr != 0 && cap_ptr <= PCI_REGMAX - 15) {
 		pci_set_cfgdata32(gvt->gvt_pi, cap_ptr,
 			gvt->host_config[cap_ptr]);
 		pci_set_cfgdata32(gvt->gvt_pi, cap_ptr + 4,


### PR DESCRIPTION
gvt_init_config() may perform out-of-range read on host_config, add bound check before accessing it.

Tracked-On: #8382

Reviewed-by: Jian Jun Chen <jian.jun.chen@intel.com>