### PR TITLE
config_tools: remove rstcloth package

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pyodide.js
+++ b/misc/config_tools/configurator/packages/configurator/src/pyodide.js
@@ -18,8 +18,7 @@ export default async function () {
             './thirdLib/elementpath-2.5.0-py3-none-any.whl',
             './thirdLib/defusedxml-0.7.1-py2.py3-none-any.whl',
             './thirdLib/xmlschema-1.9.2-py3-none-any.whl',
-            './thirdLib/acrn_config_tools-3.0-py3-none-any.whl',
-            './thirdLib/rstcloth-0.5.2-py3-none-any.whl'
+            './thirdLib/acrn_config_tools-3.0-py3-none-any.whl'
         ])
     `)
 

--- a/misc/config_tools/configurator/packages/configurator/thirdLib/library.json
+++ b/misc/config_tools/configurator/packages/configurator/thirdLib/library.json
@@ -124,23 +124,6 @@
           "to": "defusedxml-0.7.1-py2.py3-none-any.whl"
         }
       ]
-    },
-    {
-      "name": "rstcloth-0.5.2-py3-none-any.whl",
-      "check": {
-        "type": "file",
-        "path": "rstcloth-0.5.2-py3-none-any.whl"
-      },
-      "clean": [
-        "rstcloth-0.5.2-py3-none-any.whl"
-      ],
-      "install": [
-        {
-          "type": "download",
-          "from": "https://files.pythonhosted.org/packages/f1/fa/e653417b4eb6319e9b120f8d9bb16f7c5a4bcc5d1f8a2039d3106f7504e6/rstcloth-0.5.2-py3-none-any.whl",
-          "to": "rstcloth-0.5.2-py3-none-any.whl"
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
9c2d0f8858f8 ("config_tools: replace RstCloth library with class.") removes all usage of rstcloth in code, but the rstcloth package is not removed from acrn-configurator and it will still download dependencies for rstcloth. This patch simply removes it.

Tracked-On: #8395

Reviewed-by: Junjie Mao <junjie.mao@intel.com>