### PR TITLE
config_tools: add customized parameters in launch script generation logic

### DIFF
--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -11,6 +11,7 @@ import os
 import sys
 
 import copy
+import shlex
 import argparse
 
 import logging
@@ -417,6 +418,10 @@ def generate_for_one_vm(board_etree, hv_scenario_etree, vm_scenario_etree, vm_id
     ###
     # Lastly, conclude the device model parameters with the VM name
     ###
+    customized_parameters = eval_xpath(vm_scenario_etree, ".//customized_parameters/text()")
+    if customized_parameters is not None:
+        customized_parameters = shlex.quote(customized_parameters)
+        script.add_plain_dm_parameter(f"{customized_parameters}")
     script.add_plain_dm_parameter(f"{vm_name}")
 
     return script

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -472,6 +472,11 @@ argument and memory.</xs:documentation>
         <xs:documentation>Enable virtualization of PCIe Precision Time Measurement (PTM) mechanism for devices with PTM capability and for real-time application. The hypervisor provides PCIe root port emulation instead of host bridge emulation for the VM. PTM coordinates timing between the device and root port with the device's local timebases without relying on software.</xs:documentation>
       </xs:annotation>
     </xs:element>
+    <xs:element name="customized_parameters" type="xs:string" minOccurs="0">
+      <xs:annotation acrn:title="Customized Parameters" acrn:views="advanced">
+        <xs:documentation>Specify the customized parameters that are appened to the device model when launching this VM.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
     <xs:element name="virtio_devices">
       <xs:annotation acrn:title="Virt-IO devices" acrn:views="basic" acrn:applicable-vms="post-launched">
         <xs:documentation>Enable virt-IO devices in post-launched VMs.</xs:documentation>


### PR DESCRIPTION
add customized parameters in the launch script generation logic. If user specify customized parameters in configurator, we will append them to the dm parameters for launching VMs.

Tracked-On: #8408
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>