### PR TITLE
doc: add mirror for v2.7 intersphinx inventory file

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,7 +53,8 @@ extlinks = {
 # (We only need to link to an archive that has the older release notes)
 
 intersphinx_mapping = {
-        'v2.7': ('https://projectacrn.github.io/2.7', None),
+        'v2.7': ('https://projectacrn.github.io/2.7',
+                 (None, 'https://raw.githubusercontent.com/projectacrn/projectacrn.github.io/master/2.7/objects.inv')),
         }
 
 graphviz_output_format='png'


### PR DESCRIPTION
This patch enables intersphinx to pull the objects.inv file directly from projectarcn/projectacrn.github.io repo when github pages was experiencing downtime.