### PR TITLE
enable VHWP for guests who owns pCPUs(part 2)

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -224,6 +224,16 @@ bool is_vhwp_configured(const struct acrn_vm *vm)
 }
 
 /**
+ * @pre vm != NULL && vm_config != NULL && vm->vmid < CONFIG_MAX_VM_NUM
+ */
+bool is_vtm_configured(const struct acrn_vm *vm)
+{
+	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
+
+	return ((vm_config->guest_flags & GUEST_FLAG_VTM) != 0U);
+}
+
+/**
  * @brief VT-d PI posted mode can possibly be used for PTDEVs assigned
  * to this VM if platform supports VT-d PI AND lapic passthru is not configured
  * for this VM.

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -1314,5 +1314,8 @@ void update_msr_bitmap_x2apic_passthru(struct acrn_vcpu *vcpu)
 	enable_msr_interception(msr_bitmap, MSR_IA32_EXT_XAPICID, INTERCEPT_READ);
 	enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_LDR, INTERCEPT_READ);
 	enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_ICR, INTERCEPT_WRITE);
+	if (!is_vtm_configured(vcpu->vm)) {
+		enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_LVT_THERMAL, INTERCEPT_READ_WRITE);
+	}
 	set_tsc_msr_interception(vcpu, exec_vmread64(VMX_TSC_OFFSET_FULL) != 0UL);
 }

--- a/hypervisor/include/arch/x86/asm/guest/vm.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm.h
@@ -275,6 +275,7 @@ bool vm_hide_mtrr(const struct acrn_vm *vm);
 void update_vm_vlapic_state(struct acrn_vm *vm);
 enum vm_vlapic_mode check_vm_vlapic_mode(const struct acrn_vm *vm);
 bool is_vhwp_configured(const struct acrn_vm *vm);
+bool is_vtm_configured(const struct acrn_vm *vm);
 /*
  * @pre vm != NULL
  */

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -64,6 +64,7 @@
 #define GUEST_FLAG_REE				(1UL << 10U)	/* Whether the VM is REE VM */
 #define GUEST_FLAG_PMU_PASSTHROUGH	(1UL << 11U)    /* Whether PMU is passed through */
 #define GUEST_FLAG_VHWP				(1UL << 12U)    /* Whether the VM supports vHWP */
+#define GUEST_FLAG_VTM				(1UL << 13U)    /* Whether the VM supports virtual thermal monitor */
 
 /* TODO: We may need to get this addr from guest ACPI instead of hardcode here */
 #define VIRTUAL_SLEEP_CTL_ADDR		0x400U /* Pre-launched VM uses ACPI reduced HW mode and sleep control register */


### PR DESCRIPTION
Background:

Currently CPU frequency control is hidden to guests, and controlled by
hypervisor. While it is sufficient in most cases, some guest OS may
still need CPU performance info to make multi-core scheduling decisions.

This is seen on Linux kernel, which uses HWP highest performance level
as CPU core's priority in multi-core scheduling (CONFIG_SCHED_MC_PRIO).
Enabling this kernel feature could improve performance as single thread
workloads are scheduled on the highest performance cores. This is
significantly useful for guests with hybrid cores.

Design:

The concept is to create a virtual HWP(VHWP) interface for guests, so
that guest can have some CPU performance managing and prioritized MC
scheduling abilities.

For guests owning its pCPUs, we can just allow vCPU read
IA32_HWP_CAPABLITIES and write certain bit fields in IA32_HWP_REQUEST.
But for CPU sharing guests, vCPU’s performance capability involves how
they share CPU time slice, and it is much more complicated. Currently we
only support guest who owns its pCPUs. Windows guests are also excluded
for this feature, as it does not load frequency driver in VM.

Intel_pstate driver also relies on CONFIG_ACPI_CPPC_LIB to implement
prioritized MC scheduling, this means we also need to provide ACPI _CPC
in DM.

Another thing is thermal. Thermal events are delivered through lapic
thermal LVT. Currently ACRN does not support delivering those interrupts
to guests by virtual lapic. They need to be virtualized to provide
guests some thermal management abilities in the future. Currently we
just hide those thermal program interfaces from guests.


