### PR TITLE
Backport compiler fix for release 3.2

### DIFF
--- a/devicemodel/hw/pci/gvt.c
+++ b/devicemodel/hw/pci/gvt.c
@@ -256,7 +256,7 @@ gvt_init_config(struct pci_gvt *gvt)
 	/* capability */
 	pci_set_cfgdata8(gvt->gvt_pi, PCIR_CAP_PTR, gvt->host_config[0x34]);
 	cap_ptr = gvt->host_config[0x34];
-	while (cap_ptr != 0) {
+	while (cap_ptr != 0 && cap_ptr <= PCI_REGMAX - 15) {
 		pci_set_cfgdata32(gvt->gvt_pi, cap_ptr,
 			gvt->host_config[cap_ptr]);
 		pci_set_cfgdata32(gvt->gvt_pi, cap_ptr + 4,

--- a/misc/services/life_mngr/list.h
+++ b/misc/services/life_mngr/list.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2023 Intel Corporation.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/queue.h>
+
+#define list_foreach_safe(var, head, field, tvar)	\
+for ((var) = LIST_FIRST((head));			\
+	(var) && ((tvar) = LIST_NEXT((var), field), 1); \
+	(var) = (tvar))

--- a/misc/services/life_mngr/socket.c
+++ b/misc/services/life_mngr/socket.c
@@ -18,12 +18,7 @@
 #include <arpa/inet.h>
 #include "socket.h"
 #include "log.h"
-
-
-#define list_foreach_safe(var, head, field, tvar)	\
-for ((var) = LIST_FIRST((head));			\
-	(var) && ((tvar) = LIST_NEXT((var), field), 1);\
-	(var) = (tvar))
+#include "list.h"
 
 
 static int setup_and_listen_unix_socket(const char *sock_path, int num)

--- a/misc/services/life_mngr/uart_channel.c
+++ b/misc/services/life_mngr/uart_channel.c
@@ -18,6 +18,7 @@
 #include <stdint.h>
 #include "uart_channel.h"
 #include "log.h"
+#include "list.h"
 #include "config.h"
 #include "command.h"
 
@@ -308,9 +309,9 @@ struct channel_dev *create_uart_channel_dev(struct uart_channel *c, char *path, 
 }
 static void destroy_uart_channel_devs(struct uart_channel *c)
 {
-	struct channel_dev *c_dev;
+	struct channel_dev *c_dev, *tc_dev;
 
-	LIST_FOREACH(c_dev, &c->tty_open_head, open_list) {
+	list_foreach_safe(c_dev, &c->tty_open_head, open_list, tc_dev) {
 		pthread_mutex_lock(&c->tty_conn_list_lock);
 		LIST_REMOVE(c_dev, open_list);
 		pthread_mutex_unlock(&c->tty_conn_list_lock);


### PR DESCRIPTION
Backport following commits to release 3.2 to solve build issues with gcc 12/13

c9e5fd146 misc: fix the summary issue after update board xml
632097778 dm: gvt: add bound check in gvt_init_config()
e4e25f076 hv: sgx: refactor partition_epc()