### PR TITLE
hv: allow non-service vm to read MSR_PLATFORM_INFO (CEh)

### DIFF
--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -797,7 +797,9 @@ int32_t rdmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 			     MSR_PLATFORM_INFO_MIN_OPERATING_RATIO_MASK |
 			     MSR_PLATFORM_INFO_SAMPLE_PART;
 		} else {
-			err = -EACCES;
+			/* Allow read by non-service vm for compatibility */
+			v = 0UL;
+			pr_warn("%s(): vm%d read MSR_PLATFORM_INFO", __func__, vcpu->vm->vm_id);
 		}
 		break;
 	}


### PR DESCRIPTION
Guests may read MSR_PLATFORM_INFO to get nominal TSC frequency, though it should be replaced by reading CPUID leaf 0x16 on newer processors. This patch emulates MSR_PLATFORM_INFO with 0 for non-service vm instead of injecting #GP to avoid guest crash.

Tracked-On: #8406
Reviewed-by: Junjie Mao <junjie.mao@intel.com>