### PR TITLE
hv: bugfix: fix the ptdev irq destination issue

### DIFF
--- a/hypervisor/include/arch/x86/asm/apicreg.h
+++ b/hypervisor/include/arch/x86/asm/apicreg.h
@@ -253,6 +253,8 @@ union ioapic_rte {
 
 /* fields in LDR */
 #define	APIC_LDR_RESERVED	0x00ffffffU
+#define X2APIC_LDR_LOGICAL_ID_MASK	0x0000ffffU
+#define X2APIC_LDR_CLUSTER_ID_MASK	0xffff0000U
 
 /* fields in DFR */
 #define	APIC_DFR_RESERVED	0x0fffffffU


### PR DESCRIPTION
According to SDM Vol3 11.12.10, in x2APIC mode, Logical Destination has two parts:
  - Cluster ID (LDR[31:16])
  - Logical ID (LDR[15:0]) Cluster ID is a numerical address, while Logical ID is a 16bit mask. We can only use Logical ID to address multi destinations within a Cluster.

So we can't just 'or' all the Logical Destination in LDR registers to get one mask for all target pCPUs. This would get a wrong destination mask if the target Destinations are from different Clusters.

For example in ADL/RPL x2APIC LDRs for core 2-5 are 0x10001 0x10100 0x20001 0x20100. If we 'or' them together, we would get a Logical Destination of 0x30101, which points to core 6 and another core. If core 6 is running a RTVM, then the irq is unable to get to core 2-5, causing the guest on core 2-5 driver fail.

There would be no perfect fix for this issue, cause we can't address all Logical Destinations for different Clusters. This patch is a simple fix, by just keep the first Cluster of all target Logical Destinations.

Tracked-On: #8435

Reviewed-by: Junjie Mao <junjie.mao@intel.com>