### PR TITLE
misc: sample_application: fix setup_hmi_vm.sh for Ubuntu 22.04

### DIFF
--- a/misc/sample_application/image_builder/create_image.sh
+++ b/misc/sample_application/image_builder/create_image.sh
@@ -227,7 +227,7 @@ function cleanup() {
 mount_point=$(pwd)/mnt
 if [[ ${vm_type} == "hmi-vm" ]]; then
     target_image=${hmi_vm_image}
-    size_modifier="+5G"
+    size_modifier="+7G"
 elif [[ ${vm_type} == "rt-vm" ]]; then
     target_image=${rt_vm_image}
     size_modifier="+1G"

--- a/misc/sample_application/image_builder/setup_hmi_vm.sh
+++ b/misc/sample_application/image_builder/setup_hmi_vm.sh
@@ -12,17 +12,20 @@ function umount_directory() {
 }
 
 function update_package_info() {
-    apt update -y && apt install python3 python3-pip \
-        net-tools python3-matplotlib \
-	linux-modules-extra-$(uname -r) \
-	openssh-server \
-	isc-dhcp-server -y
+    apt update -y
+    # Remove needrestart to disable interactive prompts in apt install
+    apt remove -y needrestart
+    apt install -y python3 python3-pip net-tools python3-matplotlib openssh-server \
+        isc-dhcp-server linux-generic-hwe-$(lsb_release -sr)
     pip3 install flask 'numpy>=1.18.5' pandas posix_ipc
-
 }
 
 function install_desktop() {
     apt install ubuntu-gnome-desktop -y
+}
+
+function cleanup_packages() {
+    apt autoremove -y
 }
 
 function change_root_password() {
@@ -64,6 +67,7 @@ try_step "Unmounting /root" umount_directory /root
 try_step "Unmounting /home" umount_directory /home
 try_step "Updating package information" update_package_info
 try_step "Installing GNOME desktop" install_desktop
+try_step "Cleaning up packages" cleanup_packages
 try_step "Changing the password of the root user" change_root_password
 try_step "Enable root user login" enable_root_login
 try_step "Adding the normal user acrn" add_normal_user


### PR DESCRIPTION
In chroot environment, the running kernel is the host kernel, so uname command cannot get the kernel verison in image. Since hmi-vm uses GVT-d, and kernel 5.15 does not support newer iGPUs in 13th Gen processors, this patch installs the linux-generic-hwe kernel (5.19) instead of linux-modules-extra package.

In Ubuntu 22.04, package needrestart is installed by default to interactively prompt user there is a pending kernel upgrade or serivces need to be restarted in apt. This patch removes it.

Also, this patch expands hmi-vm image by 2GB to hold the new kernel and runs 'apt autoremove' after everything is installed.