### PR TITLE
doc: update network configuration section

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -667,8 +667,12 @@ The ACRN hypervisor boots the Ubuntu Service VM automatically.
    so the Device Model can create a bridge device (acrn-br0) that provides User VMs with
    wired network access:
 
+   .. warning::
+      The IP address of Service VM may change after executing the following command.
+
    .. code-block:: bash
 
+      cp /usr/share/doc/acrnd/examples/* /etc/systemd/network
       sudo systemctl enable --now systemd-networkd
 
 .. _gsg-user-vm:

--- a/doc/getting-started/sample-app.rst
+++ b/doc/getting-started/sample-app.rst
@@ -449,8 +449,14 @@ Install and Run ACRN on the Target System
      sudo apt purge acrn-hypervisor
      sudo apt install /tmp/acrn-hypervisor*.deb  /tmp/*acrn-service-vm*.deb
 
-#. Enable networking services for sharing with the HMI User VM::
+#. Enable networking services for sharing with the HMI User VM:
 
+   .. warning::
+      The IP address of Service VM may change after executing the following command.
+
+   .. code-block:: bash
+
+     cp /usr/share/doc/acrnd/examples/* /etc/systemd/network
      sudo systemctl enable --now systemd-networkd
 
 #. Reboot the system::


### PR DESCRIPTION
Launch script attaches guest network to bridge acrn-br0 by default, while this bridge is not automatically created during installation. This patch updates the documentation to guide users with the sample bridge configuration in Getting Started Guide and Sample Application Guide.

Tracked-On: #8448