### PR TITLE
doc: building doc with python 3.11 + doxygen 1.9.4

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -2012,8 +2012,6 @@ pci_msix_enabled(struct pci_vdev *dev)
  *
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  * @param index MSIx table entry index.
- *
- * @return None
  */
 void
 pci_generate_msix(struct pci_vdev *dev, int index)
@@ -2041,8 +2039,6 @@ pci_generate_msix(struct pci_vdev *dev, int index)
  *
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  * @param index Message data index.
- *
- * @return None
  */
 void
 pci_generate_msi(struct pci_vdev *dev, int index)
@@ -2163,8 +2159,6 @@ pci_lintr_route(struct pci_vdev *dev)
  * @brief Assert INTx pin of virtual PCI device
  *
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
- *
- * @return None
  */
 void
 pci_lintr_assert(struct pci_vdev *dev)
@@ -2189,8 +2183,6 @@ pci_lintr_assert(struct pci_vdev *dev)
  * @brief Deassert INTx pin of virtual PCI device
  *
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
- *
- * @return None
  */
 void
 pci_lintr_deassert(struct pci_vdev *dev)

--- a/devicemodel/hw/pci/virtio/virtio.c
+++ b/devicemodel/hw/pci/virtio/virtio.c
@@ -187,8 +187,6 @@ virtio_poll_timer(void *arg, uint64_t nexp)
  * @param pci_virtio_dev Pointer to instance of certain virtio device.
  * @param dev Pointer to struct pci_vdev which emulates a PCI device.
  * @param queues Pointer to struct virtio_vq_info, normally an array.
- *
- * @return None
  */
 void
 virtio_linkup(struct virtio_base *base, struct virtio_ops *vops,
@@ -226,8 +224,6 @@ virtio_linkup(struct virtio_base *base, struct virtio_ops *vops,
  * If MSI-X is enabled, this also resets all the vectors to NO_VECTOR.
  *
  * @param base Pointer to struct virtio_base.
- *
- * @return None
  */
 void
 virtio_reset_dev(struct virtio_base *base)
@@ -275,8 +271,6 @@ virtio_reset_dev(struct virtio_base *base)
  *
  * @param base Pointer to struct virtio_base.
  * @param barnum Which BAR[0..5] to use.
- *
- * @return None
  */
 void
 virtio_set_io_bar(struct virtio_base *base, int barnum)
@@ -765,8 +759,6 @@ vq_endchains(struct virtio_vq_info *vq, int used_all_avail)
  *
  * @param base Pointer to struct virtio_base.
  * @param vq Pointer to struct virtio_vq_info.
- *
- * @return None
  */
 void vq_clear_used_ring_flags(struct virtio_base *base, struct virtio_vq_info *vq)
 {
@@ -1929,8 +1921,6 @@ virtio_pci_read(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
  * @param offset Register offset in bytes within a BAR region.
  * @param size Access range in bytes.
  * @param value Data value to be written into register.
- *
- * @return None
  */
 void
 virtio_pci_write(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -350,8 +350,6 @@ int	pci_emul_add_pciecap(struct pci_vdev *pi, int pcie_device_type);
  *
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  * @param index Message data index.
- *
- * @return None
  */
 void	pci_generate_msi(struct pci_vdev *dev, int index);
 
@@ -360,8 +358,6 @@ void	pci_generate_msi(struct pci_vdev *dev, int index);
  *
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  * @param index MSIs table entry index.
- *
- * @return None
  */
 void	pci_generate_msix(struct pci_vdev *dev, int index);
 
@@ -369,8 +365,6 @@ void	pci_generate_msix(struct pci_vdev *dev, int index);
  * @brief Assert INTx pin of virtual PCI device
  *
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
- *
- * @return None
  */
 void	pci_lintr_assert(struct pci_vdev *dev);
 
@@ -378,8 +372,6 @@ void	pci_lintr_assert(struct pci_vdev *dev);
  * @brief Deassert INTx pin of virtual PCI device
  *
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
- *
- * @return None
  */
 void	pci_lintr_deassert(struct pci_vdev *dev);
 
@@ -417,8 +409,6 @@ struct pci_vdev *pci_get_vdev_info(int slot);
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  * @param offset Offset in configuration space.
  * @param val Value in 1 byte.
- *
- * @return None
  */
 static inline void
 pci_set_cfgdata8(struct pci_vdev *dev, int offset, uint8_t val)
@@ -436,8 +426,6 @@ pci_set_cfgdata8(struct pci_vdev *dev, int offset, uint8_t val)
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  * @param offset Offset in configuration space.
  * @param val Value in 2 bytes.
- *
- * @return None
  */
 static inline void
 pci_set_cfgdata16(struct pci_vdev *dev, int offset, uint16_t val)
@@ -455,8 +443,6 @@ pci_set_cfgdata16(struct pci_vdev *dev, int offset, uint16_t val)
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  * @param offset Offset in configuration space.
  * @param val Value in 4 bytes.
- *
- * @return None
  */
 static inline void
 pci_set_cfgdata32(struct pci_vdev *dev, int offset, uint32_t val)

--- a/devicemodel/include/virtio.h
+++ b/devicemodel/include/virtio.h
@@ -510,8 +510,6 @@ vq_has_descs(struct virtio_vq_info *vq)
  *
  * @param vb Pointer to struct virtio_base.
  * @param vq Pointer to struct virtio_vq_info.
- *
- * @return None
  */
 static inline void
 vq_interrupt(struct virtio_base *vb, struct virtio_vq_info *vq)
@@ -533,8 +531,6 @@ vq_interrupt(struct virtio_base *vb, struct virtio_vq_info *vq)
  * MSI-X or a generic MSI interrupt with config changed event.
  *
  * @param vb Pointer to struct virtio_base.
- *
- * @return None
  */
 static inline void
 virtio_config_changed(struct virtio_base *vb)
@@ -567,8 +563,6 @@ struct iovec;
  * @param dev Pointer to struct pci_vdev which emulates a PCI device.
  * @param queues Pointer to struct virtio_vq_info, normally an array.
  * @param backend_type can be VBSU, VBSK or VHOST
- *
- * @return None
  */
 void virtio_linkup(struct virtio_base *base, struct virtio_ops *vops,
 		   void *pci_virtio_dev, struct pci_vdev *dev,
@@ -624,8 +618,6 @@ int virtio_intr_init(struct virtio_base *base, int barnum, int use_msix);
  * If MSI-X is enabled, this also resets all the vectors to NO_VECTOR.
  *
  * @param base Pointer to struct virtio_base.
- *
- * @return None
  */
 void virtio_reset_dev(struct virtio_base *base);
 
@@ -634,8 +626,6 @@ void virtio_reset_dev(struct virtio_base *base);
  *
  * @param base Pointer to struct virtio_base.
  * @param barnum Which BAR[0..5] to use.
- *
- * @return None
  */
 void virtio_set_io_bar(struct virtio_base *base, int barnum);
 
@@ -660,8 +650,6 @@ int vq_getchain(struct virtio_vq_info *vq, uint16_t *pidx,
  * available ring.
  *
  * @param vq Pointer to struct virtio_vq_info.
- *
- * @return None
  */
 void vq_retchain(struct virtio_vq_info *vq);
 
@@ -672,8 +660,6 @@ void vq_retchain(struct virtio_vq_info *vq);
  * @param vq Pointer to struct virtio_vq_info.
  * @param idx Pointer to available ring position, returned by vq_getchain().
  * @param iolen Number of data bytes to be returned to frontend.
- *
- * @return None
  */
 void vq_relchain(struct virtio_vq_info *vq, uint16_t idx, uint32_t iolen);
 
@@ -685,8 +671,6 @@ void vq_relchain(struct virtio_vq_info *vq, uint16_t idx, uint32_t iolen);
  *
  * @param vq Pointer to struct virtio_vq_info.
  * @param used_all_avail Flag indicating if driver used all available chains.
- *
- * @return None
  */
 void vq_endchains(struct virtio_vq_info *vq, int used_all_avail);
 
@@ -699,8 +683,6 @@ void vq_endchains(struct virtio_vq_info *vq, int used_all_avail);
  *
  * @param base Pointer to struct virtio_base.
  * @param vq Pointer to struct virtio_vq_info.
- *
- * @return None
  */
 void vq_clear_used_ring_flags(struct virtio_base *base, struct virtio_vq_info *vq);
 
@@ -735,8 +717,6 @@ uint64_t virtio_pci_read(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
  * @param offset Register offset in bytes within a BAR region.
  * @param size Access range in bytes.
  * @param value Data value to be written into register.
- *
- * @return None
  */
 void virtio_pci_write(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
 		      int baridx, uint64_t offset, int size, uint64_t value);

--- a/doc/acrn.doxyfile
+++ b/doc/acrn.doxyfile
@@ -1809,7 +1809,7 @@ LATEX_HIDE_INDICES     = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_SOURCE_CODE      = NO
+# LATEX_SOURCE_CODE      = NO
 
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
@@ -1891,7 +1891,7 @@ RTF_EXTENSIONS_FILE    =
 # The default value is: NO.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
-RTF_SOURCE_CODE        = NO
+# RTF_SOURCE_CODE        = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the man page output
@@ -1989,7 +1989,7 @@ DOCBOOK_OUTPUT         = docbook
 # The default value is: NO.
 # This tag requires that the tag GENERATE_DOCBOOK is set to YES.
 
-DOCBOOK_PROGRAMLISTING = NO
+# DOCBOOK_PROGRAMLISTING = NO
 
 #---------------------------------------------------------------------------
 # Configuration options for the AutoGen Definitions output
@@ -2187,7 +2187,7 @@ EXTERNAL_PAGES         = YES
 # powerful graphs.
 # The default value is: YES.
 
-CLASS_DIAGRAMS         = YES
+# CLASS_DIAGRAMS         = YES
 
 # You can define message sequence charts within doxygen comments using the \msc
 # command. Doxygen will then run the mscgen tool (see:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -133,7 +133,7 @@ language = 'en'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'misc/README.rst' ]
+exclude_patterns = ['_build', 'misc/README.rst', 'venv' ]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/doc/developer-guides/c_coding_guidelines.rst
+++ b/doc/developer-guides/c_coding_guidelines.rst
@@ -3312,8 +3312,7 @@ each function:
     ``@post <post-condition description>``.
 12) The brief description of the function return value shall be documented
     with the format ``@return <brief description of return value>``.
-13) A void-returning function shall be documented with the format
-    ``@return None``.
+13) A void-returning function shall not be documented with ``@return``.
 14) The comments explaining the actual return values shall be documented with
     the format ``@retval <return value> <return value explanation>``.
 15) If the description of one element needs to span multiple lines, each line

--- a/doc/scripts/filter-known-issues.py
+++ b/doc/scripts/filter-known-issues.py
@@ -36,7 +36,6 @@ import logging
 import mmap
 import os
 import re
-import sre_constants
 import sys
 import traceback
 
@@ -69,7 +68,7 @@ def config_import_file(filename):
                 regex = gd['regex']
                 try:
                     r = re.compile(regex, re.MULTILINE)
-                except sre_constants.error as e:
+                except re.error as e:
                     logging.error("%s: bytes %d-%d: bad regex: %s",
                                   filename, m.start(), m.end(), e)
                     raise

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -547,8 +547,6 @@ static void vlapic_accept_intr(struct acrn_vlapic *vlapic, uint32_t vector, bool
  *
  * @param[in] dest_pcpu_id Target CPU ID.
  * @param[in] anv Activation Notification Vectors (ANV)
- *
- * @return None
  */
 static void apicv_trigger_pi_anv(uint16_t dest_pcpu_id, uint32_t anv)
 {
@@ -1256,8 +1254,6 @@ static bool vlapic_find_deliverable_intr(const struct acrn_vlapic *vlapic, uint3
  *
  * @param[in] vlapic Pointer to target vLAPIC data structure
  * @param[in] vector Target virtual interrupt vector
- *
- * @return None
  *
  * @pre vlapic != NULL
  */

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -276,8 +276,6 @@ void send_single_ipi(uint16_t pcpu_id, uint32_t vector)
 
 /**
  * @pre pcpu_id < MAX_PCPU_NUM
- *
- * @return None
  */
 void send_single_init(uint16_t pcpu_id)
 {

--- a/hypervisor/dm/io_req.c
+++ b/hypervisor/dm/io_req.c
@@ -53,8 +53,6 @@ __unused static void acrn_print_request(uint16_t vcpu_id, const struct acrn_io_r
  * @brief Reset all IO requests status of the VM
  *
  * @param vm The VM whose IO requests to be reset
- *
- * @return None
  */
 void reset_vm_ioreqs(struct acrn_vm *vm)
 {
@@ -827,8 +825,6 @@ static inline struct mem_io_node *find_free_mmio_node(struct acrn_vm *vm)
  * @param start The base address of the range \p read_write can emulate
  * @param end The end of the range (exclusive) \p read_write can emulate
  * @param handler_private_data Handler-specific data which will be passed to \p read_write when called
- *
- * @return None
  */
 void register_mmio_emulation_handler(struct acrn_vm *vm,
 	hv_mem_io_handler_t read_write, uint64_t start,
@@ -861,8 +857,6 @@ void register_mmio_emulation_handler(struct acrn_vm *vm,
  * @param vm The VM to which the MMIO handler is unregistered
  * @param start The base address of the range which wants to unregister
  * @param end The end of the range (exclusive) which wants to unregister
- *
- * @return None
  */
 void unregister_mmio_emulation_handler(struct acrn_vm *vm,
 					uint64_t start, uint64_t end)

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -192,8 +192,6 @@ vioapic_set_irqline_nolock(const struct acrn_vm *vm, uint32_t vgsi, uint32_t ope
  *
  * @pre vgsi < get_vm_gsicount(vm)
  * @pre vm != NULL
- *
- * @return None
  */
 void
 vioapic_set_irqline_lock(const struct acrn_vm *vm, uint32_t vgsi, uint32_t operation)

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -346,8 +346,6 @@ void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val)
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
  * @pre vdev->pdev != NULL
- *
- * @return None
  */
 static void init_bars(struct pci_vdev *vdev, bool is_sriov_bar)
 {
@@ -525,7 +523,7 @@ void passthru_gpu_opregion(struct pci_vdev *vdev)
 	pci_vdev_write_vcfg(vdev, PCIR_ASLS_CTL, 4U, gpu_opregion_gpa | (gpu_asls_phys & ~PCIM_ASLS_OPREGION_MASK));
 }
 
-/*
+/**
  * @brief Initialize a specified passthrough vdev structure.
  *
  * The function init_vdev_pt is used to initialize a vdev structure. If a vdev structure supports
@@ -539,8 +537,6 @@ void passthru_gpu_opregion(struct pci_vdev *vdev)
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
  * @pre vdev->pdev != NULL
- *
- * @return None
  */
 void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev)
 {
@@ -597,7 +593,7 @@ void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev)
 
 }
 
-/*
+/**
  * @brief Destruct a specified passthrough vdev structure.
  *
  * The function deinit_vdev_pt is the destructor corresponding to the function init_vdev_pt.
@@ -605,8 +601,6 @@ void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev)
  * @param vdev  pointer to vdev data structure
  *
  * @pre vdev != NULL
- *
- * @return None
  */
 void deinit_vdev_pt(struct pci_vdev *vdev) {
 

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -846,7 +846,7 @@ void vpci_update_one_vbar(struct pci_vdev *vdev, uint32_t bar_idx, uint32_t val,
 	}
 }
 
-/*
+/**
  * @brief Add emulated legacy PCI capability support for virtual PCI device
  *
  * @param vdev     Pointer to vdev data structure
@@ -855,8 +855,6 @@ void vpci_update_one_vbar(struct pci_vdev *vdev, uint32_t bar_idx, uint32_t val,
  *
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- *
- * @return None
  */
 uint32_t vpci_add_capability(struct pci_vdev *vdev, uint8_t *capdata, uint8_t caplen)
 {

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -540,8 +540,6 @@ static void vpic_set_pinstate(struct acrn_vpic *vpic, uint32_t pin, uint8_t leve
  * @param[in] irqline   Target IRQ number
  * @param[in] operation action options:GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
- *
- * @return None
  */
 void vpic_set_irqline(struct acrn_vpic *vpic, uint32_t vgsi, uint32_t operation)
 {
@@ -613,7 +611,6 @@ void vpic_get_irqline_trigger_mode(const struct acrn_vpic *vpic, uint32_t vgsi,
  *			with eligible vector if any.
  *
  * @pre this function should be called after vpic_init()
- * @return None
  */
 void vpic_pending_intr(struct acrn_vpic *vpic, uint32_t *vecptr)
 {
@@ -669,8 +666,6 @@ static void vpic_pin_accepted(struct i8259_reg_state *i8259, uint32_t pin)
  *
  * @param[in] vm     Pointer to target VM
  * @param[in] vector Target virtual interrupt vector
- *
- * @return None
  *
  * @pre vm != NULL
  * @pre this function should be called after vpic_init()

--- a/hypervisor/include/arch/x86/asm/guest/assign.h
+++ b/hypervisor/include/arch/x86/asm/guest/assign.h
@@ -32,8 +32,6 @@
  * @param[in] virt_gsi virtual GSI number associated with the passthrough device
  * @param[in] vgsi_ctlr INTX_CTLR_IOAPIC or INTX_CTLR_PIC
  *
- * @return None
- *
  * @pre vm != NULL
  *
  */
@@ -120,8 +118,6 @@ int32_t ptirq_add_intx_remapping(struct acrn_vm *vm, uint32_t virt_gsi, uint32_t
  * @param[in] pic_pin true for pic, false for ioapic
  * @param[in] is_phy_gsi true if gsi is physical, false if gsi is virtual
  *
- * @return None
- *
  * @pre vm != NULL
  *
  */
@@ -136,8 +132,6 @@ void ptirq_remove_intx_remapping(const struct acrn_vm *vm, uint32_t gsi, bool pi
  * @param[in] phys_bdf physical bdf associated with the passthrough device
  * @param[in] vector_count number of vectors
  *
- * @return None
- *
  * @pre vm != NULL
  *
  */
@@ -149,8 +143,6 @@ void ptirq_remove_msix_remapping(const struct acrn_vm *vm, uint16_t phys_bdf, ui
  * Deactivate & remove all mapping entries of the virt_gsis defined in VM config for given vm.
  *
  * @param[in] vm pointer to acrn_vm
- *
- * @return None
  *
  * @pre vm != NULL
  *

--- a/hypervisor/include/arch/x86/asm/guest/ept.h
+++ b/hypervisor/include/arch/x86/asm/guest/ept.h
@@ -37,8 +37,6 @@ bool ept_is_valid_mr(struct acrn_vm *vm, uint64_t mr_base_gpa, uint64_t size);
  * @brief EPT page tables destroy
  *
  * @param[inout] vm the pointer that points to VM data structure
- *
- * @return None
  */
 void destroy_ept(struct acrn_vm *vm);
 /**
@@ -83,8 +81,6 @@ uint64_t service_vm_hpa2gpa(uint64_t hpa);
  * @param[in] size The size of guest physical memory region that needs
  *                 to be mapped
  * @param[in] prot_orig The specified memory access right and memory type
- *
- * @return None
  */
 void ept_add_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t hpa,
 		uint64_t gpa, uint64_t size, uint64_t prot_orig);
@@ -100,8 +96,6 @@ void ept_add_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t hpa,
  *                     that will be set
  * @param[in] prot_clr The specified memory access right and memory type
  *                     that will be cleared
- *
- * @return None
  */
 void ept_modify_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa,
 		uint64_t size, uint64_t prot_set, uint64_t prot_clr);
@@ -114,8 +108,6 @@ void ept_modify_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa,
  *                physical memory region whoes mapping needs to be deleted
  * @param[in] size The size of guest physical memory region
  *
- * @return None
- *
  * @pre [gpa,gpa+size) has been mapped into host physical memory region
  */
 void ept_del_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa,
@@ -127,8 +119,6 @@ void ept_del_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa,
  * @param[in] pge the pointer that points to the page entry
  *
  * @param[in] size the size of the page
- *
- * @return None
  */
 void ept_flush_leaf_page(uint64_t *pge, uint64_t size);
 
@@ -149,8 +139,6 @@ void *get_eptp(struct acrn_vm *vm);
  * @param[in] cb the pointer that points to walk_ept_table callback, the callback
  * 		will be invoked when getting a present page entry from EPT, and
  *		the callback could get the page entry and page size parameters.
- *
- * @return None
  */
 void walk_ept_table(struct acrn_vm *vm, pge_handler cb);
 

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -400,8 +400,6 @@ uint64_t vcpu_get_gpreg(const struct acrn_vcpu *vcpu, uint32_t reg);
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] reg register of the vcpu
  * @param[in] val the value set the register of the vcpu
- *
- * @return None
  */
 void vcpu_set_gpreg(struct acrn_vcpu *vcpu, uint32_t reg, uint64_t val);
 
@@ -423,8 +421,6 @@ uint64_t vcpu_get_rip(struct acrn_vcpu *vcpu);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] val the value set RIP
- *
- * @return None
  */
 void vcpu_set_rip(struct acrn_vcpu *vcpu, uint64_t val);
 
@@ -446,8 +442,6 @@ uint64_t vcpu_get_rsp(const struct acrn_vcpu *vcpu);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] val the value set RSP
- *
- * @return None
  */
 void vcpu_set_rsp(struct acrn_vcpu *vcpu, uint64_t val);
 
@@ -469,8 +463,6 @@ uint64_t vcpu_get_efer(struct acrn_vcpu *vcpu);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] val the value set EFER
- *
- * @return None
  */
 void vcpu_set_efer(struct acrn_vcpu *vcpu, uint64_t val);
 
@@ -492,8 +484,6 @@ uint64_t vcpu_get_rflags(struct acrn_vcpu *vcpu);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] val the value set RFLAGS
- *
- * @return None
  */
 void vcpu_set_rflags(struct acrn_vcpu *vcpu, uint64_t val);
 
@@ -517,8 +507,6 @@ uint64_t vcpu_get_guest_msr(const struct acrn_vcpu *vcpu, uint32_t msr);
  * @param[in] vcpu pointer to vcpu data structure
  * @param[in] msr the guest MSR
  * @param[in] val the value to set the target MSR
- *
- * @return None
  */
 void vcpu_set_guest_msr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t val);
 
@@ -526,8 +514,6 @@ void vcpu_set_guest_msr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t val);
  * @brief write eoi_exit_bitmap to VMCS fields
  *
  * @param[in] vcpu pointer to vcpu data structure
- *
- * @return None
  */
 void vcpu_set_vmcs_eoi_exit(const struct acrn_vcpu *vcpu);
 
@@ -535,8 +521,6 @@ void vcpu_set_vmcs_eoi_exit(const struct acrn_vcpu *vcpu);
  * @brief reset all eoi_exit_bitmaps
  *
  * @param[in] vcpu pointer to vcpu data structure
- *
- * @return None
  */
 
 void vcpu_reset_eoi_exit_bitmaps(struct acrn_vcpu *vcpu);
@@ -548,8 +532,6 @@ void vcpu_reset_eoi_exit_bitmaps(struct acrn_vcpu *vcpu);
  *
  * @param[in] vcpu pointer to vcpu data structure
  * @param[in] vector
- *
- * @return None
  */
 void vcpu_set_eoi_exit_bitmap(struct acrn_vcpu *vcpu, uint32_t vector);
 /**
@@ -559,8 +541,6 @@ void vcpu_set_eoi_exit_bitmap(struct acrn_vcpu *vcpu, uint32_t vector);
  *
  * @param[in] vcpu pointer to vcpu data structure
  * @param[in] vector
- *
- * @return None
  */
 void vcpu_clear_eoi_exit_bitmap(struct acrn_vcpu *vcpu, uint32_t vector);
 /**
@@ -570,8 +550,6 @@ void vcpu_clear_eoi_exit_bitmap(struct acrn_vcpu *vcpu, uint32_t vector);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] vcpu_regs all the registers' value
- *
- * @return None
  */
 void set_vcpu_regs(struct acrn_vcpu *vcpu, struct acrn_regs *vcpu_regs);
 
@@ -582,8 +560,6 @@ void set_vcpu_regs(struct acrn_vcpu *vcpu, struct acrn_regs *vcpu_regs);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] mode the reset mode
- *
- * @return None
  */
 void reset_vcpu_regs(struct acrn_vcpu *vcpu, enum reset_mode mode);
 
@@ -596,8 +572,6 @@ bool sanitize_cr0_cr4_pattern(void);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] vgdt_base_gpa guest physical address of gdt for guest
- *
- * @return None
  */
 void init_vcpu_protect_mode_regs(struct acrn_vcpu *vcpu, uint64_t vgdt_base_gpa);
 
@@ -608,8 +582,6 @@ void init_vcpu_protect_mode_regs(struct acrn_vcpu *vcpu, uint64_t vgdt_base_gpa)
  *
  * @param[inout] vcpu pointer to vCPU data structure
  * @param[in] entry startup entry for the vCPU
- *
- * @return None
  */
 void set_vcpu_startup_entry(struct acrn_vcpu *vcpu, uint64_t entry);
 
@@ -670,7 +642,6 @@ int32_t run_vcpu(struct acrn_vcpu *vcpu);
  * @param[inout] vcpu pointer to vcpu data structure
  * @pre vcpu != NULL
  * @pre vcpu->state == VCPU_ZOMBIE
- * @return None
  */
 void offline_vcpu(struct acrn_vcpu *vcpu);
 
@@ -683,7 +654,6 @@ void offline_vcpu(struct acrn_vcpu *vcpu);
  * @param[in] mode the reset mode
  * @pre vcpu != NULL
  * @pre vcpu->state == VCPU_ZOMBIE
- * @return None
  */
 void reset_vcpu(struct acrn_vcpu *vcpu, enum reset_mode mode);
 
@@ -694,8 +664,6 @@ void reset_vcpu(struct acrn_vcpu *vcpu, enum reset_mode mode);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] new_state the state to set vcpu
- *
- * @return None
  */
 void zombie_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state);
 
@@ -707,7 +675,6 @@ void zombie_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state);
  * @param[inout] vcpu pointer to vcpu data structure
  * @pre vcpu != NULL
  * @pre vcpu->state == VCPU_INIT
- * @return None
  */
 void launch_vcpu(struct acrn_vcpu *vcpu);
 
@@ -717,8 +684,6 @@ void launch_vcpu(struct acrn_vcpu *vcpu);
  * Kick a vCPU to handle the pending events.
  *
  * @param[in] vcpu pointer to vcpu data structure
- *
- * @return None
  */
 void kick_vcpu(struct acrn_vcpu *vcpu);
 
@@ -769,8 +734,6 @@ static inline bool is_lapic_pt_enabled(struct acrn_vcpu *vcpu)
  *
  * @param[in] vcpu_index a zero based index of where the vCPU is located in the vCPU list for current pCPU
  * @pre vcpu_index < CONFIG_MAX_VM_NUM
- *
- * @return None
  */
 void vcpu_handle_pi_notification(uint32_t vcpu_index);
 

--- a/hypervisor/include/arch/x86/asm/guest/virq.h
+++ b/hypervisor/include/arch/x86/asm/guest/virq.h
@@ -39,8 +39,6 @@ int32_t vcpu_queue_exception(struct acrn_vcpu *vcpu, uint32_t vector_arg, uint32
  *
  * @param[in] vcpu Pointer to vCPU.
  *
- * @return None
- *
  * @pre vcpu != NULL
  */
 void vcpu_inject_extint(struct acrn_vcpu *vcpu);
@@ -49,8 +47,6 @@ void vcpu_inject_extint(struct acrn_vcpu *vcpu);
  * @brief Inject NMI to guest.
  *
  * @param[in] vcpu Pointer to vCPU.
- *
- * @return None
  *
  * @pre vcpu != NULL
  */
@@ -61,8 +57,6 @@ void vcpu_inject_nmi(struct acrn_vcpu *vcpu);
  *
  * @param[in] vcpu     Pointer to vCPU.
  * @param[in] err_code Error Code to be injected.
- *
- * @return None
  *
  * @pre vcpu != NULL
  */
@@ -75,8 +69,6 @@ void vcpu_inject_gp(struct acrn_vcpu *vcpu, uint32_t err_code);
  * @param[in] addr     Address that result in PF.
  * @param[in] err_code Error Code to be injected.
  *
- * @return None
- *
  * @pre vcpu != NULL
  */
 void vcpu_inject_pf(struct acrn_vcpu *vcpu, uint64_t addr, uint32_t err_code);
@@ -86,8 +78,6 @@ void vcpu_inject_pf(struct acrn_vcpu *vcpu, uint64_t addr, uint32_t err_code);
  *
  * @param[in] vcpu Pointer to vCPU.
  *
- * @return None
- *
  * @pre vcpu != NULL
  */
 void vcpu_inject_ud(struct acrn_vcpu *vcpu);
@@ -96,8 +86,6 @@ void vcpu_inject_ud(struct acrn_vcpu *vcpu);
  * @brief Inject stack fault exeception(SS) to guest.
  *
  * @param[in] vcpu Pointer to vCPU.
- *
- * @return None
  *
  * @pre vcpu != NULL
  */

--- a/hypervisor/include/arch/x86/asm/guest/vmtrr.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmtrr.h
@@ -60,8 +60,6 @@ struct acrn_vcpu;
  * @param[inout] vcpu The pointer that points VCPU data structure
  * @param[in] msr Virtual MTRR MSR Address
  * @param[in] value The value that will be writen into virtual MTRR MSR
- *
- * @return None
  */
 void write_vmtrr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t value);
 /**
@@ -77,8 +75,6 @@ uint64_t read_vmtrr(const struct acrn_vcpu *vcpu, uint32_t msr);
  * @brief Virtual MTRR initialization
  *
  * @param[inout] vcpu The pointer that points VCPU data structure
- *
- * @return None
  */
 void init_vmtrr(struct acrn_vcpu *vcpu);
 /**

--- a/hypervisor/include/arch/x86/asm/guest/vmx_io.h
+++ b/hypervisor/include/arch/x86/asm/guest/vmx_io.h
@@ -82,8 +82,6 @@ void deny_guest_pio_access(struct acrn_vm *vm, uint16_t port_address, uint32_t n
 
 /**
  * @brief Fire HSM interrupt to Service VM
- *
- * @return None
  */
 void arch_fire_hsm_interrupt(void);
 

--- a/hypervisor/include/arch/x86/asm/lapic.h
+++ b/hypervisor/include/arch/x86/asm/lapic.h
@@ -121,8 +121,6 @@ void send_single_ipi(uint16_t pcpu_id, uint32_t vector);
  * @brief Send an INIT signal to a single pCPU
  *
  * @param[in] pcpu_id The id of destination physical cpu
- *
- * @return None
  */
 void send_single_init(uint16_t pcpu_id);
 

--- a/hypervisor/include/arch/x86/asm/mmu.h
+++ b/hypervisor/include/arch/x86/asm/mmu.h
@@ -127,28 +127,20 @@ static inline uint64_t round_pde_down(uint64_t val)
 
 /**
  * @brief MMU paging enable
- *
- * @return None
  */
 void enable_paging(void);
 /**
  * @brief Supervisor-mode execution prevention (SMEP) enable
- *
- * @return None
  */
 void enable_smep(void);
 
 /**
  * @brief Supervisor-mode Access Prevention (SMAP) enable
- *
- * @return None
  */
 void enable_smap(void);
 
 /**
  * @brief MMU page tables initialization
- *
- * @return None
  */
 void init_paging(void);
 
@@ -163,14 +155,10 @@ void set_paging_nx(uint64_t base, uint64_t size);
  * @brief Specified signle VPID flush
  *
  * @param[in] vpid the specified VPID
- *
- * @return None
  */
 void flush_vpid_single(uint16_t vpid);
 /**
  * @brief All VPID flush
- *
- * @return None
  */
 void flush_vpid_global(void);
 
@@ -178,8 +166,6 @@ void flush_vpid_global(void);
  * @brief Guest-physical mappings and combined mappings invalidation
  *
  * @param[in] eptp the pointer that points the eptp
- *
- * @return None
  */
 void invept(const void *eptp);
 

--- a/hypervisor/include/arch/x86/asm/tsc.h
+++ b/hypervisor/include/arch/x86/asm/tsc.h
@@ -36,15 +36,11 @@ uint32_t get_tsc_khz(void);
  *
  * @remark Generic time related routines, e.g., cpu_tickrate(), us_to_ticks(),
  * udelay(), etc., relies on this function being called earlier during system initialization.
- *
- * @return None
  */
 void calibrate_tsc(void);
 
 /**
  * @brief Initialize HPET.
- *
- * @return None
  */
 void hpet_init(void);
 

--- a/hypervisor/include/common/delay.h
+++ b/hypervisor/include/common/delay.h
@@ -13,8 +13,6 @@
  * @brief Busy wait a few micro seconds.
  *
  * @param[in] us micro seconds to delay.
- *
- * @retval None
  */
 void udelay(uint32_t us);
 

--- a/hypervisor/include/common/timer.h
+++ b/hypervisor/include/common/timer.h
@@ -59,8 +59,6 @@ struct hv_timer {
  *
  * @remark Don't initialize a timer twice if it has been added to the timer list
  *         after calling add_timer. If you want to, delete the timer from the list first.
- *
- * @return None
  */
 void initialize_timer(struct hv_timer *timer,
 		      timer_handle_t func, void *priv_data,
@@ -92,8 +90,6 @@ bool timer_is_started(const struct hv_timer *timer);
  * @param[in] timer Pointer to timer.
  * @param[in] timeout deadline to interrupt.
  * @param[in] period period of the periodic timer in unit of CPU ticks.
- *
- * @return None
  */
 void update_timer(struct hv_timer *timer, uint64_t timeout, uint64_t period);
 
@@ -114,16 +110,12 @@ int32_t add_timer(struct hv_timer *timer);
  *
  * @param[in] timer Pointer to timer.
  *
- * @return None
- *
  * @remark Don't call it in the timer callback function or interrupt content.
  */
 void del_timer(struct hv_timer *timer);
 
 /**
  * @brief Initialize timer.
- *
- * @return None
  */
 void timer_init(void);
 

--- a/hypervisor/include/dm/io_req.h
+++ b/hypervisor/include/dm/io_req.h
@@ -192,8 +192,6 @@ int32_t acrn_insert_request(struct acrn_vcpu *vcpu, const struct io_request *io_
  * @brief Reset all IO requests status of the VM
  *
  * @param vm The VM whose IO requests to be reset
- *
- * @return None
  */
 void reset_vm_ioreqs(struct acrn_vm *vm);
 
@@ -213,7 +211,6 @@ uint32_t get_io_req_state(struct acrn_vm *vm, uint16_t vcpu_id);
  * @param vm Target VM context
  * @param vcpu_id VCPU ID of the IO request
  * @param state State to be set
- * @return None
  */
 void set_io_req_state(struct acrn_vm *vm, uint16_t vcpu_id, uint32_t state);
 
@@ -221,7 +218,6 @@ void set_io_req_state(struct acrn_vm *vm, uint16_t vcpu_id, uint32_t state);
  * @brief Set the vector for HV callback HSM
  *
  * @param vector vector for HV callback HSM
- * @return None
  */
 void set_hsm_notification_vector(uint32_t vector);
 
@@ -277,8 +273,6 @@ void   register_pio_emulation_handler(struct acrn_vm *vm, uint32_t pio_idx,
  * @param end The end of the range (exclusive) \p read_write can emulate
  * @param handler_private_data Handler-specific data which will be passed to \p read_write when called
  * @param hold_lock Whether hold the lock to handle the MMIO access
- *
- * @return None
  */
 void register_mmio_emulation_handler(struct acrn_vm *vm,
 	hv_mem_io_handler_t read_write, uint64_t start,
@@ -292,8 +286,6 @@ void register_mmio_emulation_handler(struct acrn_vm *vm,
  * @param vm The VM to which the MMIO handler is unregistered
  * @param start The base address of the range which wants to unregister
  * @param end The end of the range (exclusive) which wants to unregister
- *
- * @return None
  */
 void unregister_mmio_emulation_handler(struct acrn_vm *vm,
 					uint64_t start, uint64_t end);

--- a/hypervisor/include/dm/ivshmem.h
+++ b/hypervisor/include/dm/ivshmem.h
@@ -32,8 +32,6 @@ extern const struct pci_vdev_ops vpci_ivshmem_ops;
  * @brief Initialize ivshmem shared memory regions
  *
  * Initialize ivshmem shared memory regions based on user configuration.
- *
- * @return None
  */
 void init_ivshmem_shared_memory(void);
 

--- a/hypervisor/include/dm/vioapic.h
+++ b/hypervisor/include/dm/vioapic.h
@@ -93,8 +93,6 @@ void reset_vioapics(const struct acrn_vm *vm);
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
  * @pre irqline < vioapic_pincount(vm)
- *
- * @return None
  */
 void	vioapic_set_irqline_lock(const struct acrn_vm *vm, uint32_t vgsi, uint32_t operation);
 
@@ -110,7 +108,6 @@ void	vioapic_set_irqline_lock(const struct acrn_vm *vm, uint32_t vgsi, uint32_t 
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
  * @pre irqline < vioapic_pincount(vm)
- * @return None
  */
 void	vioapic_set_irqline_nolock(const struct acrn_vm *vm, uint32_t vgsi, uint32_t operation);
 

--- a/hypervisor/include/dm/vpic.h
+++ b/hypervisor/include/dm/vpic.h
@@ -151,8 +151,6 @@ void vpic_init(struct acrn_vm *vm);
  * @param[in] vgsi      GSI for the virtual interrupt
  * @param[in] operation action options:GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
- *
- * @return None
  */
 void vpic_set_irqline(struct acrn_vpic *vpic, uint32_t vgsi, uint32_t operation);
 
@@ -162,8 +160,6 @@ void vpic_set_irqline(struct acrn_vpic *vpic, uint32_t vgsi, uint32_t operation)
  * @param[in]    vpic   Pointer to target VM's vpic table
  * @param[inout] vecptr Pointer to vector buffer and will be filled
  *			with eligible vector if any.
- *
- * @return None
  */
 void vpic_pending_intr(struct acrn_vpic *vpic, uint32_t *vecptr);
 
@@ -172,8 +168,6 @@ void vpic_pending_intr(struct acrn_vpic *vpic, uint32_t *vecptr);
  *
  * @param[in] vpic     Pointer to target VM's vpic table
  * @param[in] vector Target virtual interrupt vector
- *
- * @return None
  *
  * @pre vm != NULL
  */

--- a/misc/efi-stub/container.c
+++ b/misc/efi-stub/container.c
@@ -528,8 +528,6 @@ static UINTN container_get_hv_ram_size(HV_LOADER hvld)
  * @brief Free up memory allocated by the container loader
  *
  * @param[in]  hvld Loader handle
- *
- * @return None
  */
 static void container_deinit(HV_LOADER hvld)
 {


### PR DESCRIPTION
This patchset enables building document with python 3.11 and doxygen 1.9.4. A major change is that all '@return None' are removed as void-returning functions shall not have any return value documented as required by doxygen 1.9.4 or later versions.

Verified doc can be built successfully on Ubuntu 23.04 (python 3.11.2 + doxygen 1.9.4) and Ubuntu 22.04 (python 3.10.6 + doxygen 1.9.1)

Tracked-On: #8425