### PR TITLE
doc: update header banner for stable documentation link

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -5,7 +5,7 @@
         <p class="admonition-title">Important</p>
         <p>This is the latest documentation for the unstable development branch of
         Project ACRN (master).<br/>Use the drop-down menu on the left to select
-        documentation for a stable release such as <a href="/3.1/">v3.1</a> or
+        documentation for a stable release such as <a href="/3.2/">v3.2</a> or
         <a href="/3.0/">v3.0</a>.</p>
     </div>
   {% endif %}


### PR DESCRIPTION
Update the header banner on the latest documentation to references 3.2 and 3.0 stable release documentation (instead of 3.1)