### PR TITLE
hv mutli-function device passthru fixes

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -315,6 +315,7 @@ VP_DM_C_SRCS += dm/vpci/vpci.c
 VP_DM_C_SRCS += dm/vpci/vhostbridge.c
 VP_DM_C_SRCS += dm/vpci/vroot_port.c
 VP_DM_C_SRCS += dm/vpci/vpci_bridge.c
+VP_DM_C_SRCS += dm/vpci/vpci_mf_dev.c
 VP_DM_C_SRCS += dm/vpci/ivshmem.c
 VP_DM_C_SRCS += dm/vpci/pci_pt.c
 VP_DM_C_SRCS += dm/vpci/vmsi.c

--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -12,7 +12,7 @@
 /*
  * @pre pdev != NULL;
  */
-static bool is_allocated_to_prelaunched_vm(struct pci_pdev *pdev)
+static bool allocate_to_prelaunched_vm(struct pci_pdev *pdev)
 {
 	bool found = false;
 	uint16_t vmid;
@@ -56,7 +56,7 @@ struct acrn_vm_pci_dev_config *init_one_dev_config(struct pci_pdev *pdev)
 	struct acrn_vm_config *vm_config;
 	struct acrn_vm_pci_dev_config *dev_config = NULL;
 
-	if (!is_allocated_to_prelaunched_vm(pdev)) {
+	if (!allocate_to_prelaunched_vm(pdev)) {
 		for (vmid = 0U; vmid < CONFIG_MAX_VM_NUM; vmid++) {
 			vm_config = get_vm_config(vmid);
 			if (vm_config->load_order != SERVICE_VM) {

--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -52,38 +52,36 @@ static bool allocate_to_prelaunched_vm(struct pci_pdev *pdev)
  */
 struct acrn_vm_pci_dev_config *init_one_dev_config(struct pci_pdev *pdev)
 {
-	uint16_t vmid;
-	struct acrn_vm_config *vm_config;
 	struct acrn_vm_pci_dev_config *dev_config = NULL;
+	bool is_allocated_to_prelaunched_vm = allocate_to_prelaunched_vm(pdev);
+	bool is_allocated_to_hv = is_hv_owned_pdev(pdev->bdf);
 
-	if (!allocate_to_prelaunched_vm(pdev)) {
-		for (vmid = 0U; vmid < CONFIG_MAX_VM_NUM; vmid++) {
-			vm_config = get_vm_config(vmid);
-			if (vm_config->load_order != SERVICE_VM) {
-				continue;
-			}
+	if (service_vm_config != NULL) {
+		dev_config = &service_vm_config->pci_devs[service_vm_config->pci_dev_num];
 
-			dev_config = &vm_config->pci_devs[vm_config->pci_dev_num];
-			if (is_hv_owned_pdev(pdev->bdf)) {
-				/* Service VM need to emulate the type1 pdevs owned by HV */
-				dev_config->emu_type = PCI_DEV_TYPE_SERVICE_VM_EMUL;
-				if (is_bridge(pdev)) {
-					dev_config->vdev_ops = &vpci_bridge_ops;
-				} else if (is_host_bridge(pdev)) {
-					dev_config->vdev_ops = &vhostbridge_ops;
-				} else {
-					/* May have type0 device, E.g. debug pci uart */
-					break;
-				}
+		if (is_allocated_to_hv) {
+			/* Service VM need to emulate the type1 pdevs owned by HV */
+			dev_config->emu_type = PCI_DEV_TYPE_SERVICE_VM_EMUL;
+			if (is_bridge(pdev)) {
+				dev_config->vdev_ops = &vpci_bridge_ops;
+			} else if (is_host_bridge(pdev)) {
+				dev_config->vdev_ops = &vhostbridge_ops;
 			} else {
-				dev_config->emu_type = PCI_DEV_TYPE_PTDEV;
+				/* May have type0 device, E.g. debug pci uart */
+				dev_config = NULL;
 			}
-
-			dev_config->vbdf.value = pdev->bdf.value;
-			dev_config->pbdf.value = pdev->bdf.value;
-			dev_config->pdev = pdev;
-			vm_config->pci_dev_num++;
+		} else if (is_allocated_to_prelaunched_vm) {
+			dev_config = NULL;
+		} else {
+			dev_config->emu_type = PCI_DEV_TYPE_PTDEV;
 		}
+	}
+
+	if (dev_config != NULL) {
+		dev_config->vbdf.value = pdev->bdf.value;
+		dev_config->pbdf.value = pdev->bdf.value;
+		dev_config->pdev = pdev;
+		service_vm_config->pci_dev_num++;
 	}
 	return dev_config;
 }

--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -75,6 +75,16 @@ struct acrn_vm_pci_dev_config *init_one_dev_config(struct pci_pdev *pdev)
 		} else {
 			dev_config->emu_type = PCI_DEV_TYPE_PTDEV;
 		}
+
+		if ((is_allocated_to_hv || is_allocated_to_prelaunched_vm)
+				&& (dev_config == NULL)
+				&& is_pci_cfg_multifunction(pdev->hdr_type)
+				&& (pdev->bdf.bits.f == 0U))
+		{
+			dev_config = &service_vm_config->pci_devs[service_vm_config->pci_dev_num];
+			dev_config->emu_type = PCI_DEV_TYPE_DUMMY_MF_EMUL;
+			dev_config->vdev_ops = &vpci_mf_dev_ops;
+		}
 	}
 
 	if (dev_config != NULL) {

--- a/hypervisor/dm/vpci/vpci_mf_dev.c
+++ b/hypervisor/dm/vpci/vpci_mf_dev.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <asm/guest/vm.h>
+#include <errno.h>
+#include <logmsg.h>
+#include <pci.h>
+#include "vpci_priv.h"
+
+/* config space of dummy multifunction device */
+#define PCI_DUMMY_DEVICE_VENDOR		0x1D94U
+#define PCI_DUMMY_DEVICE_ID		0x145AU
+#define DUMMY_MF_REV			0x1U
+#define DUMMY_MF_CLASS			0x0U
+
+static void init_vpci_mf_dev(struct pci_vdev *vdev)
+{
+	pci_vdev_write_vcfg(vdev, PCIR_VENDOR, 2U, PCI_DUMMY_DEVICE_VENDOR);
+	pci_vdev_write_vcfg(vdev, PCIR_DEVICE, 2U, PCI_DUMMY_DEVICE_ID);
+	pci_vdev_write_vcfg(vdev, PCIR_REVID, 1U, DUMMY_MF_REV);
+	pci_vdev_write_vcfg(vdev, PCIR_CLASS, 1U, DUMMY_MF_CLASS);
+	pci_vdev_write_vcfg(vdev, PCIR_HDRTYPE, 1U, PCIM_HDRTYPE_NORMAL | PCIM_MFDEV);
+
+	vdev->parent_user = NULL;
+	vdev->user = vdev;
+}
+
+static void deinit_vpci_mf_dev(struct pci_vdev *vdev)
+{
+	vdev->parent_user = NULL;
+	vdev->user = NULL;
+}
+
+static int32_t read_vpci_mf_dev(struct pci_vdev *vdev, uint32_t offset,
+	uint32_t bytes, uint32_t *val)
+{
+	*val = pci_vdev_read_vcfg(vdev, offset, bytes);
+
+	return 0;
+}
+
+static int32_t write_vpci_mf_dev(__unused struct pci_vdev *vdev, __unused uint32_t offset,
+	__unused uint32_t bytes, __unused uint32_t val)
+{
+	return 0;
+}
+
+const struct pci_vdev_ops vpci_mf_dev_ops = {
+	.init_vdev         = init_vpci_mf_dev,
+	.deinit_vdev       = deinit_vpci_mf_dev,
+	.write_vdev_cfg    = write_vpci_mf_dev,
+	.read_vdev_cfg     = read_vpci_mf_dev,
+};

--- a/hypervisor/include/arch/x86/asm/vm_config.h
+++ b/hypervisor/include/arch/x86/asm/vm_config.h
@@ -217,5 +217,6 @@ uint8_t get_vm_severity(uint16_t vm_id);
 bool vm_has_matched_name(uint16_t vmid, const char *name);
 
 extern struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM];
+extern struct acrn_vm_config *const service_vm_config;
 
 #endif /* VM_CONFIG_H_ */

--- a/hypervisor/include/arch/x86/asm/vm_config.h
+++ b/hypervisor/include/arch/x86/asm/vm_config.h
@@ -29,9 +29,11 @@
 #define SERVICE_VM_IDLE		"idle=halt "
 #endif
 
+#define PCI_DEV_TYPE_NONE		0U
 #define PCI_DEV_TYPE_PTDEV		(1U << 0U)
 #define PCI_DEV_TYPE_HVEMUL		(1U << 1U)
 #define PCI_DEV_TYPE_SERVICE_VM_EMUL	(1U << 2U)
+#define PCI_DEV_TYPE_DUMMY_MF_EMUL	(1U << 3U)
 
 #define MAX_MMIO_DEV_NUM	2U
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -184,6 +184,7 @@ struct acrn_vm;
 
 extern const struct pci_vdev_ops vhostbridge_ops;
 extern const struct pci_vdev_ops vpci_bridge_ops;
+extern const struct pci_vdev_ops vpci_mf_dev_ops;
 int32_t init_vpci(struct acrn_vm *vm);
 void deinit_vpci(struct acrn_vm *vm);
 struct pci_vdev *pci_find_vdev(struct acrn_vpci *vpci, union pci_bdf vbdf);

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -87,6 +87,15 @@
     </xsl:if>
     <xsl:value-of select="$newline"/>
     <xsl:value-of select="$end_of_array_initializer" />
+    <xsl:value-of select="$newline"/>
+    <xsl:choose>
+      <xsl:when test="count(vm[load_order='SERVICE_VM'])">
+        <xsl:value-of select="concat('struct acrn_vm_config *const service_vm_config = &amp;vm_configs[', vm[load_order='SERVICE_VM']/@id, '];')" />
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat('struct acrn_vm_config *const service_vm_config =', ' NULL;')" />
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template match="vm">


### PR DESCRIPTION
When function 0 in a multi-function PCI device is passthru to Pre-launched VM
or owned by the hypervisor, a dummy function 0 should be emulated for Service
VM if the other functions are left to Service VM.

We met this case on a platform whose LPSS device contains a PCI serial port at
function 0 together with several I2C functions.

The first patch improves the PCI device config initialization logic as
discussed in [1].
The second patch add the dummy multi-function device support.

[1] https://lists.projectacrn.org/g/acrn-dev/message/37656