### PR TITLE
refine BVT scheduler

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -973,8 +973,7 @@ int32_t prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id)
 		vcpu->thread_obj.host_sp = build_stack_frame(vcpu);
 		vcpu->thread_obj.switch_out = context_switch_out;
 		vcpu->thread_obj.switch_in = context_switch_in;
-		vcpu->thread_obj.priority = get_vm_config(vm->vm_id)->vm_prio;
-		init_thread_data(&vcpu->thread_obj);
+		init_thread_data(&vcpu->thread_obj, &get_vm_config(vm->vm_id)->sched_params);
 		for (i = 0; i < VCPU_EVENT_NUM; i++) {
 			init_event(&vcpu->events[i]);
 		}

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -97,6 +97,7 @@ void run_idle_thread(void)
 {
 	uint16_t pcpu_id = get_pcpu_id();
 	struct thread_object *idle = &per_cpu(idle, pcpu_id);
+	struct sched_params idle_params = {0};
 	char idle_name[16];
 
 	snprintf(idle_name, 16U, "idle%hu", pcpu_id);
@@ -105,7 +106,8 @@ void run_idle_thread(void)
 	idle->thread_entry = default_idle;
 	idle->switch_out = NULL;
 	idle->switch_in = NULL;
-	idle->priority = PRIO_IDLE;
+	idle_params.prio = PRIO_IDLE;
+	init_thread_data(idle, &idle_params);
 
 	run_thread(idle);
 

--- a/hypervisor/common/sched_bvt.c
+++ b/hypervisor/common/sched_bvt.c
@@ -168,7 +168,7 @@ static void sched_bvt_deinit(struct sched_control *ctl)
 	del_timer(&bvt_ctl->tick_timer);
 }
 
-static void sched_bvt_init_data(struct thread_object *obj)
+static void sched_bvt_init_data(struct thread_object *obj, __unused struct sched_params * params)
 {
 	struct sched_bvt_data *data;
 

--- a/hypervisor/common/sched_iorr.c
+++ b/hypervisor/common/sched_iorr.c
@@ -132,7 +132,7 @@ void sched_iorr_deinit(struct sched_control *ctl)
 	del_timer(&iorr_ctl->tick_timer);
 }
 
-void sched_iorr_init_data(struct thread_object *obj)
+void sched_iorr_init_data(struct thread_object *obj, __unused struct sched_params * params)
 {
 	struct sched_iorr_data *data;
 

--- a/hypervisor/common/sched_prio.c
+++ b/hypervisor/common/sched_prio.c
@@ -11,6 +11,7 @@
 struct sched_prio_data {
 	/* keep list as the first item */
 	struct list_head list;
+	int priority;
 };
 
 static int sched_prio_init(struct sched_control *ctl)
@@ -25,12 +26,13 @@ static int sched_prio_init(struct sched_control *ctl)
 	return 0;
 }
 
-static void sched_prio_init_data(struct thread_object *obj)
+static void sched_prio_init_data(struct thread_object *obj, struct sched_params *params)
 {
 	struct sched_prio_data *data;
 
 	data = (struct sched_prio_data *)obj->data;
 	INIT_LIST_HEAD(&data->list);
+	data->priority = params->priority;
 }
 
 static struct thread_object *sched_prio_pick_next(struct sched_control *ctl)
@@ -52,15 +54,15 @@ static void prio_queue_add(struct thread_object *obj)
 	struct sched_prio_control *prio_ctl =
 		(struct sched_prio_control *)obj->sched_ctl->priv;
 	struct sched_prio_data *data = (struct sched_prio_data *)obj->data;
-	struct thread_object *iter_obj;
+	struct sched_prio_data *iter_data;
 	struct list_head *pos;
 
 	if (list_empty(&prio_ctl->prio_queue)) {
 		list_add(&data->list, &prio_ctl->prio_queue);
 	} else {
 		list_for_each(pos, &prio_ctl->prio_queue) {
-			iter_obj = container_of(pos, struct thread_object, data);
-			if (iter_obj->priority < obj->priority) {
+			iter_data = container_of(pos, struct sched_prio_data, list);
+			if (iter_data->priority < data->priority) {
 				list_add_node(&data->list, pos->prev, pos);
 				break;
 			}

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -95,14 +95,14 @@ void deinit_sched(uint16_t pcpu_id)
 	}
 }
 
-void init_thread_data(struct thread_object *obj)
+void init_thread_data(struct thread_object *obj, struct sched_params *params)
 {
 	struct acrn_scheduler *scheduler = get_scheduler(obj->pcpu_id);
 	uint64_t rflag;
 
 	obtain_schedule_lock(obj->pcpu_id, &rflag);
 	if (scheduler->init_data != NULL) {
-		scheduler->init_data(obj);
+		scheduler->init_data(obj, params);
 	}
 	/* initial as BLOCKED status, so we can wake it up to run */
 	set_thread_status(obj, THREAD_STS_BLOCKED);
@@ -238,7 +238,6 @@ void run_thread(struct thread_object *obj)
 {
 	uint64_t rflag;
 
-	init_thread_data(obj);
 	obtain_schedule_lock(obj->pcpu_id, &rflag);
 	get_cpu_var(sched_ctl).curr_obj = obj;
 	set_thread_status(obj, THREAD_STS_RUNNING);

--- a/hypervisor/include/arch/x86/asm/vm_config.h
+++ b/hypervisor/include/arch/x86/asm/vm_config.h
@@ -15,6 +15,7 @@
 #include <vm_configurations.h>
 #include <asm/sgx.h>
 #include <acrn_hv_defs.h>
+#include <schedule.h>
 
 #define AFFINITY_CPU(n)		(1UL << (n))
 #define MAX_VCPUS_PER_VM	MAX_PCPU_NUM
@@ -170,7 +171,7 @@ struct acrn_vm_config {
 							 *	GUEST_FLAG_LAPIC_PASSTHROUGH
 							 * We could add more guest flags in future;
 							 */
-	uint32_t vm_prio;				/* The priority for VM vCPU scheduling */
+	struct sched_params sched_params;		/* Scheduler params for vCPUs of this VM */
 	uint16_t companion_vm_id;			/* The companion VM id for this VM */
 	struct acrn_vm_mem_config memory;		/* memory configuration of VM */
 	struct epc_section epc;				/* EPC memory configuration of VM */

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -31,6 +31,16 @@ enum thread_priority {
 	PRIO_MAX
 };
 
+/* 
+ * For now, we just have several parameters for all the schedulers. So we
+ * put them together here for simplicity. TODO When this structure grows big
+ * enough, we need to replace it with a union of parameters of different
+ * schedulers.
+ */
+struct sched_params {
+	uint32_t prio;		/* The priority of a thread */
+};
+
 struct thread_object;
 typedef void (*thread_entry_t)(struct thread_object *obj);
 typedef void (*switch_t)(struct thread_object *obj);
@@ -45,8 +55,6 @@ struct thread_object {
 	uint64_t host_sp;
 	switch_t switch_out;
 	switch_t switch_in;
-
-	int priority;
 
 	uint8_t data[THREAD_DATA_SIZE];
 };
@@ -67,7 +75,7 @@ struct acrn_scheduler {
 	/* init scheduler */
 	int32_t	(*init)(struct sched_control *ctl);
 	/* init private data of scheduler */
-	void	(*init_data)(struct thread_object *obj);
+	void	(*init_data)(struct thread_object *obj, struct sched_params *params);
 	/* pick the next thread object */
 	struct thread_object* (*pick_next)(struct sched_control *ctl);
 	/* put thread object into sleep */
@@ -117,7 +125,7 @@ void deinit_sched(uint16_t pcpu_id);
 void obtain_schedule_lock(uint16_t pcpu_id, uint64_t *rflag);
 void release_schedule_lock(uint16_t pcpu_id, uint64_t rflag);
 
-void init_thread_data(struct thread_object *obj);
+void init_thread_data(struct thread_object *obj, struct sched_params *params);
 void deinit_thread_data(struct thread_object *obj);
 
 void make_reschedule_request(uint16_t pcpu_id);

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -39,6 +39,12 @@ enum thread_priority {
  */
 struct sched_params {
 	uint32_t prio;		/* The priority of a thread */
+
+	/* per thread parameters for bvt scheduler */
+	uint8_t bvt_weight;	/* the weight of a thread */
+	int32_t bvt_warp_value; /* the warp reduce effective VT to boost priority */
+	uint32_t bvt_warp_limit;	/* max time in one warp */
+	uint32_t bvt_unwarp_period;	/* min unwarp time after a warp */
 };
 
 struct thread_object;

--- a/hypervisor/include/lib/util.h
+++ b/hypervisor/include/lib/util.h
@@ -22,6 +22,9 @@
 
 #define max(x, y)	(((x) < (y)) ? (y) : (x))
 
+/** return a value of v clamped to the range [l, h] */
+#define clamp(v, l, h)	(max(min((v), (h)), (l)))
+
 /** Replaces 'x' by the string "x". */
 #define STRINGIFY(x) #x
 

--- a/misc/config_tools/data/generic_board/generic_code/hybrid/vm_configurations.c
+++ b/misc/config_tools/data/generic_board/generic_code/hybrid/vm_configurations.c
@@ -22,7 +22,10 @@ struct acrn_vm_config
 			 /* Static configured VM0 */
 			 CONFIG_PRE_STD_VM,
 			 .name = "SAFETY_VM0",
-			 .vm_prio = PRIO_LOW,
+			 .sched_params =
+			 	 {
+					 .prio = PRIO_LOW,
+				 },
 			 .companion_vm_id = 65535U,
 			 .guest_flags = (GUEST_FLAG_STATIC_VM),
 			 .cpu_affinity = VM0_CONFIG_CPU_AFFINITY,
@@ -106,7 +109,10 @@ struct acrn_vm_config
 				CONFIG_SERVICE_VM,
 				.name = "ACRN_Service_VM",
 				/* Allow Service VM to reboot the system since it is the highest priority VM. */
-				.vm_prio = PRIO_LOW,
+				.sched_params =
+					{
+						.prio = PRIO_LOW,
+					},
 				.companion_vm_id = 65535U,
 				.guest_flags = (GUEST_FLAG_STATIC_VM),
 				.cpu_affinity = SERVICE_VM_CONFIG_CPU_AFFINITY,
@@ -163,7 +169,10 @@ struct acrn_vm_config
 				/* Static configured VM2 */
 				CONFIG_POST_STD_VM,
 				.name = "POST_STD_VM1",
-				.vm_prio = PRIO_LOW,
+				.sched_params =
+					{
+						.prio = PRIO_LOW,
+					},
 				.companion_vm_id = 65535U,
 				.guest_flags = (GUEST_FLAG_STATIC_VM),
 				.cpu_affinity = VM2_CONFIG_CPU_AFFINITY,
@@ -186,7 +195,10 @@ struct acrn_vm_config
 				/* Static configured VM3 */
 				CONFIG_POST_STD_VM,
 				.name = "POST_STD_VM2",
-				.vm_prio = PRIO_LOW,
+				.sched_params =
+					{
+						.prio = PRIO_LOW,
+					},
 				.companion_vm_id = 65535U,
 				.guest_flags = (GUEST_FLAG_STATIC_VM),
 				.cpu_affinity = VM3_CONFIG_CPU_AFFINITY,

--- a/misc/config_tools/data/generic_board/generic_code/partitioned/vm_configurations.c
+++ b/misc/config_tools/data/generic_board/generic_code/partitioned/vm_configurations.c
@@ -25,7 +25,10 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		/* Static configured VM0 */
 		CONFIG_PRE_STD_VM,
 		.name = "PRE_STD_VM0",
-		.vm_prio = PRIO_LOW,
+		.sched_params =
+			{
+				.prio = PRIO_LOW,
+			},
 		.companion_vm_id = 65535U,
 		.guest_flags = (GUEST_FLAG_STATIC_VM),
 		.cpu_affinity = VM0_CONFIG_CPU_AFFINITY,
@@ -102,7 +105,10 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		/* Static configured VM1 */
 		CONFIG_PRE_STD_VM,
 		.name = "PRE_STD_VM1",
-		.vm_prio = PRIO_LOW,
+		.sched_params =
+			{
+				.prio = PRIO_LOW,
+			},
 		.companion_vm_id = 65535U,
 		.guest_flags = (GUEST_FLAG_STATIC_VM),
 		.cpu_affinity = VM1_CONFIG_CPU_AFFINITY,

--- a/misc/config_tools/data/generic_board/generic_code/shared/vm_configurations.c
+++ b/misc/config_tools/data/generic_board/generic_code/shared/vm_configurations.c
@@ -17,7 +17,10 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		CONFIG_SERVICE_VM,
 		.name = "ACRN_Service_VM",
 		/* Allow Service VM to reboot the system since it is the highest priority VM. */
-		.vm_prio = PRIO_LOW,
+		.sched_params =
+			{
+				.prio = PRIO_LOW,
+			},
 		.companion_vm_id = 65535U,
 		.guest_flags = (GUEST_FLAG_STATIC_VM),
 		.cpu_affinity = SERVICE_VM_CONFIG_CPU_AFFINITY,
@@ -74,7 +77,10 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		/* Static configured VM1 */
 		CONFIG_POST_STD_VM,
 		.name = "POST_STD_VM1",
-		.vm_prio = PRIO_LOW,
+		.sched_params =
+			{
+				.prio = PRIO_LOW,
+			},
 		.companion_vm_id = 65535U,
 		.guest_flags = (GUEST_FLAG_STATIC_VM),
 		.cpu_affinity = VM1_CONFIG_CPU_AFFINITY,
@@ -105,7 +111,10 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		/* Static configured VM2 */
 		CONFIG_POST_RT_VM,
 		.name = "POST_RT_VM1",
-		.vm_prio = PRIO_LOW,
+		.sched_params =
+			{
+				.prio = PRIO_LOW,
+			},
 		.companion_vm_id = 65535U,
 		.guest_flags = (GUEST_FLAG_LAPIC_PASSTHROUGH | GUEST_FLAG_RT | GUEST_FLAG_STATIC_VM),
 		.cpu_affinity = VM2_CONFIG_CPU_AFFINITY,

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -442,6 +442,62 @@ These settings can only be changed at build time.</xs:documentation>
         <xs:documentation>Specify the VM vCPU priority for scheduling.</xs:documentation>
       </xs:annotation>
     </xs:element>
+    <xs:element name="bvt_weight" default="1">
+      <xs:annotation acrn:views="advanced">
+        <xs:documentation>Specify the VM vCPU weight for scheduling.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+         <xs:annotation>
+           <xs:documentation>Integer from 1 to 128.</xs:documentation>
+         </xs:annotation>
+        <xs:restriction base="xs:integer">
+          <xs:minInclusive value="1" />
+          <xs:maxInclusive value="128" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:element>
+    <xs:element name="bvt_warp_value" default="0">
+      <xs:annotation acrn:views="">
+        <xs:documentation>Specify the VM vCPU warp in MCU (minimum charging unit, i.e. tick period) to prioritize them.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+         <xs:annotation>
+           <xs:documentation>Integer from -8192 to 8192.</xs:documentation>
+         </xs:annotation>
+        <xs:restriction base="xs:integer">
+          <xs:minInclusive value="-8192" />
+          <xs:maxInclusive value="8192" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:element>
+    <xs:element name="bvt_warp_limit" default="0">
+      <xs:annotation acrn:views="">
+        <xs:documentation>Specify the VM vCPU warp limit time in MCU (minimum charging unit, i.e. tick period) to prevent starving non-warpped threads.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+         <xs:annotation>
+           <xs:documentation>Integer from 0 to 10.</xs:documentation>
+         </xs:annotation>
+        <xs:restriction base="xs:integer">
+          <xs:minInclusive value="0" />
+          <xs:maxInclusive value="10" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:element>
+    <xs:element name="bvt_unwarp_period" default="0">
+      <xs:annotation acrn:views="">
+        <xs:documentation>Specify the VM vCPU unwarp period in MCU (minimum charging unit, i.e. tick period) after a warp.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+         <xs:annotation>
+           <xs:documentation>Integer from 0 to 10.</xs:documentation>
+         </xs:annotation>
+        <xs:restriction base="xs:integer">
+          <xs:minInclusive value="0" />
+          <xs:maxInclusive value="10" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:element>
     <xs:element name="companion_vmid" type="xs:integer" default="65535">
       <xs:annotation acrn:views="">
         <xs:documentation>Specify the companion VM id of this VM.</xs:documentation>

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -112,6 +112,10 @@
     </xsl:if>
     <xsl:value-of select="acrn:initializer('sched_params', '{', true())" />
     <xsl:value-of select="acrn:initializer('prio', priority)" />
+    <xsl:value-of select="acrn:initializer('bvt_weight', bvt_weight)" />
+    <xsl:value-of select="acrn:initializer('bvt_warp_value', bvt_warp_value)" />
+    <xsl:value-of select="acrn:initializer('bvt_warp_limit', bvt_warp_limit)" />
+    <xsl:value-of select="acrn:initializer('bvt_unwarp_period', bvt_unwarp_period)" />
     <xsl:text>},</xsl:text>
     <xsl:value-of select="$newline" />
     <xsl:value-of select="acrn:initializer('companion_vm_id', concat(companion_vmid, 'U'))" />

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -110,7 +110,10 @@
       <xsl:value-of select="acrn:comment('Allow Service VM to reboot the system since it is the highest priority VM.')" />
       <xsl:value-of select="$newline" />
     </xsl:if>
-    <xsl:value-of select="acrn:initializer('vm_prio', priority)" />
+    <xsl:value-of select="acrn:initializer('sched_params', '{', true())" />
+    <xsl:value-of select="acrn:initializer('prio', priority)" />
+    <xsl:text>},</xsl:text>
+    <xsl:value-of select="$newline" />
     <xsl:value-of select="acrn:initializer('companion_vm_id', concat(companion_vmid, 'U'))" />
     <xsl:call-template name="guest_flags" />
 


### PR DESCRIPTION
This series refines BVT scheduler parameters and add weight support for
threads to allow more flexiable cpu resource allocation among VCPU threads
from different VMs.

As of now, BVT parameters can only be statically set in config tool. We can
allow dynamic parameters tuning via hypercalls in the future.