### PR TITLE
hv: allocate ivshmem shared memory from E820

### DIFF
--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -86,7 +86,7 @@ static void reserve_ept_bitmap(void)
 	bitmap_size = (get_ept_page_num() * CONFIG_MAX_VM_NUM) / 8;
 	bitmap_offset = get_ept_page_num() / 8;
 
-	bitmap_base = e820_alloc_memory(bitmap_size, ~0UL);
+	bitmap_base = e820_alloc_memory(bitmap_size, MEM_SIZE_MAX);
 	set_paging_supervisor(bitmap_base, bitmap_size);
 
 	for(i = 0; i < CONFIG_MAX_VM_NUM; i++){
@@ -103,7 +103,7 @@ void reserve_buffer_for_ept_pages(void)
 	uint16_t vm_id;
 	uint32_t offset = 0U;
 
-	page_base = e820_alloc_memory(get_total_ept_4k_pages_size(), ~0UL);
+	page_base = e820_alloc_memory(get_total_ept_4k_pages_size(), MEM_SIZE_MAX);
 	set_paging_supervisor(page_base, get_total_ept_4k_pages_size());
 	for (vm_id = 0U; vm_id < CONFIG_MAX_VM_NUM; vm_id++) {
 		ept_pages[vm_id] = (struct page *)(void *)(page_base + offset);

--- a/hypervisor/arch/x86/guest/vept.c
+++ b/hypervisor/arch/x86/guest/vept.c
@@ -51,12 +51,12 @@ static void init_vept_pool(void)
 {
 	uint64_t page_base;
 
-	page_base = e820_alloc_memory(calc_sept_size(), ~0UL);
+	page_base = e820_alloc_memory(calc_sept_size(), MEM_SIZE_MAX);
 
 	set_paging_supervisor(page_base, calc_sept_size());
 
 	sept_pages = (struct page *)page_base;
-	sept_page_bitmap = (uint64_t*)e820_alloc_memory((calc_sept_page_num() / 64U), ~0UL);
+	sept_page_bitmap = (uint64_t *)e820_alloc_memory((calc_sept_page_num() / 64U), MEM_SIZE_MAX);
 }
 
 static bool is_present_ept_entry(uint64_t ept_entry)

--- a/hypervisor/dm/vpci/ivshmem.c
+++ b/hypervisor/dm/vpci/ivshmem.c
@@ -66,16 +66,15 @@ struct ivshmem_device {
 	struct ivshmem_shm_region *region;
 };
 
-/* IVSHMEM_SHM_SIZE is provided by offline tool */
-static uint8_t ivshmem_base[IVSHMEM_SHM_SIZE] __aligned(PDE_SIZE);
 static struct ivshmem_device ivshmem_dev[IVSHMEM_DEV_NUM];
 static spinlock_t ivshmem_dev_lock = { .head = 0U, .tail = 0U, };
 
 void init_ivshmem_shared_memory()
 {
 	uint32_t i;
-	uint64_t addr = hva2hpa(&ivshmem_base);
+	uint64_t addr;
 
+	addr = e820_alloc_memory(roundup(IVSHMEM_SHM_SIZE, PDE_SIZE), MEM_SIZE_MAX);
 	for (i = 0U; i < ARRAY_SIZE(mem_regions); i++) {
 		mem_regions[i].hpa = addr;
 		addr += mem_regions[i].size;

--- a/hypervisor/include/arch/x86/asm/e820.h
+++ b/hypervisor/include/arch/x86/asm/e820.h
@@ -18,6 +18,8 @@
 
 #define E820_MAX_ENTRIES	64U
 
+#define MEM_SIZE_MAX (~0UL)
+
 /** Defines a single entry in an E820 memory map. */
 struct e820_entry {
    /** The base address of the memory range. */


### PR DESCRIPTION
ACRN boot fails when size of ivshmem device is configured to 512MB,
this patch series is to allocate this memory from E820 table instead of
reserving in hypervisor.