### PR TITLE
dm: xhci: remove bus/port limit

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -4172,11 +4172,6 @@ pci_xhci_parse_bus_port(struct pci_xhci_vdev *xdev, char *opts)
 		goto errout;
 	}
 
-	if (bus >= USB_NATIVE_NUM_BUS || port >= USB_NATIVE_NUM_PORT) {
-		rc = -1;
-		goto errout;
-	}
-
 	if (!usb_native_is_bus_existed(bus) ||
 			!usb_native_is_port_existed(bus, port)) {
 		rc = -2;

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -221,12 +221,6 @@ enum USB_ERRCODE {
 	do { if (lvl <= usb_log_level) pr_dbg(LOG_TAG fmt, ##args); } while (0)
 
 #define NATIVE_USBSYS_DEVDIR "/sys/bus/usb/devices"
-#define NATIVE_USB2_SPEED "480"
-#define NATIVE_USB3_SPEED "5000"
-#define USB_NATIVE_NUM_PORT 20
-#define USB_NATIVE_NUM_BUS 5
-
-#define USB_DROPPED_XFER_MAGIC	0xaaaaaaaa55555555
 
 inline bool
 index_valid(int head, int tail, int maxcnt, int idx) {


### PR DESCRIPTION
Currently only devices on usb bus 0~4, port 0~19 can be passthrough to the emulated XHCI controller. Remove this unnecessary limit.

Some unused definitions are also removed.

Tracked-On: #8506

Reviewed-by: Jian Jun Chen <jian.jun.chen@intel.com>