### PR TITLE
Support ACPI MCFG multi tables boards for board_inspector

### DIFF
--- a/misc/config_tools/board_inspector/legacy/acpi.py
+++ b/misc/config_tools/board_inspector/legacy/acpi.py
@@ -576,6 +576,10 @@ def store_px_data(sysnode, config):
 
 def store_mmcfg_base_data(mmcfg_node, config):
 
+    # in case there're MCFG1/MCFG2 instead of MCFG
+    if not os.path.exists(mmcfg_node):
+        mmcfg_node += "1"
+
     print("\t/* PCI mmcfg base of MCFG */", file=config)
     with open(mmcfg_node, 'rb') as mmcfg:
         mmcfg.read(MCFG_OFFSET)


### PR DESCRIPTION
Some motherboards exposes MCFG1/MCFG2 instead of one ACPI MCFG table, thus no /sys/firmware/acpi/tables/MCFG exists but MCFG1 and MCFG2.

Read MCFG1 if MCFG doesn't exist.

The same issue report/fix is at https://github.com/intel/pcm/issues/74.