### PR TITLE
hv: configure hv console default output in scenario file

### DIFF
--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -23,7 +23,7 @@ struct hv_timer console_timer;
 #define CONSOLE_KICK_TIMER_TIMEOUT  40UL /* timeout is 40ms*/
 /* Switching key combinations for shell and uart console */
 #define GUEST_CONSOLE_TO_HV_SWITCH_KEY      0       /* CTRL + SPACE */
-uint16_t console_vmid = ACRN_INVALID_VMID;
+uint16_t console_vmid = CONFIG_CONSOLE_DEFAULT_VM;
 
 /* if use INIT to kick pcpu only, if not notification IPI still is used for sharing CPU */
 static bool use_init_ipi = false;

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -34,6 +34,11 @@
         <xs:documentation>Select the default log level for log messages written to the serial console. Log messages with the selected value or lower are displayed.</xs:documentation>
       </xs:annotation>
     </xs:element>
+    <xs:element name="CONSOLE_VM" type="xs:integer" default="65535">
+      <xs:annotation acrn:title="Default VM in hypervisor console output" acrn:views="basic">
+        <xs:documentation>Select the default VM in hypervisor console output. Default is hypervisor console.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:all>
 </xs:complexType>
 

--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -63,6 +63,13 @@
       <xsl:with-param name="value" select="CONSOLE_LOGLEVEL" />
     </xsl:call-template>
 
+    <xsl:call-template name="integer-by-key-value">
+      <xsl:with-param name="key" select="'CONSOLE_DEFAULT_VM'" />
+      <xsl:with-param name="value" select="CONSOLE_VM" />
+      <!-- Default is HV console, ACRN_INVALID_VMID -->
+      <xsl:with-param name="default" select="'0xffff'" />
+    </xsl:call-template>
+
     <xsl:apply-templates select="SERIAL_CONSOLE" />
   </xsl:template>
 


### PR DESCRIPTION
Add a new option CONSOLE_VM in scenario to set the default vm to be outputted in hv console, when it is not set, acrn console will be used (current behavior). This is intended for debugging vm boot issues.

Tracked-On: #8518

Reviewed-by: Junjie Mao <junjie.mao@intel.com>