### PR TITLE
hv: support multi function ivshmem device

### DIFF
--- a/hypervisor/dm/vpci/ivshmem.c
+++ b/hypervisor/dm/vpci/ivshmem.c
@@ -336,6 +336,8 @@ static void init_ivshmem_vdev(struct pci_vdev *vdev)
 	pci_vdev_write_vcfg(vdev, PCIR_DEVICE, 2U, IVSHMEM_DEVICE_ID);
 	pci_vdev_write_vcfg(vdev, PCIR_REVID, 1U, IVSHMEM_REV);
 	pci_vdev_write_vcfg(vdev, PCIR_CLASS, 1U, IVSHMEM_CLASS);
+	pci_vdev_write_vcfg(vdev, PCIR_HDRTYPE, 1U,
+		PCIM_HDRTYPE_NORMAL | ((vdev->bdf.bits.f == 0U) ? PCIM_MFDEV : 0U));
 	add_vmsix_capability(vdev, MAX_IVSHMEM_MSIX_TBL_ENTRY_NUM, IVSHMEM_MSIX_BAR);
 
 	/* initialize ivshmem bars */


### PR DESCRIPTION
Currently ivshmem device can only be configurated as single function device(bdf.f = 0) on bus 0. This greatly limits the number of ivshmem devices we can create. This patch is to enable multiple function bit in HEADER_TYPE config register, so that we can create many more ivshmem devices by using different function numbers on one bus:dev.

The multi function device bit is to be set on ivshmem devices whose function number equls 0. PCI spec describe it as: ‘When Set, indicates that the Device may contain multiple Functions, but not necessarily.’, So if this dev is the only one on the bus:dev, it is still OK.

Tracked-On: #8520

Reviewed-by: Junjie Mao <junjie.mao@intel.com>