### PR TITLE
doc: specify the python pkg version

### DIFF
--- a/doc/getting-started/getting-started.rst
+++ b/doc/getting-started/getting-started.rst
@@ -119,8 +119,13 @@ To set up the ACRN build environment on the development computer:
            xsltproc clang-format bc libpixman-1-dev libsdl2-dev libegl-dev \
            libgles-dev libdrm-dev gnu-efi libelf-dev \
            build-essential git-buildpackage devscripts dpkg-dev equivs lintian \
-           apt-utils pristine-tar dh-python python3-lxml python3-defusedxml \
-           python3-tqdm python3-xmlschema python3-elementpath acpica-tools
+           apt-utils pristine-tar dh-python acpica-tools
+
+#. Install Python package dependencies:
+
+   .. code-block:: bash
+
+      sudo pip3 install "elementpath==2.5.0" lxml "xmlschema==1.9.2" defusedxml tqdm
 
 #. Get the ACRN hypervisor and ACRN kernel source code, and check out the
    current release branch.


### PR DESCRIPTION
specify the python pkg version using the command
'sudo pip3 install "elementpath==2.5.0" lxml xmlschema defusedxml tqdm' because fix PR #8384 is not in v3.2 branch.