### PR TITLE
Fix Debian packaging postinst partition finding

### DIFF
--- a/misc/packaging/acrn-hypervisor.postinst
+++ b/misc/packaging/acrn-hypervisor.postinst
@@ -21,7 +21,7 @@ GENERATED_PARAMS=(cpu_perf_policy=Performance)
 #ACRN parameters End
 
 ACRNBIN="/boot/acrn.${SCENARIO}.${BOARD}.bin"
-type=$(lsblk -l |awk '$NF == "/" {print $1}')
+type=$(findmnt / |awk '$1 == "/" {print $2}')
 
 pattern='^/dev/.* UUID="([^"]+)".* PARTUUID="([^"]+)"'
 while IFS= read -r line; do
@@ -29,7 +29,7 @@ while IFS= read -r line; do
         uuid="${BASH_REMATCH[1]}"
         partuuid="${BASH_REMATCH[2]}"
     fi
-done < <(blkid |grep ext4 |grep ${type})
+done < <(blkid |grep ${type})
 
 filename="/etc/grub.d/40_custom"
 

--- a/misc/packaging/acrn-kernel.postinst
+++ b/misc/packaging/acrn-kernel.postinst
@@ -3,7 +3,7 @@
 # postinst script for acrn kernel
 filename="/etc/grub.d/40_custom"
 menu=$(grep ACRN_deb_multiboot2 ${filename}) || true
-type=$(lsblk -l |awk '$NF == "/" {print $1}')
+type=$(findmnt / |awk '$1 == "/" {print $2}')
 str=$(blkid |grep ${type})
 uuid=$(echo $str |cut -d " " -f 2|cut -d "=" -f 2)
 str=$(blkid |grep ${type})


### PR DESCRIPTION
If the root partition is bind mounted with / and another, the current postinst script (using command lsblk) will fail to find the partition: $type will be "/" only and cause the following command may find the wrong partition.

And current command forces the root partition to be ext4.

This patch fixes the two issues.

Two setups with bind mounted root partition;

Ubuntu 22.04 desktop, bind mount firefox snap:
```
> lsblk
nvme0n1      259:19   0 931.5G  0 disk
├─nvme0n1p1  259:20   0   243M  0 part /boot/efi
├─nvme0n1p2  259:21   0 927.5G  0 part /var/snap/firefox/common/host-hunspell
│                                      /
```

Windows WSL2, bind mount WSLg:
```
> lsblk
sdc    8:32   0     1T  0 disk /mnt/wslg/distro
                               /
```

Tracked-On: #8532