### PR TITLE
config-tools: do not generate tpm2 log area config when LAML or LASA …

### DIFF
--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -375,7 +375,7 @@
       <xsl:value-of select="acrn:initializer('mem_type', 'EPT_UNCACHED')" />
       <xsl:text>},</xsl:text>
       <xsl:value-of select="$newline" />
-      <xsl:if test="//capability[@id='log_area']">
+      <xsl:if test="//capability[@id='log_area'] and //capability[@id='log_area']/log_area_minimum_length != '0x0' and //capability[@id='log_area']/log_area_start_address != '0x0'">
         <xsl:value-of select="acrn:initializer('res[1]', '{', true())" />
         <xsl:value-of select="acrn:initializer('user_vm_pa', 'VM0_TPM_EVENTLOG_BASE_ADDR')" />
         <xsl:value-of select="acrn:initializer('host_pa', 'VM0_TPM_EVENTLOG_BASE_ADDR_HPA')" />


### PR DESCRIPTION
…is 0

When LAML or LASA of TPM2 event log is 0, the log area is invalid. It should not be configured in mmiodevs of vm_configurations.c.

Tracked-On: #8540
Reviewed-by: Junjie Mao <junjie.mao@intel.com>