### PR TITLE
dm: lpc uart emulation enhancements

### DIFF
--- a/devicemodel/hw/pci/lpc.c
+++ b/devicemodel/hw/pci/lpc.c
@@ -87,6 +87,7 @@ lpc_device_parse(const char *opts)
 	if (lpcdev != NULL) {
 		for (unit = 0; unit < LPC_UART_NUM; unit++) {
 			if (strcasecmp(lpcdev, lpc_uart_names[unit]) == 0) {
+				lpc_uart_vdev[unit].enabled = 1;
 				lpc_uart_vdev[unit].opts = str;
 				error = 0;
 				goto done;
@@ -201,6 +202,9 @@ lpc_init(struct vmctx *ctx)
 	for (unit = 0; unit < LPC_UART_NUM; unit++) {
 		lpc_uart = &lpc_uart_vdev[unit];
 		name = lpc_uart_names[unit];
+
+		if (lpc_uart->enabled == 0)
+			continue;
 
 		if (uart_legacy_alloc(unit,
 				      &lpc_uart->iobase,

--- a/devicemodel/hw/pci/lpc.c
+++ b/devicemodel/hw/pci/lpc.c
@@ -59,7 +59,7 @@ SYSRES_IO(NMISC_PORT, 1);
 
 static struct pci_vdev *lpc_bridge;
 
-#define	LPC_UART_NUM	2
+#define	LPC_UART_NUM	4
 static struct lpc_uart_vdev {
 	struct uart_vdev *uart;
 	const char *opts;
@@ -68,7 +68,7 @@ static struct lpc_uart_vdev {
 	int	enabled;
 } lpc_uart_vdev[LPC_UART_NUM];
 
-static const char *lpc_uart_names[LPC_UART_NUM] = { "COM1", "COM2" };
+static const char *lpc_uart_names[LPC_UART_NUM] = { "COM1", "COM2", "COM3", "COM4" };
 
 /*
  * LPC device configuration is in the following form:

--- a/devicemodel/hw/uart_core.c
+++ b/devicemodel/hw/uart_core.c
@@ -52,6 +52,10 @@
 #define COM1_IRQ	4
 #define	COM2_BASE	0x2F8
 #define COM2_IRQ	3
+#define COM3_BASE	0x3E8
+#define COM3_IRQ	6
+#define COM4_BASE	0x2E8
+#define COM4_IRQ	7
 
 #define	DEFAULT_RCLK	1843200
 #define	DEFAULT_BAUD	9600
@@ -83,6 +87,8 @@ static struct {
 } uart_lres[] = {
 	{ COM1_BASE, COM1_IRQ, false},
 	{ COM2_BASE, COM2_IRQ, false},
+	{ COM3_BASE, COM3_IRQ, false},
+	{ COM4_BASE, COM4_IRQ, false},
 };
 
 #define	UART_NLDEVS	(ARRAY_SIZE(uart_lres))


### PR DESCRIPTION
This patchset enhances current lpc uart emulation feature including supporting emulating COM3 and 4, this is used for improving debugging experience on post-launched vm without hv console.
