### PR TITLE
config_tools: fix pre_launch VM ACPI table

### DIFF
--- a/misc/config_tools/acpi_gen/asl_gen.py
+++ b/misc/config_tools/acpi_gen/asl_gen.py
@@ -394,11 +394,12 @@ def gen_root_pci_bus(path, prt_packages):
     resources.append(res)
 
     # The PCI hole above 4G
+    qword_address_space_cls = rdt.LargeResourceItemQWordAddressSpace_factory()
     res = create_object(
-        dword_address_space_cls,
+        qword_address_space_cls,
         type   = 1,    # Large type
-        name   = rdt.LARGE_RESOURCE_ITEM_ADDRESS_SPACE_RESOURCE,
-        length = ctypes.sizeof(dword_address_space_cls) - 3,
+        name   = rdt.LARGE_RESOURCE_ITEM_QWORD_ADDRESS_SPACE,
+        length = ctypes.sizeof(qword_address_space_cls) - 3,
         _TYP   = 0,    # Memory range
         _DEC   = 0,    # Positive decoding
         _MIF   = 1,    # Minimum address fixed


### PR DESCRIPTION
Current acpi table adopts the DWordAddressSpace to present 
the PCI hole above 4G. It is not correct, because DWordAddressSpace 
is used to present the mem space below 4G.
Follow the ACPI spec, modify to QWordAddressSpace here.

Refer: 19.6.22. CreateQWordField (Create 64-Bit Buffer Field)

Tracked-On: #8552
Signed-off-by: Zhangwei6 <wei6.zhang@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>