### PR TITLE
hv: add max_len for sbuf_put param

### DIFF
--- a/hypervisor/common/vm_event.c
+++ b/hypervisor/common/vm_event.c
@@ -37,7 +37,7 @@ int32_t send_vm_event(struct acrn_vm *vm, struct vm_event *event)
 
 	if (sbuf != NULL) {
 		spinlock_obtain(&vm->vm_event_lock);
-		size_sent = sbuf_put(sbuf, (uint8_t *)event);
+		size_sent = sbuf_put(sbuf, (uint8_t *)event, sizeof(*event));
 		spinlock_release(&vm->vm_event_lock);
 		if (size_sent == sizeof(struct vm_event)) {
 			arch_fire_hsm_interrupt();

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -91,18 +91,14 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 
 	/* Check whether output to memory */
 	if (do_mem_log) {
-		uint32_t i, msg_len;
+		uint32_t msg_len;
 		struct shared_buf *sbuf = per_cpu(sbuf, pcpu_id)[ACRN_HVLOG];
 
 		/* If sbuf is not ready, we just drop the massage */
 		if (sbuf != NULL) {
 			msg_len = strnlen_s(buffer, LOG_MESSAGE_MAX_SIZE);
-
-			for (i = 0U; i < (((msg_len - 1U) / LOG_ENTRY_SIZE) + 1U);
-					i++) {
-				(void)sbuf_put(sbuf, (uint8_t *)buffer +
-							(i * LOG_ENTRY_SIZE));
-			}
+			(void)sbuf_put_many(sbuf, LOG_ENTRY_SIZE, (uint8_t *)buffer,
+				LOG_ENTRY_SIZE * (((msg_len - 1U) / LOG_ENTRY_SIZE) + 1));
 		}
 	}
 }

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -303,7 +303,6 @@ static int32_t profiling_sbuf_put_variable(struct shared_buf *sbuf,
  */
 static int32_t profiling_generate_data(int32_t collector, uint32_t type)
 {
-	uint64_t i;
 	uint32_t remaining_space = 0U;
 	int32_t 	ret = 0;
 	struct data_header pkt_header;
@@ -380,13 +379,8 @@ static int32_t profiling_generate_data(int32_t collector, uint32_t type)
 				return 0;
 			}
 
-			for (i = 0U; i < (((DATA_HEADER_SIZE - 1U) / SEP_BUF_ENTRY_SIZE) + 1U); i++) {
-				(void)sbuf_put(sbuf, (uint8_t *)&pkt_header + i * SEP_BUF_ENTRY_SIZE);
-			}
-
-			for (i = 0U; i < (((payload_size - 1U) / SEP_BUF_ENTRY_SIZE) + 1U); i++) {
-				(void)sbuf_put(sbuf, (uint8_t *)payload + i * SEP_BUF_ENTRY_SIZE);
-			}
+			(void)sbuf_put_many(sbuf, SEP_BUF_ENTRY_SIZE, (uint8_t *)&pkt_header, sizeof(pkt_header));
+			(void)sbuf_put_many(sbuf, SEP_BUF_ENTRY_SIZE, (uint8_t *)payload, payload_size);
 
 			ss->samples_logged++;
 		}

--- a/hypervisor/debug/trace.c
+++ b/hypervisor/debug/trace.c
@@ -56,7 +56,7 @@ static inline void trace_put(uint16_t cpu_id, uint32_t evid, uint32_t n_data, st
 	entry->id = evid;
 	entry->n_data = (uint8_t)n_data;
 	entry->cpu = (uint8_t)cpu_id;
-	(void)sbuf_put(sbuf, (uint8_t *)entry);
+	(void)sbuf_put(sbuf, (uint8_t *)entry, sizeof(*entry));
 }
 
 void TRACE_2L(uint32_t evid, uint64_t e, uint64_t f)

--- a/hypervisor/dm/io_req.c
+++ b/hypervisor/dm/io_req.c
@@ -176,7 +176,7 @@ static int acrn_insert_asyncio(struct acrn_vcpu *vcpu, const uint64_t asyncio_fd
 
 	if (sbuf != NULL) {
 		spinlock_obtain(&vm->asyncio_lock);
-		while (sbuf_put(sbuf, (uint8_t *)&asyncio_fd) == 0U) {
+		while (sbuf_put(sbuf, (uint8_t *)&asyncio_fd, sizeof(asyncio_fd)) == 0U) {
 			/* sbuf is full, try later.. */
 			spinlock_release(&vm->asyncio_lock);
 			asm_pause();

--- a/hypervisor/include/common/sbuf.h
+++ b/hypervisor/include/common/sbuf.h
@@ -17,7 +17,8 @@
  *@pre sbuf != NULL
  *@pre data != NULL
  */
-uint32_t sbuf_put(struct shared_buf *sbuf, uint8_t *data);
+uint32_t sbuf_put(struct shared_buf *sbuf, uint8_t *data, uint32_t max_len);
+uint32_t sbuf_put_many(struct shared_buf *sbuf, uint32_t elem_size, uint8_t *data, uint32_t data_size);
 int32_t sbuf_share_setup(uint16_t cpu_id, uint32_t sbuf_id, uint64_t *hva);
 void sbuf_reset(void);
 uint32_t sbuf_next_ptr(uint32_t pos, uint32_t span, uint32_t scope);


### PR DESCRIPTION
sbuf_put copies sbuf->ele_size of data, and puts into ring. Currently this function assumes that data size from caller is no less than sbuf->ele_size.

But as sbuf->ele_size is usually setup by some sources outside of the HV (e.g., the service VM), it is not meant to be trusted. So caller should provide the max length of the data for safety reason. sbuf_put() will return UINT32_MAX if max_len of data is less than element size.

Additionally, a helper function sbuf_put_many() is added for putting multiple entries.

Tracked-On: #8547

Reviewed-by: Junjie Mao <junjie.mao@intel.com>