### PR TITLE
dm: fix LPC UART no output issue after reboot

### DIFF
--- a/devicemodel/hw/pci/lpc.c
+++ b/devicemodel/hw/pci/lpc.c
@@ -65,7 +65,7 @@ static struct lpc_uart_vdev {
 	const char *opts;
 	int	iobase;
 	int	irq;
-	int	enabled;
+	int	enabled;	/* enabled/configured by user */
 } lpc_uart_vdev[LPC_UART_NUM];
 
 static const char *lpc_uart_names[LPC_UART_NUM] = { "COM1", "COM2", "COM3", "COM4" };
@@ -185,7 +185,6 @@ lpc_deinit(struct vmctx *ctx)
 		uart_release_backend(lpc_uart->uart, lpc_uart->opts);
 		uart_legacy_dealloc(unit);
 		lpc_uart->uart = NULL;
-		lpc_uart->enabled = 0;
 	}
 }
 
@@ -233,7 +232,6 @@ lpc_init(struct vmctx *ctx)
 		error = register_inout(&iop);
 		if (error)
 			goto init_failed;
-		lpc_uart->enabled = 1;
 	}
 
 	return 0;


### PR DESCRIPTION
The meaning of lpc_uart_vdev::enabled was changed from runtime enablement status of UARTs to user configuration in commit 852f10cc3. So it's incorrect to clear it in lpc_deinit() which will cause UARTs disabled after reboot.

Tracked-On: #8537
Fixes: 852f10cc3 ("dm: lpc: only emulate COM ports specified in command line")