### PR TITLE
hv: console reads all input chars in one poll

### DIFF
--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -104,20 +104,27 @@ struct acrn_vuart *vm_console_vuart(struct acrn_vm *vm)
 static void vuart_console_rx_chars(struct acrn_vuart *vu)
 {
 	char ch = -1;
+	bool recv = false;
 
-	/* Get data from physical uart */
-	ch = uart16550_getc();
+	while (1) {
+		/* Get data from physical uart */
+		ch = uart16550_getc();
+		if (ch == -1)
+			break;
 
-	if (ch == GUEST_CONSOLE_TO_HV_SWITCH_KEY) {
-		/* Switch the console */
-		console_vmid = ACRN_INVALID_VMID;
-		printf("\r\n\r\n ---Entering ACRN SHELL---\r\n");
-	}
-	if (ch != -1) {
+		if (ch == GUEST_CONSOLE_TO_HV_SWITCH_KEY) {
+			/* Switch the console */
+			console_vmid = ACRN_INVALID_VMID;
+			printf("\r\n\r\n ---Entering ACRN SHELL---\r\n");
+			break;
+		}
+
 		vuart_putchar(vu, ch);
+		recv = true;
+	}
+	if (recv) {
 		vuart_toggle_intr(vu);
 	}
-
 }
 
 /**


### PR DESCRIPTION
For uart console, some control keys are defined as byte sequences, such as:
 * up arrow - 0x1b/0x5b/0x41
 * F8 - 0x1b/0x5b/0x31/0x39/0x7e

Currently hv console only read one char per poll.
When guest vuart console is active, those byte sequences may not be sent to guest vuart in good timing due to the poll interval. Thus control keys such as up/down can not be used in shell or vim.

The solution is to read all input chars in one poll, so that control keys can be received by guest OS properly.

Tracked-On: #8564

Reviewed-by: Junjie Mao <junjie.mao@intel.com>