### PR TITLE
hv: return error code for default case in hcall_vm_intr_monitor

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1208,6 +1208,8 @@ int32_t hcall_vm_intr_monitor(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm,
 			intr_hdr = (struct acrn_intr_monitor *)hpa2hva(hpa);
 			stac();
 			if (intr_hdr->buf_cnt <= (MAX_PTDEV_NUM * 2U)) {
+				status = 0;
+
 				switch (intr_hdr->cmd) {
 				case INTR_CMD_GET_DATA:
 					intr_hdr->buf_cnt = ptirq_get_intr_data(target_vm,
@@ -1222,10 +1224,9 @@ int32_t hcall_vm_intr_monitor(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm,
 
 				default:
 					/* if cmd wrong it goes here should not happen */
+					status = -EINVAL;
 					break;
 				}
-
-				status = 0;
 			}
 			clac();
 		}


### PR DESCRIPTION
In hcall_vm_intr_monitor(), the default case for intr_hdr->cmd is a wrong case. So, it should return error code back. But it returns success code 0 in current codes.

Tracked-On: #8580
Reviewed-by: Fei Li <fei1.li@intel.com>