### PR TITLE
Hv break char for kdb upstream

### DIFF
--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -138,7 +138,7 @@ static uint8_t vuart_intr_reason(const struct acrn_vuart *vu)
 	if (((vu->lsr & (LSR_OE | LSR_BI)) != 0U) && ((vu->ier & IER_ELSI) != 0U)) {
 		ret = IIR_RLS;
 	} else if ((fifo_numchars(&vu->rxfifo) > 0U) && ((vu->ier & IER_ERBFI) != 0U)) {
-		ret = IIR_RXTOUT;
+		ret = IIR_RXRDY;
 	} else if (vu->thre_int_pending && ((vu->ier & IER_ETBEI) != 0U)) {
 		ret = IIR_TXRDY;
 	} else if(((vu->msr & MSR_DELTA_MASK) != 0U) && ((vu->ier & IER_EMSC) != 0U)) {

--- a/hypervisor/include/dm/vuart.h
+++ b/hypervisor/include/dm/vuart.h
@@ -75,6 +75,7 @@ struct acrn_vuart {
 	char vuart_tx_buf[TX_BUF_SIZE];
 	bool thre_int_pending;	/* THRE interrupt pending */
 	bool active;
+	bool escaping;		/* in escaping sequence, for console vuarts */
 	struct acrn_vuart *target_vu; /* Pointer to target vuart */
 	struct acrn_vm *vm;
 	struct pci_vdev *vdev;	/* pci vuart */


### PR DESCRIPTION
The first patch adds an key escaping sequence to ensure that users can input
any key to guest serial via vm console. This makes it possible to debug
Service VM kernel with kgdb/kdb and sysrq. The key sequence to switch from
guest console to HV console has changed to "<break> + e". In minicom, it will
be a sequence of "<ctrl-a> + f + e".

The second patch fixes the interrupt ID in IIR for normal data receiving.
Although the old RX Timeout value worked but RX Ready is more reasonable.