### PR TITLE
misc: fix invalid escape sequence in python 3.12

### DIFF
--- a/misc/config_tools/library/board_cfg_lib.py
+++ b/misc/config_tools/library/board_cfg_lib.py
@@ -148,7 +148,7 @@ def get_max_clos_mask(board_file):
     if (len(rdt_res) == 0) or (len(rdt_res_clos_max) == 0):
         return rdt_res, rdt_res_clos_max, rdt_res_mask_max
     else:
-        return list(re.split(', |\s |,', rdt_res)), list(map(int, rdt_res_clos_max.split(','))), list(re.split(', |\s |,', rdt_res_mask_max))
+        return list(re.split(r', |\s |,', rdt_res)), list(map(int, rdt_res_clos_max.split(','))), list(re.split(r', |\s |,', rdt_res_mask_max))
 
 
 def get_rootfs(config_file):
@@ -377,7 +377,7 @@ def get_p_state_index_from_ratio(ratio):
         i = 0
         closest_index = 1
         for line in px_info:
-            l = re.search("0x(\w*)UL}", line)
+            l = re.search(r"0x(\w*)UL}", line)
             if l != None:
                 state_ratio = int(l.group(1), 16) >> 8
                 if state_ratio <= ratio:

--- a/misc/config_tools/static_allocators/gpa.py
+++ b/misc/config_tools/static_allocators/gpa.py
@@ -72,10 +72,8 @@ LEGACY_VUART_IO_PORT_SIZE = 0x10
 VMSIX_VBAR_SIZE = 4 * SIZE_K
 
 # Constant for VIRT_ACPI_NVS_ADDR
-"""
-VIRT_ACPI_NVS_ADDR and PRE_RTVM_SW_SRAM_END_GPA
-need to be consistant with the layout of hypervisor\arch\x86\guest\ve820.c
-"""
+# VIRT_ACPI_NVS_ADDR and PRE_RTVM_SW_SRAM_END_GPA
+# need to be consistant with the layout of hypervisor\arch\x86\guest\ve820.c
 VIRT_ACPI_NVS_ADDR = 0x7FF00000
 RESERVED_NVS_AREA = 0xB0000
 

--- a/misc/packaging/gen_acrn_deb.py
+++ b/misc/packaging/gen_acrn_deb.py
@@ -85,7 +85,7 @@ def create_acrn_deb(board, scenario, version, build_dir):
 
     a_f = open(build_dir + "/hypervisor/.scenario.xml", 'r')
     for a_line in a_f:
-        l = re.search("<CPU_PERFORMANCE_POLICY>(\w*)</CPU_PERFORMANCE_POLICY>", a_line)
+        l = re.search(r"<CPU_PERFORMANCE_POLICY>(\w*)</CPU_PERFORMANCE_POLICY>", a_line)
         if l != None:
             break;
     start = lines.index('#ACRN parameters Start\n')
@@ -250,10 +250,10 @@ def clean_configurator_deb(version, build_dir):
 
     add_cmd_list(cmd_list, 'bash -c "find -name "*.log" -delete"', config_tools_path)
     add_cmd_list(cmd_list, 'bash -c "find -name "*.whl" -delete"', config_tools_path)
-    add_cmd_list(cmd_list, 'bash -c "find -name "*.egg-info" -prune -exec rm -rf {} \;"', config_tools_path)
-    add_cmd_list(cmd_list, 'bash -c "find -name "node_modules" -prune -exec rm -rf {} \;"', config_tools_path)
-    add_cmd_list(cmd_list, 'bash -c "find -name "build" -prune -exec rm -rf {} \;"', config_tools_path)
-    add_cmd_list(cmd_list, 'bash -c "find -name "target" -prune -exec rm -rf {} \;"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "find -name "*.egg-info" -prune -exec rm -rf {} \\;"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "find -name "node_modules" -prune -exec rm -rf {} \\;"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "find -name "build" -prune -exec rm -rf {} \\;"', config_tools_path)
+    add_cmd_list(cmd_list, 'bash -c "find -name "target" -prune -exec rm -rf {} \\;"', config_tools_path)
     add_cmd_list(cmd_list, 'bash -c "rm -rf dist"', config_tools_path)
     add_cmd_list(cmd_list, 'bash -c "rm -rf schema/sliced.xsd"', config_tools_path)
     add_cmd_list(cmd_list, 'bash -c "rm -rf schema/allchecks.xsd"', config_tools_path)


### PR DESCRIPTION
Python 3.12 adds escape sequence check in strings, if it is invalid, a SyntaxWarning will be given. Fix it by using raw string notation in regular expressions, and changing comments in unused string literal to normal comments.

Tracked-On: #8588

Reviewed-by: Junjie Mao <junjie.mao@intel.com>