### PR TITLE
config_tools: support the GUEST_FLAG_VTM flag

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -409,6 +409,11 @@ These settings can only be changed at build time.</xs:documentation>
         <xs:documentation>Enable virtualization of the Cache Allocation Technology (CAT) feature in RDT. CAT enables you to allocate cache to VMs, providing isolation to avoid performance interference from other VMs.</xs:documentation>
       </xs:annotation>
     </xs:element>
+    <xs:element name="virtual_thermal_monitor" type="Boolean" default="n" minOccurs="0">
+      <xs:annotation acrn:title="Virtual Thermal Monitor" acrn:applicable-vms="pre-launched, post-launched, service-vm" acrn:views="advanced">
+        <xs:documentation>Enable virtualization of the Thermal Monitor feature for this VM. This feature enables VM to retrieve SOC temperature and thermal irq. And this VM can implement cooling stategies based on these information.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
     <xs:element name="virtual_cat_number" default="0" minOccurs="0">
       <xs:annotation acrn:title="Maximum virtual CLOS" acrn:applicable-vms="pre-launched, post-launched" acrn:views="advanced">
         <xs:documentation>Max number of virtual CLOS MASK</xs:documentation>

--- a/misc/config_tools/static_allocators/guest_flags.py
+++ b/misc/config_tools/static_allocators/guest_flags.py
@@ -21,6 +21,7 @@ policies = [
     GuestFlagPolicy(".//secure_world_support = 'y'", "GUEST_FLAG_SECURE_WORLD_ENABLED"),
     GuestFlagPolicy(".//hide_mtrr_support = 'y'", "GUEST_FLAG_HIDE_MTRR"),
     GuestFlagPolicy(".//nested_virtualization_support = 'y'", "GUEST_FLAG_NVMX_ENABLED"),
+    GuestFlagPolicy(".//virtual_thermal_monitor = 'y'", "GUEST_FLAG_VTM"),
     GuestFlagPolicy(".//security_vm = 'y'", "GUEST_FLAG_SECURITY_VM"),
     GuestFlagPolicy(".//vm_type = 'RTVM'", "GUEST_FLAG_RT"),
     GuestFlagPolicy(".//vm_type = 'RTVM' and .//load_order = 'PRE_LAUNCHED_VM' and //hv/BUILD_TYPE= 'debug'", "GUEST_FLAG_PMU_PASSTHROUGH"),


### PR DESCRIPTION
In hv, we implement the feature of thermal virtualization, We want to use this GUEST_FLAG_VTM flag to enable and disable this feature. So we mark this flag in config tools.


porting from the inner source repo. 

Tracked-On: #8595

Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>
Signed-off-by: Zhangwei6 <wei6.zhang@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>