### PR TITLE
misc: fix v-model used on props for vue3 make strictly checking

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src-tauri/Cargo.lock
+++ b/misc/config_tools/configurator/packages/configurator/src-tauri/Cargo.lock
@@ -1362,7 +1362,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.0.0"
+ "indexmap 2.0.0",
  "slab",
  "tokio",
  "tokio-util",

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -25,7 +25,7 @@
           </div>
         </div>
       </template>
-      <Board v-model:WorkingFolder="WorkingFolder" v-model:board="board" v-model:schemas="schemas"
+      <Board :WorkingFolder="WorkingFolder" v-model:board="board" v-model:schemas="schemas"
              @boardUpdate="boardUpdate"/>
     </b-accordion-item>
 

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
@@ -31,7 +31,7 @@
     </div>
     <VueForm
         :key="(currentActiveVMID===-1?'HV':`VM${currentActiveVMID}`)+currentFormMode+'ConfigForm'"
-        v-model="currentFormData"
+        :currentFormData="currentFormData"
         :form-props="formProps"
         :ui-schema="uiSchema"
         :schema="currentFormSchema[currentFormMode]"

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/NewBoard.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/NewBoard.vue
@@ -1,6 +1,6 @@
 <template>
   <b-modal title="Board XML overwrite" fade no-close-on-backdrop
-           v-model="showModal"
+           :showModal="showModal"
            @cancel="cancel"
            @abort="cancel"
            @close="cancel"

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/Scenario/NewScenario.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/Scenario/NewScenario.vue
@@ -1,6 +1,6 @@
 <template>
   <b-modal id="newScenarioModal" size="xl" title="Create a New Scenario" fade no-close-on-backdrop
-           v-model="showModal"
+           :showModal="showModal"
            @cancel="cancel"
            @abort="cancel"
            @close="cancel"

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/Scenario/OverwriteMessage.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/Scenario/OverwriteMessage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <b-modal id="my-modal" no-close-on-backdrop
-             title="Scenario XML Overwrite" v-model="showModal"
+             title="Scenario XML Overwrite" :showModal="showModal"
              @cancel="cancel"
              @hidden="cancel"
              @abort="cancel"

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/Scenario/SaveScenario.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/Scenario/SaveScenario.vue
@@ -1,6 +1,6 @@
 <template>
   <b-modal title="ACRN Configurator" ok-only fade
-           v-model="showModal"
+           :showModal="showModal"
            @ok="overWrite"
   >
     <div class="picture">


### PR DESCRIPTION
I make this change during recent building configurator but got a failure. The change is to fix the problem caused by vue3's strictly syntax chacking. It is reported for newly releases only and before v3.2.25 it is a warning. I follow the error message and suggestion to change the code. Error message said "v-model cannot be used on a prop, because local prop bindings are not writable".
Suggestion said "Use v-bind binding combined with v-on listener to emit update" I ran the build & install procedure to verify the problem was solved.


Tracked-on: #8596