### PR TITLE
misc: add checking while append new vm

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -254,6 +254,12 @@ export default {
       }
       maxVMID++;
       this.scenario.vm.push(configurator.newVM(maxVMID, load_order))
+
+      //checking while adding new vm
+      let scenarioXMLData = this.scenarioToXML(this.scenario)
+      let all_errors = configurator.pythonObject.validateScenario(this.board.content, scenarioXMLData)
+      this.errors = this.translateErrors(all_errors, this.scenario)
+
       this.switchTab(maxVMID)
     },
     deleteVM() {


### PR DESCRIPTION
This patch will add checking cpu affinity while user click to add new vm. When I was following client's findings up I found that if I click to add a new post-launched vm for step 3.Configure settings for scenario and launch scripts, it failed to show error messages. The current version will check cpu affinity and serial port for post-launched and hv when creating a new vm, it wont verify when adding new post-launched & pre-launched vms, it will fail to save scenario configuration file without any explanation. I've rebuilt and run configurator, confirmed the checking procedure works.


Tracked-On: #8601
Reviewed-by: Junjie Mao junjie.mao@intel.com