### PR TITLE
dm: enable lpss device passthrough

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -1918,31 +1918,29 @@ pci_bus_write_dsdt(int bus)
 	dsdt_line("        ,, , AddressRangeMemory, TypeStatic)");
 	dsdt_line("    })");
 
-	if (!is_rtvm) {
-		count = pci_count_lintr(bus);
-		if (count != 0) {
-			dsdt_indent(2);
-			dsdt_line("Name (PPRT, Package ()");
-			dsdt_line("{");
-			pci_walk_lintr(bus, pci_pirq_prt_entry, NULL);
-			dsdt_line("})");
-			dsdt_line("Name (APRT, Package ()");
-			dsdt_line("{");
-			pci_walk_lintr(bus, pci_apic_prt_entry, NULL);
-			dsdt_line("})");
-			dsdt_line("Method (_PRT, 0, NotSerialized)");
-			dsdt_line("{");
-			dsdt_line("  If (PICM)");
-			dsdt_line("  {");
-			dsdt_line("    Return (APRT)");
-			dsdt_line("  }");
-			dsdt_line("  Else");
-			dsdt_line("  {");
-			dsdt_line("    Return (PPRT)");
-			dsdt_line("  }");
-			dsdt_line("}");
-			dsdt_unindent(2);
-		}
+	count = pci_count_lintr(bus);
+	if (count != 0) {
+		dsdt_indent(2);
+		dsdt_line("Name (PPRT, Package ()");
+		dsdt_line("{");
+		pci_walk_lintr(bus, pci_pirq_prt_entry, NULL);
+		dsdt_line("})");
+		dsdt_line("Name (APRT, Package ()");
+		dsdt_line("{");
+		pci_walk_lintr(bus, pci_apic_prt_entry, NULL);
+		dsdt_line("})");
+		dsdt_line("Method (_PRT, 0, NotSerialized)");
+		dsdt_line("{");
+		dsdt_line("  If (PICM)");
+		dsdt_line("  {");
+		dsdt_line("    Return (APRT)");
+		dsdt_line("  }");
+		dsdt_line("  Else");
+		dsdt_line("  {");
+		dsdt_line("    Return (PPRT)");
+		dsdt_line("  }");
+		dsdt_line("}");
+		dsdt_unindent(2);
 	}
 
 	dsdt_indent(2);

--- a/devicemodel/include/passthru.h
+++ b/devicemodel/include/passthru.h
@@ -9,6 +9,7 @@
 #define __PASSTHRU_H__
 
 #include <types.h>
+#include <limits.h>
 
 #include "pciaccess.h"
 #include "pci_core.h"
@@ -37,7 +38,9 @@ struct passthru_dev {
 	bool need_reset;
 	bool d3hot_reset;
 	bool need_rombar;
+	bool need_dsdt;
 	char *rom_buffer;
+	char dsdt_path[256];
 	bool (*has_virt_pcicfg_regs)(int offset);
 };
 


### PR DESCRIPTION
This patch is to enable the passthrough of lpss devices, such as sdio, spi, uart.