### PR TITLE
dm: deinit iothreads on vm reset

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -674,6 +674,8 @@ vm_reset_vdevs(struct vmctx *ctx)
 	pci_irq_deinit(ctx);
 	ioapic_deinit();
 
+	iothread_deinit();
+
 	pci_irq_init(ctx);
 	atkbdc_init(ctx);
 	vrtc_init(ctx);


### PR DESCRIPTION
iothreads are created by emulated block devices like virtio. These devices are resetted on vm reset, but these iothreads are not freed, causing a resource leak. Fix it by deinit all iothreads on vm reset.

Tracked-On: #8612

Reviewed-by: Jian Jun Chen <jian.jun.chen@intel.com>