### PR TITLE
hv: cpuid: fix hybrid related cpuid error

### DIFF
--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -596,10 +596,10 @@ static inline void percpu_cpuid_init(void)
 	if (pcpu_has_cap(X86_FEATURE_HYBRID)) {
 		/* 0x2U, 0x4U, 0x6U, 0x14U, 0x16U, 0x18U, 0x1A, 0x1C, 0x80000006U */
 		uint32_t hybrid_leaves[] = {CPUID_TLB, CPUID_CACHE,
-			CPUID_THERMAL_POWER, CPUID_FREQ, CPUID_ADDR_TRANS,
-			CPUID_MODEL_ID, CPUID_LAST_BRANCH_RECORD,
+			CPUID_THERMAL_POWER, CPUID_TRACE, CPUID_FREQ,
+			CPUID_ADDR_TRANS, CPUID_MODEL_ID, CPUID_LAST_BRANCH_RECORD,
 			CPUID_EXTEND_CACHE};
-		memcpy_s((pcpu_cpuids.leaves + pcpu_cpuids.leaf_nr * sizeof(uint32_t)),
+		memcpy_s(pcpu_cpuids.leaves + pcpu_cpuids.leaf_nr,
 			 sizeof(hybrid_leaves), hybrid_leaves, sizeof(hybrid_leaves));
 		pcpu_cpuids.leaf_nr += sizeof(hybrid_leaves)/sizeof(uint32_t);
 	}


### PR DESCRIPTION
Some cpuids will return invalid values on hybrid platform because of the error in the pointer arithmetic. Add `(void *)` before `cpu_cpuids.leaves`.

Leaf 0x14 is used to report Intel Processor Trace Enumeration and varies between P-cores and E-cores on hybrid platform. So add it to `hybrid_leaves`.

Tracked-On: #8608
Fixes: 59a8cc4c2 ("hv: cpuid: make leaf 0x4 per-cpu in hybrid architecture")

Reviewed-by: Junjie Mao <junjie.mao@intel.com>