### PR TITLE
release: fix the compilation error in release mode

### DIFF
--- a/hypervisor/release/trace.c
+++ b/hypervisor/release/trace.c
@@ -17,3 +17,5 @@ void TRACE_6C(__unused uint32_t evid, __unused uint8_t a1, __unused uint8_t a2,
 		__unused uint8_t a3, __unused uint8_t a4, __unused uint8_t b1, __unused uint8_t b2)
 {
 }
+
+void TRACE_16STR(__unused uint32_t evid, __unused const char name[]) {}


### PR DESCRIPTION
Commit `512c98fd7 hv: trace: show cpu usage of vms in pcpu sharing case` causes the compilation error in release mode:
  hypervisor/common/schedule.c:190: undefined reference to `TRACE_16STR'

This patch fixes this issue.

Tracked-On: #861