### PR TITLE
misc: Configurator Main VM Support

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/lib/acrn.ts
+++ b/misc/config_tools/configurator/packages/configurator/src/lib/acrn.ts
@@ -651,6 +651,10 @@ class PythonObject {
     generateConfigSummary(boardXMLText, scenarioXMLText) {
         return this.api('generateConfigSummary', 'plaintext', boardXMLText, scenarioXMLText)
     }
+
+    updateSchema(boardXMLText, scenarioXMLText) {
+        return this.api('updateSchema', 'plaintext', boardXMLText, scenarioXMLText)
+    }
 }
 
 class Configurator {

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/Scenario/NewScenario.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/Scenario/NewScenario.vue
@@ -32,7 +32,7 @@
           </b-form-radio>
 
           <b-form-radio class="mb-3" v-model="scenarioTemplate" value="partitioned">
-            Partitioned <i>(Pre-launched VMs only)</i>
+            Partitioned <i>(Pre-launched VMs or with Main VM)</i>
           </b-form-radio>
 
           <b-form-radio class="mb-3" v-model="scenarioTemplate" value="hybrid">
@@ -53,6 +53,10 @@
           <b-form-input v-if="scenarioTemplate!=='shared'" type="number" min="0" max="8" v-model="preLaunch"/>
           <b v-if="scenarioTemplate!=='partitioned'">Service VM:</b>
           <b-form-input v-if="scenarioTemplate!=='partitioned'" disabled type="number" model-value="1"/>
+
+          <b v-if="scenarioTemplate=='partitioned'">Main VM:</b>
+          <b-form-input v-if="scenarioTemplate=='partitioned'" min="0" max="1" type="number" v-model="mainVM"/>
+
           <b v-if="scenarioTemplate!=='partitioned'">Post-launch VMs:</b>
           <b-form-input v-if="scenarioTemplate!=='partitioned'" type="number" min="0" max="8" v-model="postLaunch"/>
         </div>
@@ -83,7 +87,8 @@ export default {
       version: branchVersion,
       scenarioTemplate: "shared",
       preLaunch: 1,
-      postLaunch: 1
+      postLaunch: 1,
+      mainVM: 1
     }
   },
   methods: {
@@ -102,6 +107,7 @@ export default {
         post = this.postLaunch
       } else if (this.scenarioTemplate === 'partitioned') {
         pre = this.preLaunch
+        service = this.mainVM;
       } else if (this.scenarioTemplate === 'hybrid') {
         pre = this.preLaunch;
         service = 1;

--- a/misc/config_tools/configurator/pyodide/updateSchema.py
+++ b/misc/config_tools/configurator/pyodide/updateSchema.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+__package__ = 'configurator.pyodide'
+
+from .pyodide import convert_result, nuc11_board, nuc11_scenario
+
+import re
+from lxml import etree
+
+
+class GenerateSchema:
+
+    def __init__(self, board, scenario):
+        parser = etree.XMLParser(remove_blank_text=True)
+        self.board_etree = etree.fromstring(board, parser)
+        self.scenario = scenario
+
+    @property
+    def pcis(self):
+        line = self.board_etree.xpath('/acrn-config/PCI_DEVICE/text()')[0]
+        cnt = []
+        for line in line.replace('\t', '').split('\n'):
+            re_cpi = re.compile(r'^([0-9A-Fa-f]{1,2}:[0-1][0-9A-Fa-f]\.[0-7].*)\(')
+            ret_ = re_cpi.search(line)
+            if ret_:
+                ret = ret_.group(1).strip()
+                if re.search(r'^00:00.0', ret):  # omit 00:00.0
+                    continue
+                cnt.append(ret)
+        return cnt
+
+    @property
+    def schemas(self):
+        return self.scenario
+
+    def update(self):
+        return sorted(list(set(self.pcis) - set(self.schemas)))
+
+
+def updateSchema(board, scenario):
+    return convert_result(GenerateSchema(board, scenario).update())
+
+
+main = updateSchema
+
+
+def test():
+    main(nuc11_board, nuc11_scenario)
+
+
+if __name__ == '__main__':
+    test()


### PR DESCRIPTION
This patch is to support Main VM, i.e., the Main VM scenario is similar to paritioned scenario, which select one VM as Main VM and owns the physical resources.

I extracted all pcis from the board, substracted them with dispatched ones and then make an assignment to replace the old enums.

This is implemented through two methods called updateSchema which is to update schema on the current VM and updateLoadSchema which is to maintain pcis, i.e. removed the pcis listed on the pre-launched VM, while loading scenario.xml.

I tested locally and confirmed the functionalties above are implemented.


Tracked-On: #8657