### PR TITLE
misc: fix openssl's vulnerability for tauri

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src-tauri/Cargo.lock
+++ b/misc/config_tools/configurator/packages/configurator/src-tauri/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "glob",
  "itertools",
  "log",
+ "openssl",
  "serde",
  "serde_json",
  "tauri",
@@ -2252,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.60"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -2284,9 +2285,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.96"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",

--- a/misc/config_tools/configurator/packages/configurator/src-tauri/Cargo.toml
+++ b/misc/config_tools/configurator/packages/configurator/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.57"
 tauri-build = { version = "1.5.2", features = [] }
 
 [dependencies]
+openssl = "0.10.66" # fix vulnerability only
 serde_json = "1.0.81"
 serde = { version = "1.0.137", features = ["derive"] }
 tauri = { version = "1.6.7", features = ["api-all", "devtools"] }


### PR DESCRIPTION
Trivy scaned one vulnerability three days ago and we fixed it now.

The title for vulnerability is openssl's `MemBio:get_buf` has undefined behavior with empty buffers.

I tested through building configurator, launching it and generating scenario.xml & launch scripts. I confirmed the result is correct.


Tracked-On: #8668