### PR TITLE
hv: add GUEST_FLAG_STATELESS flag

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -177,10 +177,8 @@ bool is_stateful_vm(const struct acrn_vm *vm)
 {
 	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 
-	/* TEE VM doesn't has its own state. The TAs will do the content
-	 * flush by themselves, HV and OS doesn't need to care about the state.
-	 */
-	return ((vm_config->guest_flags & GUEST_FLAG_TEE) == 0U);
+	/* TEE VM has GUEST_FLAG_STATELESS set implicitly */
+	return ((vm_config->guest_flags & GUEST_FLAG_STATELESS) == 0U);
 }
 
 /**

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -65,6 +65,7 @@
 #define GUEST_FLAG_PMU_PASSTHROUGH	(1UL << 11U)    /* Whether PMU is passed through */
 #define GUEST_FLAG_VHWP				(1UL << 12U)    /* Whether the VM supports vHWP */
 #define GUEST_FLAG_VTM				(1UL << 13U)    /* Whether the VM supports virtual thermal monitor */
+#define GUEST_FLAG_STATELESS			(1UL << 14U)	/* Whether the VM is stateless (can be forcefully shutdown with no data loss) */
 
 /* TODO: We may need to get this addr from guest ACPI instead of hardcode here */
 #define VIRTUAL_SLEEP_CTL_ADDR		0x400U /* Pre-launched VM uses ACPI reduced HW mode and sleep control register */

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -487,6 +487,11 @@ These settings can only be changed at build time.</xs:documentation>
         <xs:documentation>Specify TPM2 FIXUP for VM.</xs:documentation>
       </xs:annotation>
     </xs:element>
+    <xs:element name="stateless" type="Boolean" default="n" minOccurs="0">
+      <xs:annotation acrn:title="Stateless VM" acrn:applicable-vms="pre-launched" acrn:views="advanced">
+        <xs:documentation>Indicate the VM is running a stateless operating system and it can be shutdown forcefully with no data loss.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
     <xs:element name="epc_section" type="EPCSection" minOccurs="0">
       <xs:annotation acrn:title="SGX Enclave Page Cache" acrn:views="advanced" acrn:applicable-vms="pre-launched">
         <xs:documentation>Specify the Intel Software Guard Extensions (SGX) enclave page cache (EPC) section settings.</xs:documentation>

--- a/misc/config_tools/static_allocators/guest_flags.py
+++ b/misc/config_tools/static_allocators/guest_flags.py
@@ -27,6 +27,7 @@ policies = [
     GuestFlagPolicy(".//vm_type = 'RTVM' and .//load_order = 'PRE_LAUNCHED_VM' and //hv/BUILD_TYPE= 'debug'", "GUEST_FLAG_PMU_PASSTHROUGH"),
     GuestFlagPolicy(".//vm_type = 'TEE_VM'", "GUEST_FLAG_TEE"),
     GuestFlagPolicy(".//vm_type = 'REE_VM'", "GUEST_FLAG_REE"),
+    GuestFlagPolicy("(.//load_order = 'PRE_LAUNCHED_VM' and .//stateless = 'y') or (.//vm_type = 'TEE_VM')", "GUEST_FLAG_STATELESS"),
 ]
 
 def fn(board_etree, scenario_etree, allocation_etree):


### PR DESCRIPTION
GUEST_FLAG_STATELESS indicates guest is running a stateless operating system and need to be shutdown forcefully without data loss. This flag is only appalicable to pre-launched VM. For TEE_VM, this flag will be set implicitly.

Tracked-On: #8671

Reviewed-by: Junjie Mao <junjie.mao@intel.com>