### PR TITLE
[release_3.3] Remove debconf call in grub script

### DIFF
--- a/debian/acrn-hypervisor.postinst.in
+++ b/debian/acrn-hypervisor.postinst.in
@@ -19,6 +19,8 @@ ACRNMAP="${ACRNDIR}/${BOARD}/${SCENARIO}/acrn.${BOARD}.${SCENARIO}.map"
 ACRNBIN="${ACRNDIR}/${BOARD}/${SCENARIO}/acrn.${BOARD}.${SCENARIO}.bin"
 ACRNACPI="${ACRNDIR}/${BOARD}/${SCENARIO}/acpi"
 ACRNETC="${ACRNDIR}/${BOARD}/${SCENARIO}/etc"
+ACRNBOARD="${ACRNDIR}/${BOARD}/board.xml"
+ACRNSCENARIO="${ACRNDIR}/${BOARD}/${SCENARIO}/scenario.xml"
 
 case "$1" in
     configure)
@@ -26,6 +28,10 @@ case "$1" in
             cp ${ACRNCFG} /boot/acrn-@acrnversion@.config
             cp ${ACRNMAP} /boot/acrn-@acrnversion@.map
             cp ${ACRNBIN} /boot/acrn-@acrnversion@.bin
+            if [ -f ${ACRNBOARD} ] && [ -f ${ACRNSCENARIO} ]; then
+                ln -sf ${ACRNBOARD} /usr/share/acrn/board.xml
+                ln -sf ${ACRNSCENARIO} /usr/share/acrn/scenario.xml
+            fi
             if [ -d ${ACRNACPI} ]; then
                 cp ${ACRNACPI}/ACPI_VM* /boot
             fi

--- a/debian/acrn-hypervisor.postrm.in
+++ b/debian/acrn-hypervisor.postrm.in
@@ -13,6 +13,8 @@ rm_acrn()
     rm -f /boot/acrn-@acrnversion@.map
     rm -f /boot/acrn-@acrnversion@.bin
     rm -f /boot/ACPI_VM*
+    rm -f /usr/share/acrn/board.xml
+    rm -f /usr/share/acrn/scenario.xml
 }
 
 # summary of how this script can be called:

--- a/debian/acrn-hypervisor.prerm.in
+++ b/debian/acrn-hypervisor.prerm.in
@@ -13,6 +13,8 @@ rm_acrn()
     rm -f /boot/acrn-@acrnversion@.map
     rm -f /boot/acrn-@acrnversion@.bin
     rm -f /boot/ACPI_VM*
+    rm -f /usr/share/acrn/board.xml
+    rm -f /usr/share/acrn/scenario.xml
     if [ -f /etc/serial.conf ]; then
         sed '/ START - ACRN HYPERVISOR INSTALL/,/# END - ACRN HYPERVISOR INSTALL/{d}' /etc/serial.conf
     fi

--- a/debian/grub/25_linux_acrn
+++ b/debian/grub/25_linux_acrn
@@ -25,6 +25,44 @@ datarootdir="/usr/share"
 
 CLASS="--class gnu-linux --class gnu --class os --class acrn"
 
+file_is_not_sym () {
+    case "$1" in
+        */acrn-syms-*)
+        return 1;;
+    *)
+        return 0;;
+    esac
+}
+
+# use ELF *.out files for multiboot
+acrn_out_list=
+for i in /boot/acrn*.out; do
+    if grub_file_is_not_garbage "$i" && file_is_not_sym "$i" && grub-file --is-x86-multiboot "$i"; then
+        acrn_out_list="$acrn_out_list $i"
+    fi
+done
+# use raw binary *.bin files for multiboot2
+acrn_bin_list=
+for i in /boot/acrn*.bin; do
+    if grub_file_is_not_garbage "$i" && file_is_not_sym "$i" && grub-file --is-x86-multiboot2 "$i"; then
+        acrn_bin_list="$acrn_bin_list $i"
+    fi
+done
+# we prefer multiboot2
+if [ "x${acrn_bin_list}" != "x" ]; then
+    acrn_list="${acrn_bin_list}"
+    acrn_loader="multiboot2"
+    module_loader="module2"
+else
+    acrn_list="${acrn_out_list}"
+    acrn_loader="multiboot --quirk-modules-after-kernel"
+    module_loader="module"
+fi
+# no ACRN binary found
+if [ "x${acrn_list}" = "x" ] ; then
+    exit 0
+fi
+
 # we obtain any data from scenario config
 ACRN_SCENARIO_FILE=/usr/share/acrn/scenario.xml
 if [ ! -f ${ACRN_SCENARIO_FILE} ]; then
@@ -252,44 +290,6 @@ for i in /boot/vmlinu[xz]-* /vmlinu[xz]-* /boot/kernel-*; do
         fi
     fi
 done
-
-file_is_not_sym () {
-    case "$1" in
-        */acrn-syms-*)
-        return 1;;
-    *)
-        return 0;;
-    esac
-}
-
-# use ELF *.out files for multiboot
-acrn_out_list=
-for i in /boot/acrn*.out; do
-    if grub_file_is_not_garbage "$i" && file_is_not_sym "$i" && grub-file --is-x86-multiboot "$i"; then
-        acrn_out_list="$acrn_out_list $i"
-    fi
-done
-# use raw binary *.bin files for multiboot2
-acrn_bin_list=
-for i in /boot/acrn*.bin; do
-    if grub_file_is_not_garbage "$i" && file_is_not_sym "$i" && grub-file --is-x86-multiboot2 "$i"; then
-        acrn_bin_list="$acrn_bin_list $i"
-    fi
-done
-# we prefer multiboot2
-if [ "x${acrn_bin_list}" != "x" ]; then
-    acrn_list="${acrn_bin_list}"
-    acrn_loader="multiboot2"
-    module_loader="module2"
-else
-    acrn_list="${acrn_out_list}"
-    acrn_loader="multiboot --quirk-modules-after-kernel"
-    module_loader="module"
-fi
-# no ACRN binary found
-if [ "x${acrn_list}" = "x" ] ; then
-    exit 0
-fi
 
 prepare_boot_cache=
 boot_device_id=

--- a/debian/grub/25_linux_acrn
+++ b/debian/grub/25_linux_acrn
@@ -25,23 +25,8 @@ datarootdir="/usr/share"
 
 CLASS="--class gnu-linux --class gnu --class os --class acrn"
 
-# read ACRN config (board/scenario) from debconf
-ACRN_BOARD=$(echo "get acrn-hypervisor/board" | debconf-communicate || true)
-if [ "$(echo "${ACRN_BOARD}" | awk '{print $1}')" != "0" ]; then
-    gettext_printf "ACRN: Cannot access debconf acrn-hypervisor/board: %s" "${ACRN_BOARD}\n" >&2
-    exit 0
-fi
-ACRN_BOARD="$(echo "${ACRN_BOARD}" | awk '{print $2}')"
-
-ACRN_SCENARIO=$(echo "get acrn-hypervisor/scenario" | debconf-communicate || true)
-if [ "$(echo "${ACRN_SCENARIO}" | awk '{print $1}')" != "0" ]; then
-    gettext_printf "ACRN: Cannot access debconf acrn-hypervisor/:scenario %s" "${ACRN_SCENARIO}\n" >&2
-    exit 0
-fi
-ACRN_SCENARIO="$(echo "${ACRN_SCENARIO}" | awk '{print $2}')"
-
 # we obtain any data from scenario config
-ACRN_SCENARIO_FILE=/usr/lib/x86_64-linux-gnu/acrn/${ACRN_BOARD}/${ACRN_SCENARIO}/scenario.xml
+ACRN_SCENARIO_FILE=/usr/share/acrn/scenario.xml
 if [ ! -f ${ACRN_SCENARIO_FILE} ]; then
     gettext_printf "ACRN: Missing scenario config %s\n" "${ACRN_SCENARIO_FILE}" >&2
     exit 0
@@ -376,7 +361,7 @@ EOF
                 gettext_printf "Found ACRN initrd image: %s\n" "${dirname}/${initrd}" >&2
             fi
         else
-            gettext_printf "ACRN: No initrd image for ${ACRN_BOARD}:${ACRN_SCENARIO}\n" >&2
+            gettext_printf "ACRN: No initrd image found for %s\n" "${linux}" >&2
             # "UUID=" magic is parsed by initrds.  Since there's no initrd, it can't work here.
             linux_root_device_thisversion=${GRUB_DEVICE}
         fi


### PR DESCRIPTION
Calling debconf in grub script may fail when installing with dpkg as
debconf database might be occupied by dpkg, causing update-grub fail
with message below

```
debconf: DbDriver "config": /var/cache/debconf/config.dat is locked by another process: Resource temporarily unavailable
```

This patchset fixes issue above by creating a symlink to scenario file
at fixed path /usr/share/acrn/scenario.xml and let grub-acrn script
read scenario here so that debconf is no longer called.
