### PR TITLE
doc: add custom commands in acrn.doxyfile

### DIFF
--- a/doc/acrn.doxyfile
+++ b/doc/acrn.doxyfile
@@ -241,6 +241,8 @@ TAB_SIZE               = 4
 # Allow for rst directives and advanced functions e.g. grid tables
 ALIASES  = "rst=\verbatim embed:rst:leading-asterisk"
 ALIASES += "endrst=\endverbatim"
+ALIASES += consistency="\par consistency:^^"
+ALIASES += alignment="\par alignment:^^"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"


### PR DESCRIPTION
`consistency` is used to describe the consistency rule and `alignment` is used to describe the align info.

These two are used to enhance the documentation inside a struct comment block.