### PR TITLE
doc: update optional arguments for passthrough devices

### DIFF
--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -542,6 +542,10 @@ arguments:
          capability.  The specific virtual bar will be allocated.
        * ``enable_ptm``: enable PCIe precise time measurement mechanism for the
          passthrough device.
+       * ``irq=<irq_number>``: when the passthrough PCI devices support legacy interrupt,
+         e.g. UART, SDIO controller, ``irq_number`` shall be specified.
+       * ``dsdt=<dsdt_file_dir>``: when the passthrough PCI devices support legacy interrupt
+         and customized ``dsdt_file`` are needed , e.g. SPI, ``dsdt_file_dir`` shall be specified.
 
    * - ``uart``
      - Emulated PCI UART. Use the parameter with the format


### PR DESCRIPTION
This patch adds the description of newly added optional parameters for PCI device passthrough. The new parameters are related to irq and acpi dsdt info, that are designed for the passthrough of LPSS devices.

Tracked-On: #8615