### PR TITLE
dm: acpi: support CPPC V2 capability in _OSC of DSDT for ACRN guest.

### DIFF
--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -883,6 +883,7 @@ basl_fwrite_dsdt(FILE *fp, struct vmctx *ctx)
 
 	acpi_dev_write_dsdt(ctx);
 
+	osc_write_ospm_dsdt(ctx, basl_ncpu);
 	pm_write_dsdt(ctx, basl_ncpu);
 
 	dsdt_line("}");

--- a/devicemodel/include/acpi.h
+++ b/devicemodel/include/acpi.h
@@ -127,4 +127,6 @@ int acrn_parse_iasl(char *arg);
 int get_iasl_compiler(void);
 int check_iasl_version(void);
 
+void osc_write_ospm_dsdt(struct vmctx *ctx, int ncpu);
+
 #endif /* _ACPI_H_ */


### PR DESCRIPTION
After upgrading to guest kernel 6.1.80, it checks the CPPC V2 capability in _OSC of DSDT. To support it for ACRN guest, add CPPC V2 capability in _OSC of DSDT. Currently we only support CPPC V2 capability in _OSC of DSDT.

Tracked-On: #8691

Reviewed-by: Fei Li <fei1.li@intel.com>