### PR TITLE
hv: hypercall: change condition for hcall_get_cpu_pm_state

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1102,7 +1102,7 @@ int32_t hcall_get_cpu_pm_state(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm
 	int32_t ret = -1;
 	uint64_t cmd = param1;
 
-	if (is_created_vm(target_vm)) {
+	if (is_created_vm(target_vm) || is_paused_vm(target_vm)) {
 		switch (cmd & PMCMD_TYPE_MASK) {
 		case ACRN_PMCMD_GET_PX_CNT: {
 			uint8_t px_cnt;


### PR DESCRIPTION
After rebooting guest, CPPC initialization failed because _CST and _CPC missed in DSDT table. When writing _CST and _CPC in DSDT table, it gets cx_cnt or px_cnt as condition. Getting cx_cnt or px_cnt triggers the hypercall hcall_get_cpu_pm_state. The hypercall hcall_get_cpu_pm_state uses VM_CREATED as VM state's condition. While, after rebooting guest, the VM state is VM_PAUSED when writing _CST and _CPC in DSDT table. Therefore, changing VM state's condition from VM_CREATED to VM_CREATED or VM_PAUSED for hcall_get_cpu_pm_state can solve the CPPC initialization failed issue after rebooting guest.

Tracked-On: #8695

Reviewed-by: Fei Li <fei1.li@intel.com>