### PR TITLE
hv: pci: remove unused vhostbridge_ops for service vm

### DIFF
--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -64,8 +64,6 @@ struct acrn_vm_pci_dev_config *init_one_dev_config(struct pci_pdev *pdev)
 			dev_config->emu_type = PCI_DEV_TYPE_SERVICE_VM_EMUL;
 			if (is_bridge(pdev)) {
 				dev_config->vdev_ops = &vpci_bridge_ops;
-			} else if (is_host_bridge(pdev)) {
-				dev_config->vdev_ops = &vhostbridge_ops;
 			} else {
 				/* May have type0 device, E.g. debug pci uart */
 				dev_config = NULL;


### PR DESCRIPTION
Host bridge is implemented as a type 0 device and it's always passthrough to service vm.

So remove the vhostbridge_ops for service vm.

Tracked-On: #8697