### PR TITLE
hv: multiboot: fix compilation error for module test

### DIFF
--- a/hypervisor/boot/multiboot/multiboot_priv.h
+++ b/hypervisor/boot/multiboot/multiboot_priv.h
@@ -7,6 +7,8 @@
 #ifndef MULTIBOOT_PRIV_H
 #define MULTIBOOT_PRIV_H
 
+#include <multiboot_std.h>
+
 #ifdef CONFIG_MULTIBOOT2
 /*
  * @post boot_regs[1] stores the address pointer that point to a valid multiboot2 info


### PR DESCRIPTION
Fix below compilation error when building the module test for multiboot_priv.h. 
./boot/multiboot/multiboot_priv.h: In function ‘boot_from_multiboot’: 
./boot/multiboot/multiboot_priv.h:33:27: error: ‘MULTIBOOT_INFO_MAGIC’ undeclared (first use in this function)
   33 |         return ((magic == MULTIBOOT_INFO_MAGIC) && (info != 0U));

Tracked-On: #861