### PR TITLE
doc: Document requirements for pre-launched VM

### DIFF
--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -272,6 +272,10 @@ can define your own configuration scenarios.
   are automatically launched at boot time by the hypervisor.  The User VMs can
   be Real-Time VMs (RTVMs), Safety VMs, or standard User VMs.
 
+  When selecting this scenario, ensure that ``reboot=acpi`` is included in the
+  ``bootargs`` of ``scenario.xml``. Additionally, if the target VM is named VM0,
+  ``grub.cfg`` must contain a menuentry with ``module2 /boot/ACPI_VM0.bin ACPI_VM0``.
+
 * **Hybrid** scenario simultaneously supports both sharing and partitioning on
   the consolidated system. The pre-launched (partitioned) User VMs, with their
   statically configured and unshared resources, are started by the hypervisor.


### PR DESCRIPTION
Hi all,

For a pre-launched VM, it is essential to include 'reboot=acpi' in the 'bootargs' of the scenario.xml file. Additionally, if the VM is named VM0, the grub.cfg file must contain
'module2 /boot/ACPI_VM0.bin ACPI_VM0'.

Currently, several scenario files located in misc/config_tools/data already support 'reboot=acpi'. Furthermore, the postinst Debian script automatically adds the 'module2' command to grub.cfg if the scenario is 'partitioned'. Therefore, by using the provided scenarios, the pre-launched VM can be used without any additional configuration.

However, when using a custom scenario file, there is a risk of omitting the necessary parameter and command for a pre-launched VM. To avoid such errors, it is useful to document these requirements.

Hence this pull request.  
I'd appreciate it if you could review this request and merge it with the upstream.  