### PR TITLE
misc: fail to save config_summary.rst while changing board.xml

### DIFF
--- a/misc/config_tools/scenario_config/config_summary.py
+++ b/misc/config_tools/scenario_config/config_summary.py
@@ -448,7 +448,9 @@ class GenerateRst:
 
     # Close the Rst file after all information is written.
     def close_file(self):
-        self.file.close()
+        if self.file:
+            self.service_vm_used_pcpu_list.clear()
+            self.file.close()
 
 
 def main(board_xml, scenario_xml, config_summary):


### PR DESCRIPTION
This patch is to fix the bug which will report while changing board.xml.

The former coder added data into the list without removing old ones, and the file config_summary.rst won't be dropped before generating a new one.

I removed the old data when I want to close the file config_summary.rst.

I tested by change board.xml with different pcpus and make confirmation the result is correct now.

Tracked-On: #8718