### PR TITLE
misc: configurator need to support configurable reg width for UART

### DIFF
--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -47,7 +47,7 @@ static struct console_uart uart = {
 	.enabled = true,
 	.type = MMIO,
 	.mmio_base_vaddr = (void *)CONFIG_SERIAL_MMIO_BASE,
-	.reg_width = 1,
+	.reg_width = CONFIG_SERIAL_MMIO_REG_WIDTH,
 };
 #endif
 
@@ -292,7 +292,11 @@ void uart16550_set_property(bool enabled, enum serial_dev_type uart_type, uint64
 		uart.reg_width = 4;
 	} else if (uart_type == MMIO) {
 		uart.mmio_base_vaddr = (void *)data;
-		uart.reg_width = 1;
+		#if defined(CONFIG_SERIAL_MMIO_BASE)
+		    uart.reg_width = CONFIG_SERIAL_MMIO_REG_WIDTH;
+		#else
+		    uart.reg_width = 1;
+		#endif
 	}
 }
 

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config.vue
@@ -141,7 +141,8 @@ export default {
       totalMsg: "",
       showTotalMessageFlag: false,
       isSaved:false,
-      isLoaded:false
+      isLoaded:false,
+      serial_console: '',
     }
   },
   computed: {
@@ -350,9 +351,28 @@ export default {
             }
           })
     },
+    getOption(serial_cat){
+        return this.schemas.HV.BasicConfigType.definitions.DebugOptionsType.properties[serial_cat]['hidden']
+    },
+    showOption(serial_cat, show){
+        this.schemas.HV.BasicConfigType.definitions.DebugOptionsType.properties[serial_cat]["ui:hidden"]=!show
+    },
     scenarioConfigFormDataUpdate(vmid, data) {
       if (vmid === -1) {
         this.scenario.hv = data
+        this.serial_console = this.scenario.hv.DEBUG_OPTIONS.SERIAL_CONSOLE
+        let cats = this.getOption('SERIAL_MMIO_REG_WIDTH')
+        if(cats.length==0){
+            this.showOption('SERIAL_MMIO_REG_WIDTH',false)
+        }
+        for(let c of cats){
+            if(this.serial_console===c){
+                this.showOption('SERIAL_MMIO_REG_WIDTH',true)
+                break
+            }else{
+                this.showOption('SERIAL_MMIO_REG_WIDTH',false)
+            }
+        }
       } else {
         this.scenario.vm.map((vmConfig, vmIndex) => {
           if (vmConfig['@id'] === vmid) {

--- a/misc/config_tools/scenario_config/jsonschema/converter.py
+++ b/misc/config_tools/scenario_config/jsonschema/converter.py
@@ -371,6 +371,22 @@ class XS2JS:
                     else:
                         js_ele['enum'] = dynamic_enum
 
+                # dynamic serial
+                if '@acrn:hidden' in annotation:
+                    xpath, serial_cat = annotation['@acrn:hidden'].split(',')
+                    if 'dynamicSerial' in self.features:
+                        dynamic_serial = {
+                            'type': 'dynamicSerial',
+                            'function': 'get_serial',
+                            'source': 'board_xml',
+                            'selector': xpath.strip(),
+                            'serial_cat': serial_cat.strip(),
+                        }
+                        if 'items' in js_ele:
+                            js_ele['items']['hidden'] = dynamic_serial
+                        else:
+                            js_ele['hidden'] = dynamic_serial
+
                 # widget and its options
                 self.convert_widget_config(annotation, js_ele)
 
@@ -424,6 +440,7 @@ def main():
     features = []
     if not stand_json_schema:
         features.append('dynamicEnum')
+        features.append('dynamicSerial')
     json_schema = XS2JS(schema_file, features).get_json_schema()
     json_schema = json.dumps(json_schema, indent='\t')
 

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -19,6 +19,13 @@
         <xs:documentation>Select the host serial device used for hypervisor debugging.</xs:documentation>
       </xs:annotation>
     </xs:element>
+    <xs:element name="SERIAL_MMIO_REG_WIDTH" type="RegWidthType" default="1" minOccurs="0">
+      <xs:annotation acrn:title="Default register width for serial MMIO"
+                     acrn:views="basic"
+                     acrn:hidden="//TTYS_INFO/text(),mmio">
+        <xs:documentation>Select the default register width for serial MMIO. Value can be changed at runtime.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
     <xs:element name="MEM_LOGLEVEL" type="LogLevelType" default="5">
       <xs:annotation acrn:title="ACRN log level" acrn:views="basic">
         <xs:documentation>Select the default log level for log messages stored in memory. Value can be changed at runtime. Log messages with the selected value or lower are displayed.</xs:documentation>

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -118,6 +118,20 @@ higher value (lower severity) are discarded.</xs:documentation>
   </xs:restriction>
 </xs:simpleType>
 
+<xs:simpleType name="RegWidthType">
+  <xs:annotation>
+    <xs:documentation>Register width should be 1 or 4.</xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="1">
+      <xs:annotation acrn:title="1" />
+    </xs:enumeration>
+    <xs:enumeration value="4">
+      <xs:annotation acrn:title="4" />
+    </xs:enumeration>
+  </xs:restriction>
+</xs:simpleType>
+
 <xs:simpleType name="SchedulerType">
   <xs:annotation>
     <xs:documentation>A string specifying the scheduling option:

--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -211,6 +211,7 @@
 
   <xsl:template match="SERIAL_CONSOLE">
     <xsl:variable name="tokens" select="concat(substring-before(substring-after(/acrn-offline-data/board-data/acrn-config/TTYS_INFO, concat('seri:', current())), '&#xa;'), ' ')" />
+    <xsl:variable name="mmio_reg_width" select="//config-data/acrn-config/hv/DEBUG_OPTIONS/SERIAL_MMIO_REG_WIDTH" />
     <xsl:variable name="type" select="substring-before(substring-after($tokens, 'type:'), ' ')" />
     <xsl:variable name="base" select="substring-before(substring-after($tokens, 'base:'), ' ')" />
     <xsl:variable name="irq" select="substring-before(substring-after($tokens, 'irq:'), ' ')" />
@@ -262,6 +263,10 @@
 	    <xsl:with-param name="value" select="$base" />
 	  </xsl:call-template>
 	</xsl:if>
+    <xsl:call-template name="integer-by-key-value">
+	  <xsl:with-param name="key" select="'SERIAL_MMIO_REG_WIDTH'" />
+	  <xsl:with-param name="value" select="$mmio_reg_width" />
+	</xsl:call-template>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>


### PR DESCRIPTION
We found sometime we need to configure reg width for mmio and we change the width by hand for workaround, now we can configure the width by configurator.

I defined a macro named CONFIG_SERIAL_MMIO_REG_WIDTH in uart16550.c, collected mmio ports, loaded them and made a judgement whether the current serial_console was a mmio serial, it will show an option for mmio and hide for other serial ports.

I tested three sorts of serials: portio, pci and mmio, built acrn and checked the content generated in build/hypervisor/include/config.h, I confirmed the results are correct.

Tracked-On: #8721