### PR TITLE
hv: handle reboot from Service VM properly

### DIFF
--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -1531,7 +1531,7 @@ static int32_t shell_cpuid(int32_t argc, char **argv)
 
 static int32_t shell_reboot(__unused int32_t argc, __unused char **argv)
 {
-	reset_host();
+	reset_host(false);
 	return 0;
 }
 

--- a/hypervisor/include/arch/x86/asm/host_pm.h
+++ b/hypervisor/include/arch/x86/asm/host_pm.h
@@ -12,6 +12,9 @@
 #define	BIT_SLP_EN	13U
 #define	BIT_WAK_STS	15U
 
+#define CF9_RESET_WARM	0x6
+#define CF9_RESET_COLD	0xE
+
 struct cpu_state_info {
 	uint8_t			 	px_cnt;	/* count of all Px states */
 	const struct acrn_pstate_data	*px_data;
@@ -38,7 +41,7 @@ extern void asm_enter_s3(const struct pm_s_state_data *sstate_data, uint32_t pm1
 extern void restore_s3_context(void);
 struct cpu_state_info *get_cpu_pm_state_info(void);
 struct acpi_reset_reg *get_host_reset_reg_data(void);
-void reset_host(void);
+void reset_host(bool warm);
 void init_frequency_policy(void);
 void apply_frequency_policy(void);
 


### PR DESCRIPTION
Service VM may write 0x6 to port 0xcf9 to trigger a warm reset, but current hypervisor always performs a cold reset by writing 0xE to CF9. Hypervisor should reboot the system in the same mode as Service VM specified. Specific OS features (like linux pstore) requires warm reset to keep data across reboot.

The behavior of hv console's reboot command (cold reset) remains unchanged.

Tracked-On: #8539

Reviewed-by: Junjie Mao <junjie.mao@intel.com>