### PR TITLE
hv: vm_reset: simulate RESET_CONTROL(0xCF9) register

### DIFF
--- a/hypervisor/include/arch/x86/asm/guest/vm.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm.h
@@ -181,6 +181,7 @@ struct acrn_vm {
 	struct acrn_vrtc vrtc;
 
 	uint64_t intr_inject_delay_delta; /* delay of intr injection */
+	uint32_t reset_control;
 } __aligned(PAGE_SIZE);
 
 /*


### PR DESCRIPTION
    hv: vm_reset: simulate RESET_CONTROL(0xCF9) register

    Add reset_control in acrn_vm. Use this reset_control to simulate
    RESET_CONTROL(0xCF9) register in hypervisor.

    Tracked-On: #8724
    Reviewed-by: Fei Li <fei1.li@intel.com>
