### PR TITLE
misc: fix two IOAPIC related configs

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -216,7 +216,7 @@ If your VM is not a security VM, leave this option unchecked. </xs:documentation
         <xs:documentation>Maximum number of User VMs allowed.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MAX_IOAPIC_NUM" default="1">
+    <xs:element name="MAX_IOAPIC_NUM" minOccurs="0">
       <xs:annotation acrn:views="">
         <xs:documentation>Maximum number of IOAPICs.</xs:documentation>
       </xs:annotation>
@@ -250,7 +250,7 @@ If your VM is not a security VM, leave this option unchecked. </xs:documentation
         </xs:restriction>
       </xs:simpleType>
     </xs:element>
-    <xs:element name="MAX_IOAPIC_LINES" default="120">
+    <xs:element name="MAX_IOAPIC_LINES" minOccurs="0">
       <xs:annotation acrn:views="">
         <xs:documentation>Maximum number of interrupt lines per IOAPIC.</xs:documentation>
       </xs:annotation>

--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -18,12 +18,12 @@
     <xsl:call-template name="integer-by-key-value">
       <xsl:with-param name="key" select="'MAX_IOAPIC_NUM'" />
       <xsl:with-param name="value" select="//config-data//MAX_IOAPIC_NUM/text()" />
-      <xsl:with-param name="default" select="count(.//ioapic)" />
+      <xsl:with-param name="default" select="acrn:max(1, count(.//ioapic))" />
     </xsl:call-template>
     <xsl:call-template name="integer-by-key-value">
       <xsl:with-param name="key" select="'MAX_IOAPIC_LINES'" />
       <xsl:with-param name="value" select="//config-data//MAX_IOAPIC_LINES/text()" />
-      <xsl:with-param name="default" select="math:max(.//ioapic/gsi_number/text() | exslt:node-set(0))" />
+      <xsl:with-param name="default" select="math:max(.//ioapic/gsi_number/text() | exslt:node-set(48))" />
     </xsl:call-template>
     <xsl:call-template name="msi-msix-max" />
   </xsl:template>


### PR DESCRIPTION
For Service VM, the I/O APIC number and RTE number are from platform. Otherwise, hypervisor emulates one I/O APIC and 48 RTEs. But 'MAX_IOAPIC_NUM' is always 1 and 'MAX_IOAPIC_LINES' is always 120 for now.

This patch is introduced to fix these issues.

Tracked-On: #8725
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Suggested-by: Junjie Mao <junjie.mao@intel.com>