### PR TITLE
hv: release: fix the compilation error

### DIFF
--- a/hypervisor/release/uart16550.c
+++ b/hypervisor/release/uart16550.c
@@ -11,6 +11,6 @@ void uart16550_init(__unused bool early_boot) {}
 
 bool is_pci_dbg_uart(__unused union pci_bdf bdf_value) { return false; }
 
-bool get_pio_dbg_uart_cfg(__unused uint64_t *pio_address, __unused uint64_t *nbytes) {
+bool get_pio_dbg_uart_cfg(__unused uint16_t *pio_address, __unused uint32_t *nbytes) {
 	return false;
 }


### PR DESCRIPTION
This patch fixes the following compilation error when including `release/uart16550.c` into the module test.

./release/uart16550.c:14:6: error: conflicting types for ‘get_pio_dbg_uart_cfg’; have ‘bool(uint64_t *, uint64_t *)’ {aka ‘_Bool(long unsigned int *, long unsigned int *)’}
   14 | bool get_pio_dbg_uart_cfg(__unused uint64_t *pio_address, __unused uint64_t *nbytes) {
      |      ^~~~~~~~~~~~~~~~~~~~

./include/debug/uart16550.h:142:6: note: previous declaration of ‘get_pio_dbg_uart_cfg’ with type ‘bool(uint16_t *, uint32_t *)’ {aka ‘_Bool(short unsigned int *, unsigned int *)’}
  142 | bool get_pio_dbg_uart_cfg(uint16_t *pio_address, uint32_t *nbytes);
      |      ^~~~~~~~~~~~~~~~~~~~

Tracked-On: #861