### PR TITLE
Fix e820_alloc_memory() may overlap hypervisor memory

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -503,7 +503,7 @@ void cpu_dead(void)
 		vmx_off();
 
 		stac();
-		flush_cache_range((void *)get_hv_image_base(), get_hv_ram_size());
+		flush_cache_range((void *)get_hv_image_base(), get_hv_image_size());
 		clac();
 
 		/* Set state to show CPU is dead */

--- a/hypervisor/arch/x86/guest/optee.c
+++ b/hypervisor/arch/x86/guest/optee.c
@@ -45,7 +45,7 @@ void prepare_tee_vm_memmap(struct acrn_vm *vm, const struct acrn_vm_config *vm_c
 		prepare_vm_identical_memmap(vm, E820_TYPE_RAM, EPT_WB | EPT_RWX);
 
 		hv_hpa = hva2hpa((void *)(get_hv_image_base()));
-		ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, hv_hpa, get_hv_ram_size());
+		ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, hv_hpa, get_hv_image_size());
 	}
 }
 

--- a/hypervisor/arch/x86/guest/ve820.c
+++ b/hypervisor/arch/x86/guest/ve820.c
@@ -138,8 +138,6 @@ void create_service_vm_e820(struct acrn_vm *vm)
 {
 	uint16_t vm_id;
 	uint32_t i;
-	uint64_t hv_start_pa = hva2hpa((void *)(get_hv_image_base()));
-	uint64_t hv_end_pa  = hv_start_pa + get_hv_image_size();
 	uint32_t entries_count = get_e820_entries_count();
 	struct acrn_vm_config *service_vm_config = get_vm_config(vm->vm_id);
 
@@ -148,8 +146,6 @@ void create_service_vm_e820(struct acrn_vm *vm)
 
 	vm->e820_entry_num = entries_count;
 	vm->e820_entries = service_vm_e820;
-	/* filter out hv memory from e820 table */
-	filter_mem_from_service_vm_e820(vm, hv_start_pa, hv_end_pa);
 
 	/* filter out prelaunched vm memory from e820 table */
 	for (vm_id = 0U; vm_id < CONFIG_MAX_VM_NUM; vm_id++) {

--- a/hypervisor/arch/x86/guest/ve820.c
+++ b/hypervisor/arch/x86/guest/ve820.c
@@ -139,7 +139,7 @@ void create_service_vm_e820(struct acrn_vm *vm)
 	uint16_t vm_id;
 	uint32_t i;
 	uint64_t hv_start_pa = hva2hpa((void *)(get_hv_image_base()));
-	uint64_t hv_end_pa  = hv_start_pa + get_hv_ram_size();
+	uint64_t hv_end_pa  = hv_start_pa + get_hv_image_size();
 	uint32_t entries_count = get_e820_entries_count();
 	struct acrn_vm_config *service_vm_config = get_vm_config(vm->vm_id);
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -528,7 +528,7 @@ static void prepare_service_vm_memmap(struct acrn_vm *vm)
 	 * will cause EPT violation if Service VM accesses hv memory
 	 */
 	hv_hpa = hva2hpa((void *)(get_hv_image_base()));
-	ept_del_mr(vm, pml4_page, hv_hpa, get_hv_ram_size());
+	ept_del_mr(vm, pml4_page, hv_hpa, get_hv_image_size());
 	/* unmap prelaunch VM memory */
 	for (vm_id = 0U; vm_id < CONFIG_MAX_VM_NUM; vm_id++) {
 		vm_config = get_vm_config(vm_id);

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -39,7 +39,6 @@
 #include <logmsg.h>
 #include <misc_cfg.h>
 
-static uint64_t hv_ram_size;
 static void *ppt_mmu_pml4_addr;
 /**
  * @brief The sanitized page
@@ -145,11 +144,6 @@ void invept(const void *eptp)
 	} else {
 		/* Neither type of INVEPT is supported. Skip. */
 	}
-}
-
-uint64_t get_hv_ram_size(void)
-{
-	return hv_ram_size;
 }
 
 void enable_paging(void)
@@ -265,7 +259,6 @@ void init_paging(void)
 	const struct abi_mmap *p_mmap = abi->mmap_entry;
 
 	pr_dbg("HV MMU Initialization");
-	hv_ram_size = (uint64_t)(&ld_ram_end - &ld_ram_start);
 
 	init_sanitized_page((uint64_t *)sanitized_page, hva2hpa_early(sanitized_page));
 
@@ -314,7 +307,7 @@ void init_paging(void)
 	 */
 	hv_hva = get_hv_image_base();
 	pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr, hv_hva & PDE_MASK,
-			hv_ram_size + (((hv_hva & (PDE_SIZE - 1UL)) != 0UL) ? PDE_SIZE : 0UL),
+			get_hv_image_size() + (((hv_hva & (PDE_SIZE - 1UL)) != 0UL) ? PDE_SIZE : 0UL),
 			PAGE_CACHE_WB, PAGE_CACHE_MASK | PAGE_USER, &ppt_pgtable, MR_MODIFY);
 
 	/*

--- a/hypervisor/boot/include/reloc.h
+++ b/hypervisor/boot/include/reloc.h
@@ -9,6 +9,7 @@
 extern void relocate(void);
 extern uint64_t get_hv_image_delta(void);
 extern uint64_t get_hv_image_base(void);
+extern uint64_t get_hv_image_size(void);
 
 /* external symbols that are helpful for relocation */
 extern uint8_t		_DYNAMIC[1];

--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -55,6 +55,11 @@ uint64_t get_hv_image_base(void)
 	return (get_hv_image_delta() + CONFIG_HV_RAM_START);
 }
 
+inline uint64_t get_hv_image_size(void)
+{
+	return (uint64_t)(&ld_ram_end - &ld_ram_start);
+}
+
 void relocate(void)
 {
 #ifdef CONFIG_RELOC

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -764,7 +764,7 @@ static int32_t write_protect_page(struct acrn_vm *vm,const struct wp_data *wp)
 				base_paddr = hva2hpa((void *)(get_hv_image_base()));
 				if (((hpa <= base_paddr) && ((hpa + PAGE_SIZE) > base_paddr)) ||
 						((hpa >= base_paddr) &&
-						 (hpa < (base_paddr + get_hv_ram_size())))) {
+						 (hpa < (base_paddr + get_hv_image_size())))) {
 					pr_err("%s: overlap the HV memory region.", __func__);
 				} else {
 					prot_set = (wp->set != 0U) ? 0UL : EPT_WR;

--- a/hypervisor/include/arch/x86/asm/mmu.h
+++ b/hypervisor/include/arch/x86/asm/mmu.h
@@ -169,8 +169,6 @@ void flush_vpid_global(void);
  */
 void invept(const void *eptp);
 
-uint64_t get_hv_ram_size(void);
-
 /* get PDPT address from CR3 vaule in PAE mode */
 static inline uint64_t get_pae_pdpt_addr(uint64_t cr3)
 {


### PR DESCRIPTION
e820_alloc_memory() finds a usable area in hypervisor e820 table, but
currently hypervisor memory range is also marked as usable. Mark it as
unusable to avoid corrupting hypervisor.