### PR TITLE
hv: instr_emul: Correct handling of instruction length

### DIFF
--- a/hypervisor/include/arch/x86/asm/guest/instr_emul.h
+++ b/hypervisor/include/arch/x86/asm/guest/instr_emul.h
@@ -46,6 +46,9 @@ struct instr_emul_vie {
 	uint8_t		num_valid;		/* size of the instruction */
 	uint8_t		num_processed;
 
+	struct acrn_vcpu 	*vcpu;
+	uint64_t		rip;
+
 	uint8_t		addrsize:4, opsize:4;	/* address and operand sizes */
 	uint8_t		rex_w:1,		/* REX prefix */
 			rex_r:1,


### PR DESCRIPTION
The VM-exit instruction length(VMX_EXIT_INSTR_LEN) in VMCS is undefined on EPT violation, except during delivery of a software interrupt, privileged software exception, or software exception[1]. Although CPU is likely to set the field, it can be incorrect in certain cases, such as cmp+jcc and test+jcc.

Since hypervisor does not know exactly how much bytes needed, and GVA translation is costly, it first copies at most 15 (VIE_INST_SIZE) bytes within the page, then decodes the instruction. If more bytes are needed during decoding and copied length is less than 15, it copies remaining bytes.

[1] 29.2.5, https://cdrdv2-public.intel.com/671200/325462-sdm-vol-1-2abcd-3abcd.pdf

Tracked-On: #8756