### PR TITLE
hv: hyperv: Add hyperv page destory function

### DIFF
--- a/hypervisor/arch/x86/guest/hyperv.c
+++ b/hypervisor/arch/x86/guest/hyperv.c
@@ -309,3 +309,14 @@ hyperv_init_vcpuid_entry(uint32_t leaf, uint32_t subleaf, uint32_t flags,
 	dev_dbg(DBG_LEVEL_HYPERV, "hv: %s: leaf=%x subleaf=%x flags=%x eax=%x ebx=%x ecx=%x edx=%x",
 		__func__, leaf, subleaf, flags, entry->eax, entry->ebx, entry->ecx, entry->edx);
 }
+
+void
+hyperv_page_destory(struct acrn_vm *vm)
+{
+	/* Reset the hypercall page */
+	vm->arch_vm.hyperv.hypercall_page.enabled = 0U;
+	/* Reset OS id */
+	vm->arch_vm.hyperv.guest_os_id.val64 = 0UL;
+	/* Reset the TSC page */
+	vm->arch_vm.hyperv.ref_tsc_page.enabled = 0UL;
+}

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -957,6 +957,10 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 		offline_vcpu(vcpu);
 	}
 
+#ifdef CONFIG_HYPERV_ENABLED
+	hyperv_page_destory(vm);
+#endif
+
 	/* after guest_flags not used, then clear it */
 	vm_config = get_vm_config(vm->vm_id);
 	vm_config->guest_flags &= ~DM_OWNED_GUEST_FLAG_MASK;

--- a/hypervisor/include/arch/x86/asm/guest/hyperv.h
+++ b/hypervisor/include/arch/x86/asm/guest/hyperv.h
@@ -64,4 +64,5 @@ int32_t hyperv_rdmsr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t *rval);
 void hyperv_init_time(struct acrn_vm *vm);
 void hyperv_init_vcpuid_entry(uint32_t leaf, uint32_t subleaf, uint32_t flags,
 	struct vcpuid_entry *entry);
+void hyperv_page_destory(struct acrn_vm *vm);
 #endif


### PR DESCRIPTION
In current code process, hyperv data in struct vm_arch is never cleared during VM shutdown and is retained to next VM launch. As the enabled bit of hypercall_page msr is not clear, hypercall page might cause fatal error such as Windows VM BSOD during VM restart and memory remapping. Hyperv page destory function can ensure hyperv page is destory during each VM shutdown so hyperv related config such as hypercall page is established correctly during each VM launch.

Tracked-On: #8755