### PR TITLE
dm: Fix concurrent acrn-dm hugetlb init race

### DIFF
--- a/devicemodel/core/hugetlb.c
+++ b/devicemodel/core/hugetlb.c
@@ -555,8 +555,13 @@ bool init_hugetlb(void)
 			path[i] = 0;
 			if (access(path, F_OK) != 0) {
 				if (mkdir(path, 0755) < 0) {
-					pr_err("mkdir %s failed.\n", path);
-					return -1;
+					/* We might have multiple acrn-dm instances booting VMs at
+					 * the same time
+					 */
+					if (errno != EEXIST) {
+						pr_err("mkdir %s failed: %s\n", path, errormsg(errno));
+						return false;
+					}
 				}
 			}
 			path[i] = '/';


### PR DESCRIPTION
During init of hugetlb we check and create /run/hugepage/acrn folder. Concurrent acrn-dm instances might race between the time of check and create.

This commit ignore EEXIST error when creating directory.

Tracked-On: #125284