### PR TITLE
misc: upgrade dependency for acrn-configurator

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src-tauri/Cargo.lock
+++ b/misc/config_tools/configurator/packages/configurator/src-tauri/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "acrn-configurator"
 version = "0.1.0"
 dependencies = [
+ "crossbeam-channel",
  "dirs",
  "glob",
  "idna",
@@ -613,22 +614,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"

--- a/misc/config_tools/configurator/packages/configurator/src-tauri/Cargo.toml
+++ b/misc/config_tools/configurator/packages/configurator/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ openssl = "0.10.72" # fix vulnerability only
 idna = "=1.0.0"     # fix vulnerability only
 url = "=2.5.1"      # fix vulnerability only
 tokio = "=1.43.1"   # fix vulnerability only
+crossbeam-channel = "=0.5.15"   # fix vulnerability only
 serde_json = "1.0.81"
 serde = { version = "1.0.137", features = ["derive"] }
 tauri = { version = "1.6.7", features = ["api-all", "devtools"] }


### PR DESCRIPTION
upgrade crossbeam-channel to 0.5.15 which is used by tauri's component `tao`

Tracked-On: #8769