### PR TITLE
hv: ipi/smpcall: add multi-arch framework and RISC-V support

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -163,6 +163,7 @@ COMMON_C_SRCS += common/hv_main.c
 COMMON_C_SRCS += common/vm_load.c
 COMMON_C_SRCS += common/hypercall.c
 COMMON_C_SRCS += common/ptdev.c
+COMMON_C_SRCS += common/notify.c
 COMMON_C_SRCS += dm/vrtc.c
 COMMON_C_SRCS += dm/vuart.c
 COMMON_C_SRCS += dm/io_req.c

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -148,6 +148,8 @@ endif
 # if block. The block should be entirely eliminated when we've done
 # all the work.
 #
+COMMON_C_SRCS += common/notify.c
+
 ifeq ($(ARCH),x86)
 COMMON_C_SRCS += common/ticks.c
 COMMON_C_SRCS += common/delay.c
@@ -163,7 +165,6 @@ COMMON_C_SRCS += common/hv_main.c
 COMMON_C_SRCS += common/vm_load.c
 COMMON_C_SRCS += common/hypercall.c
 COMMON_C_SRCS += common/ptdev.c
-COMMON_C_SRCS += common/notify.c
 COMMON_C_SRCS += dm/vrtc.c
 COMMON_C_SRCS += dm/vuart.c
 COMMON_C_SRCS += dm/io_req.c

--- a/hypervisor/arch/riscv/Makefile
+++ b/hypervisor/arch/riscv/Makefile
@@ -29,6 +29,7 @@ HOST_S_SRCS += arch/riscv/dummy_entry.S
 
 # HV host C sources
 HOST_C_SRCS += arch/riscv/dummy.c
+HOST_C_SRCS += arch/riscv/sbi.c
 
 # Virtual platform assembly sources
 VP_S_SRCS +=

--- a/hypervisor/arch/riscv/Makefile
+++ b/hypervisor/arch/riscv/Makefile
@@ -30,6 +30,7 @@ HOST_S_SRCS += arch/riscv/dummy_entry.S
 # HV host C sources
 HOST_C_SRCS += arch/riscv/dummy.c
 HOST_C_SRCS += arch/riscv/sbi.c
+HOST_C_SRCS += arch/riscv/notify.c
 
 # Virtual platform assembly sources
 VP_S_SRCS +=

--- a/hypervisor/arch/riscv/notify.c
+++ b/hypervisor/arch/riscv/notify.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023-2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+#include <types.h>
+#include <asm/irq.h>
+#include <asm/sbi.h>
+
+void arch_init_smp_call(void)
+{
+	/* No special handling is required at present; this can be extended in the future if needed. */
+}
+
+void arch_smp_call_kick_pcpu(uint16_t pcpu_id)
+{
+	arch_send_single_ipi(pcpu_id, IPI_NOTIFY_CPU);
+}

--- a/hypervisor/arch/riscv/sbi.c
+++ b/hypervisor/arch/riscv/sbi.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+#include <types.h>
+#include <asm/sbi.h>
+
+/**
+ * An ECALL is used as the control transfer instruction between the
+ * supervisor and the SEE.
+ *
+ * a7 encodes the SBI extension ID (EID).
+ *
+ * a6 encodes the SBI function ID (FID) for a given extension ID
+ * encoded in a7 for any SBI extension defined in or after SBI v0.2.
+ *
+ * a0 through a5 contain the arguments for the SBI function call.
+ * Registers that are not defined in the SBI function call are not
+ * reserved.
+ *
+ * All registers except a0 & a1 must be preserved across an SBI call
+ * by the callee.
+ *
+ * SBI functions must return a pair of values in a0 and a1, with a0
+ * returning an error code. This is analogous to returning the C
+ * structure.
+ */
+static sbiret sbi_ecall(uint64_t arg0, uint64_t arg1, uint64_t arg2,
+				uint64_t arg3, uint64_t arg4, uint64_t arg5,
+				uint64_t func, uint64_t ext)
+{
+	sbiret ret;
+
+	register uint64_t a0 asm ("a0") = arg0;
+	register uint64_t a1 asm ("a1") = arg1;
+	register uint64_t a2 asm ("a2") = arg2;
+	register uint64_t a3 asm ("a3") = arg3;
+	register uint64_t a4 asm ("a4") = arg4;
+	register uint64_t a5 asm ("a5") = arg5;
+	register uint64_t a6 asm ("a6") = func;
+	register uint64_t a7 asm ("a7") = ext;
+
+	asm volatile (
+		"ecall \n\t"
+		:"+r" (a0), "+r" (a1)
+		:"r" (a2), "r" (a3), "r" (a4), "r" (a5), "r" (a6), "r" (a7)
+		: "memory"
+	);
+
+	ret.error = a0;
+	ret.value = a1;
+
+	return ret;
+}

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -38,6 +38,7 @@
 #include <ticks.h>
 #include <delay.h>
 #include <thermal.h>
+#include <common/notify.h>
 
 #define CPU_UP_TIMEOUT		100U /* millisecond */
 #define CPU_DOWN_TIMEOUT	100U /* millisecond */
@@ -270,8 +271,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 
 		timer_init();
 		thermal_init();
-		setup_notification();
-		setup_pi_notification();
+		init_smp_call();
 
 		if (init_iommu() != 0) {
 			panic("failed to initialize iommu!");

--- a/hypervisor/arch/x86/guest/optee.c
+++ b/hypervisor/arch/x86/guest/optee.c
@@ -93,7 +93,7 @@ static int32_t tee_switch_to_ree(struct acrn_vcpu *vcpu)
 			 * after VM Entry and will go through the secure interrupt handling
 			 * flow in handle_x86_tee_int.
 			 */
-			send_single_ipi(pcpuid_from_vcpu(ree_vcpu), 
+			arch_send_single_ipi(pcpuid_from_vcpu(ree_vcpu),
 				(uint32_t)(vcpu->arch.pid.control.bits.nv));
 		} else if (prio(pending_intr) == prio(TEE_FIXED_NONSECURE_VECTOR)) {
 			/* The TEE_FIXED_NONSECURE_VECTOR needs to be cleared as the

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -550,7 +550,7 @@ static void vlapic_accept_intr(struct acrn_vlapic *vlapic, uint32_t vector, bool
  */
 static void apicv_trigger_pi_anv(uint16_t dest_pcpu_id, uint32_t anv)
 {
-	send_single_ipi(dest_pcpu_id, anv);
+	arch_send_single_ipi(dest_pcpu_id, anv);
 }
 
 /**

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -240,14 +240,14 @@ send_startup_ipi(uint16_t dest_pcpu_id, uint64_t cpu_startup_start_address)
 	msr_write(MSR_IA32_EXT_APIC_ICR, icr.value);
 }
 
-void send_dest_ipi_mask(uint32_t dest_mask, uint32_t vector)
+void send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector)
 {
 	uint16_t pcpu_id;
-	uint32_t mask = dest_mask;
+	uint64_t mask = dest_mask;
 
 	pcpu_id = ffs64(mask);
 	while (pcpu_id < MAX_PCPU_NUM) {
-		bitmap32_clear_nolock(pcpu_id, &mask);
+		bitmap_clear_nolock(pcpu_id, &mask);
 		send_single_ipi(pcpu_id, vector);
 		pcpu_id = ffs64(mask);
 	}

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -240,7 +240,7 @@ send_startup_ipi(uint16_t dest_pcpu_id, uint64_t cpu_startup_start_address)
 	msr_write(MSR_IA32_EXT_APIC_ICR, icr.value);
 }
 
-void send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector)
+void arch_send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector)
 {
 	uint16_t pcpu_id;
 	uint64_t mask = dest_mask;
@@ -248,12 +248,12 @@ void send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector)
 	pcpu_id = ffs64(mask);
 	while (pcpu_id < MAX_PCPU_NUM) {
 		bitmap_clear_nolock(pcpu_id, &mask);
-		send_single_ipi(pcpu_id, vector);
+		arch_send_single_ipi(pcpu_id, vector);
 		pcpu_id = ffs64(mask);
 	}
 }
 
-void send_single_ipi(uint16_t pcpu_id, uint32_t vector)
+void arch_send_single_ipi(uint16_t pcpu_id, uint32_t vector)
 {
 	union apic_icr icr;
 
@@ -299,6 +299,6 @@ void kick_pcpu(uint16_t pcpu_id)
 	if (per_cpu(mode_to_kick_pcpu, pcpu_id) == DEL_MODE_INIT) {
 		send_single_init(pcpu_id);
 	} else {
-		send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);
+		arch_send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);
 	}
 }

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -66,7 +66,7 @@ void smp_call_function(uint64_t mask, smp_call_func_t func, void *data)
 			if ((vcpu != NULL) && (is_lapic_pt_enabled(vcpu))) {
 				vcpu_make_request(vcpu, ACRN_REQUEST_SMP_CALL);
 			} else {
-				send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);
+				arch_send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);
 			}
 		} else {
 			/* pcpu is not in active, print error */

--- a/hypervisor/common/notify.c
+++ b/hypervisor/common/notify.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <asm/cpu.h>
+#include <asm/lib/atomic.h>
+#include <asm/lib/bits.h>
+#include <asm/per_cpu.h>
+#include <asm/notify.h>
+#include <common/notify.h>
+
+static volatile uint64_t smp_call_mask = 0UL;
+
+/**
+ * Run in interrupt context.
+ *
+ * Two use cases are covered:
+ *  - SMP call: when the corresponding bit in smp_call_mask is set and
+ *              smp_call_info in the per-CPU region is specified.
+ *              The registered callback will be invoked.
+ *
+ *  - Kick pCPU out of non-root mode: when the corresponding bit in smp_call_mask is clear and
+ *                                    smp_call_info in the per-CPU region is not specified.
+ *                                    No callback is invoked.
+ */
+void kick_notification(__unused uint32_t irq, __unused void *data)
+{
+	uint16_t pcpu_id = get_pcpu_id();
+
+	if (bitmap_test(pcpu_id, &smp_call_mask)) {
+		struct smp_call_info_data *smp_call = &per_cpu(smp_call_info, pcpu_id);
+
+		if (smp_call->func != NULL) {
+			smp_call->func(smp_call->data);
+		}
+		bitmap_clear_lock(pcpu_id, &smp_call_mask);
+	}
+}
+
+/**
+ * Execute the SMP call notification handler
+ */
+void handle_smp_call(void)
+{
+	kick_notification(0U, NULL);
+}
+
+/**
+ * Trigger the SMP call request to target pCPUs
+ */
+void smp_call_function(uint64_t mask, smp_call_func_t func, void *data)
+{
+	uint16_t pcpu_id;
+	struct smp_call_info_data *smp_call;
+
+	/* wait for previous smp call complete, which may run on other cpus */
+	while (atomic_cmpxchg64(&smp_call_mask, 0UL, mask) != 0UL);
+
+	pcpu_id = ffs64(mask);
+	while (pcpu_id < MAX_PCPU_NUM) {
+		bitmap_clear_nolock(pcpu_id, &mask);
+		if (pcpu_id == get_pcpu_id()) {
+			func(data);
+			bitmap_clear_nolock(pcpu_id, &smp_call_mask);
+		} else if (is_pcpu_active(pcpu_id)) {
+			smp_call = &per_cpu(smp_call_info, pcpu_id);
+
+			smp_call->func = func;
+			smp_call->data = data;
+
+			/**
+			 * arch_smp_call_kick_pcpu() is abstracted because:
+			 *  - On x86, special handling is required when LAPIC is passthrough.
+			 *  - On RISC-V, a plain IPI is sufficient to kick the target pCPU.
+			 */
+			arch_smp_call_kick_pcpu(pcpu_id);
+		} else {
+			/* pcpu is not in active, print error */
+			pr_err("pcpu_id %d not in active!", pcpu_id);
+			bitmap_clear_nolock(pcpu_id, &smp_call_mask);
+		}
+		pcpu_id = ffs64(mask);
+	}
+	/* wait for current smp call complete */
+	wait_sync_change(&smp_call_mask, 0UL);
+}
+
+/**
+ * Initialize the SMP call support during pCPU initialization
+ */
+void init_smp_call(void)
+{
+	/**
+	 * arch_init_smp_call() is abstracted because:
+	 *  - On x86, during CPU initialization, software reserves dedicated vectors and registers callback handlers
+	 *    for purposes such as notifications or posted interrupts.
+	 *  - On RISC-V, no special handling is required at present; this can be extended in the future if needed.
+	 */
+	arch_init_smp_call();
+}

--- a/hypervisor/include/arch/riscv/asm/cpu.h
+++ b/hypervisor/include/arch/riscv/asm/cpu.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef RISCV_CPU_H
+#define RISCV_CPU_H
+
+#include <types.h>
+
+static inline void wait_sync_change(__unused volatile const uint64_t *sync, __unused uint64_t wake_sync)
+{
+	/**
+	 * Dummy implementation.
+	 * Official implementations are to be provided in the platform initialization patchset (by Hang).
+	 */
+}
+
+static inline bool is_pcpu_active(__unused uint16_t pcpu_id)
+{
+	/**
+	 * Dummy implementation.
+	 * Official implementations are to be provided in the platform initialization patchset (by Hang).
+	 */
+	return true;
+}
+
+static inline uint16_t get_pcpu_id(void)
+{
+	/**
+	 * Dummy implementation.
+	 * Official implementations are to be provided in the platform initialization patchset (by Hang).
+	 */
+	return 0U;
+}
+
+#endif /* RISCV_CPU_H */

--- a/hypervisor/include/arch/riscv/asm/irq.h
+++ b/hypervisor/include/arch/riscv/asm/irq.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2023-2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+#ifndef RISCV_IRQ_H
+#define RISCV_IRQ_H
+
+#define IPI_NOTIFY_CPU		0
+
+#endif /* RISCV_IRQ_H */

--- a/hypervisor/include/arch/riscv/asm/lib/atomic.h
+++ b/hypervisor/include/arch/riscv/asm/lib/atomic.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef RISCV_ATOMIC_H
+#define RISCV_ATOMIC_H
+
+#include <types.h>
+
+static inline uint64_t atomic_cmpxchg64(__unused volatile uint64_t *ptr, __unused uint64_t old, __unused uint64_t new)
+{
+	/**
+	 * Dummy implementation.
+	 * Official implementations are to be provided in the library patchset (by Haoyu).
+	 */
+	return 0UL;
+}
+
+#endif /* RISCV_ATOMIC_H */

--- a/hypervisor/include/arch/riscv/asm/lib/bits.h
+++ b/hypervisor/include/arch/riscv/asm/lib/bits.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef RISCV_BITS_H
+#define RISCV_BITS_H
+
+#include <types.h>
+
+uint16_t ffs64(__unused uint64_t value)
+{
+	/**
+	 * Dummy implementation.
+	 * Official implementations are to be provided in the library patchset (by Haoyu).
+	 */
+	return 0U;
+}
+
+bool bitmap_test(__unused uint16_t nr, __unused const volatile uint64_t *addr)
+{
+	/**
+	 * Dummy implementation.
+	 * Official implementations are to be provided in the library patchset (by Haoyu).
+	 */
+	return true;
+}
+
+void bitmap_clear_lock(__unused uint16_t nr_arg, __unused volatile uint64_t *addr)
+{
+	/**
+	 * Dummy implementation.
+	 * Official implementations are to be provided in the library patchset (by Haoyu).
+	 */
+}
+
+void bitmap_clear_nolock(__unused uint16_t nr_arg, __unused volatile uint64_t *addr)
+{
+	/**
+	 * Dummy implementation.
+	 * Official implementations are to be provided in the library patchset (by Haoyu).
+	 */
+}
+
+#endif /* RISCV_BITS_H */

--- a/hypervisor/include/arch/riscv/asm/notify.h
+++ b/hypervisor/include/arch/riscv/asm/notify.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2023-2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+#ifndef RISCV_NOTIFY_H
+#define RISCV_NOTIFY_H
+
+#include <types.h>
+
+void arch_init_smp_call(void);
+void arch_smp_call_kick_pcpu(uint16_t pcpu_id);
+
+#endif /* RISCV_NOTIFY_H */

--- a/hypervisor/include/arch/riscv/asm/per_cpu.h
+++ b/hypervisor/include/arch/riscv/asm/per_cpu.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+#ifndef RISCV_PERCPU_H
+#define RISCV_PERCPU_H
+
+#include <common/smp.h>
+#include <types.h>
+
+struct per_cpu_region {
+	struct smp_call_info_data smp_call_info;
+} __aligned(PAGE_SIZE); /* per_cpu_region size aligned with PAGE_SIZE */
+
+extern struct per_cpu_region per_cpu_data[MAX_PCPU_NUM];
+/*
+ * get percpu data for pcpu_id.
+ */
+#define per_cpu(name, pcpu_id)	\
+	(per_cpu_data[(pcpu_id)].name)
+
+#endif /* RISCV_PERCPU_H */

--- a/hypervisor/include/arch/riscv/asm/per_cpu.h
+++ b/hypervisor/include/arch/riscv/asm/per_cpu.h
@@ -10,7 +10,7 @@
 #ifndef RISCV_PERCPU_H
 #define RISCV_PERCPU_H
 
-#include <common/smp.h>
+#include <common/notify.h>
 #include <types.h>
 
 struct per_cpu_region {

--- a/hypervisor/include/arch/riscv/asm/sbi.h
+++ b/hypervisor/include/arch/riscv/asm/sbi.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023-2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+#ifndef RISCV_SBI_H
+#define RISCV_SBI_H
+
+#include <types.h>
+
+enum sbi_eid  {
+	SBI_EID_BASE = 0x10,
+	SBI_EID_TIMER = 0x54494D45,
+	SBI_EID_IPI = 0x735049,
+	SBI_EID_RFENCE = 0x52464E43,
+	SBI_EID_HSM = 0x48534D,
+	SBI_EID_SRST = 0x53525354,
+	SBI_EID_PMU = 0x504D55,
+	SBI_EID_MPXY = 0x4D505859,
+
+	/* Experimental extensions must lie within this range */
+	SBI_EID_EXPER_START = 0x08000000,
+	SBI_EID_EXPER_END = 0x08FFFFFF,
+
+	/* Vendor extensions must lie within this range */
+	SBI_EID_VENDOR_START = 0x09000000,
+	SBI_EID_VENDOR_END = 0x09FFFFFF,
+};
+
+#define SBI_BASE_FID_GET_SPEC_VERSION		0x0
+#define SBI_BASE_FID_GET_IMP_ID			0x1
+#define SBI_BASE_FID_GET_IMP_VERSION		0x2
+#define SBI_BASE_FID_PROBE_EXT			0x3
+#define SBI_BASE_FID_GET_MVENDORID		0x4
+#define SBI_BASE_FID_GET_MARCHID		0x5
+#define SBI_BASE_FID_GET_MIMPID			0x6
+
+/* SBI function IDs for TIME extension*/
+#define SBI_TIMER_FID_SET_TIMER			0x0
+
+/* SBI function IDs for IPI extension*/
+#define SBI_IPI_FID_SEND_IPI			0x0
+
+/* SBI function IDs for RFENCE extension*/
+#define SBI_RFENCE_FID_FNECE_I			0x0
+#define SBI_RFENCE_FID_SFNECE_VMA		0x1
+#define SBI_RFENCE_FID_SFNECE_VMA_ASID		0x2
+#define SBI_RFENCE_FID_HFNECE_GVMA		0x3
+#define SBI_RFENCE_FID_HFNECE_GVMA_ASID		0x4
+#define SBI_RFENCE_FID_HFNECE_VVMA		0x5
+#define SBI_RFENCE_FID_HFNECE_VVMA_ASID		0x6
+
+/* SBI function IDs for HSM extension*/
+#define SBI_HSM_FID_HART_START			0x0
+#define SBI_HSM_FID_HART_STOP			0x1
+#define SBI_HSM_FID_HART_GET_STATUS		0x2
+#define SBI_HSM_FID_HART_SUSPEND		0x3
+
+/* SBI function IDs for MPXY extension*/
+#define SBI_MPXY_FID_GET_SHM_SIZE		0x0
+#define SBI_MPXY_FID_SET_SHM			0x1
+#define SBI_MPXY_FID_GET_CHANNEL_IDS		0x2
+#define SBI_MPXY_FID_READ_ATTRS			0x3
+#define SBI_MPXY_FID_WRITE_ATTRS		0x4
+#define SBI_MPXY_FID_SEND_MSG_WITH_RESP		0x5
+#define SBI_MPXY_FID_SEND_MSG_WITHOUT_RESP	0x6
+#define SBI_MPXY_FID_GET_NOTFICATION_EVENTS	0x7
+
+/* SBI return error codes */
+#define SBI_SUCCESS				0
+#define SBI_ERR_FAILED				-1
+#define SBI_ERR_NOT_SUPPORTED			-2
+#define SBI_ERR_INVALID_PARAM			-3
+#define SBI_ERR_DENIED				-4
+#define SBI_ERR_INVALID_ADDRESS			-5
+#define SBI_ERR_ALREADY_AVAILABLE		-6
+#define SBI_ERR_ALREADY_STARTED			-7
+#define SBI_ERR_ALREADY_STOPPED			-8
+#define SBI_ERR_NO_SHMEM			-9
+#define SBI_ERR_INVALID_STATE			-10
+#define SBI_ERR_BAD_RANGE			-11
+#define SBI_ERR_TIMEOUT				-12
+#define SBI_ERR_IO				-13
+#define SBI_ERR_DENIED_LOCKED			-14
+
+#define SBI_RFENCE_FLUSH_ALL			((uint64_t)-1)
+
+typedef struct {
+	int64_t error;
+	union {
+		int64_t value;
+		uint64_t uvalue;
+	};
+} sbiret;
+
+#endif /* RISCV_SBI_H */

--- a/hypervisor/include/arch/riscv/asm/sbi.h
+++ b/hypervisor/include/arch/riscv/asm/sbi.h
@@ -97,4 +97,7 @@ typedef struct {
 	};
 } sbiret;
 
+void arch_send_single_ipi(uint16_t pcpu_id, __unused uint32_t msg_type);
+void arch_send_dest_ipi_mask(uint64_t dest_mask, __unused uint32_t msg_type);
+
 #endif /* RISCV_SBI_H */

--- a/hypervisor/include/arch/x86/asm/lapic.h
+++ b/hypervisor/include/arch/x86/asm/lapic.h
@@ -102,7 +102,7 @@ void send_startup_ipi(uint16_t dest_pcpu_id, uint64_t cpu_startup_start_address)
  * @param[in]	dest_mask The mask of destination physical cpus
  * @param[in]	vector The vector of interrupt
  */
-void send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector);
+void arch_send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector);
 
 /**
  * @brief Send an IPI to a single pCPU
@@ -110,7 +110,7 @@ void send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector);
  * @param[in]	pcpu_id The id of destination physical cpu
  * @param[in]	vector The vector of interrupt
  */
-void send_single_ipi(uint16_t pcpu_id, uint32_t vector);
+void arch_send_single_ipi(uint16_t pcpu_id, uint32_t vector);
 
 /**
  * @}

--- a/hypervisor/include/arch/x86/asm/lapic.h
+++ b/hypervisor/include/arch/x86/asm/lapic.h
@@ -102,7 +102,7 @@ void send_startup_ipi(uint16_t dest_pcpu_id, uint64_t cpu_startup_start_address)
  * @param[in]	dest_mask The mask of destination physical cpus
  * @param[in]	vector The vector of interrupt
  */
-void send_dest_ipi_mask(uint32_t dest_mask, uint32_t vector);
+void send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector);
 
 /**
  * @brief Send an IPI to a single pCPU

--- a/hypervisor/include/arch/x86/asm/notify.h
+++ b/hypervisor/include/arch/x86/asm/notify.h
@@ -1,23 +1,16 @@
 /*
- * Copyright (C) 2020-2022 Intel Corporation.
+ * Copyright (C) 2020-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
+ *
  */
 
-#ifndef NOTIFY_H
-#define NOTIFY_H
+#ifndef X86_NOTIFY_H
+#define X86_NOTIFY_H
 
-typedef void (*smp_call_func_t)(void *data);
-struct smp_call_info_data {
-	smp_call_func_t func;
-	void *data;
-};
+#include <types.h>
 
-struct acrn_vm;
-void smp_call_function(uint64_t mask, smp_call_func_t func, void *data);
+void arch_init_smp_call(void);
+void arch_smp_call_kick_pcpu(uint16_t pcpu_id);
 
-void setup_notification(void);
-void handle_smp_call(void);
-void setup_pi_notification(void);
-
-#endif
+#endif /* X86_NOTIFY_H */

--- a/hypervisor/include/arch/x86/asm/per_cpu.h
+++ b/hypervisor/include/arch/x86/asm/per_cpu.h
@@ -14,11 +14,11 @@
 #include <profiling.h>
 #include <logmsg.h>
 #include <schedule.h>
-#include <asm/notify.h>
 #include <asm/page.h>
 #include <asm/gdt.h>
 #include <asm/security.h>
 #include <asm/vm_config.h>
+#include <common/notify.h>
 
 struct per_cpu_region {
 	/* vmxon_region MUST be 4KB-aligned */

--- a/hypervisor/include/common/notify.h
+++ b/hypervisor/include/common/notify.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef COMMON_NOTIFY_H
+#define COMMON_NOTIFY_H
+
+#include <types.h>
+
+typedef void (*smp_call_func_t)(void *data);
+
+struct smp_call_info_data {
+	smp_call_func_t func;
+	void *data;
+};
+
+void init_smp_call(void);
+void handle_smp_call(void);
+void smp_call_function(uint64_t mask, smp_call_func_t func, void *data);
+void kick_notification(__unused uint32_t irq, __unused void *data);
+
+#endif /* COMMON_NOTIFY_H */


### PR DESCRIPTION
hv: ipi/smpcall: add multi-arch framework and RISC-V support

This patchset adds multi-arch support, focusing on IPI and SMP call features.
It:
  - introduces common SMP call frameworks
  - adapts x86 code to the new SMP call framework
  - implements the IPI and SMP call for RISC-V

Changelog:
v3 -> v4:
 * Renamed SBI_EXPERIMENTAL_x and SBI_VENDOR_x.

v2 -> v3:
 * Added description for sbi_ecall().
 * Renamed SBI-related enums, macros, and data structures to align with
   the SBI specification.
 * Updated commit message and code comments to state explicitly that
   legacy SBI extensions are not supported in ACRN.
 * Refined the prototype of sbi_send_ipi() to align with the SBI spec:
     From: int64_t sbi_send_ipi(uint64_t mask)
     To:   int64_t sbi_send_ipi(uint64_t mask, uint64_t mask_base)
   In ACRN it is invoked as sbi_send_ipi(dest_mask, 0UL), with mask_base
   set to 0UL.
 * Renamed send_single_ipi() and send_dest_ipi_mask() to
   arch_send_single_ipi() and arch_send_dest_ipi_mask() respectively.
 * Merged the following two patches into one:
     [RFC PATCH v2 4/7] hv: introduce common/smp.{c,h}
     [RFC PATCH v2 5/7] hv: smpcall: x86: adapt to common SMP call
 * Split per_cpu.h implementation into a separate commit.

v1 -> v2:
 * Dropped the ops way per discussion in
   https://lists.projectacrn.org/g/acrn-dev/topic/rfc_patch_3_6_hv_ipi/114877139

Tracked-On: #8786