### PR TITLE
Assembly code for BSP and AP boot for RISC-V

### DIFF
--- a/hypervisor/arch/riscv/Makefile
+++ b/hypervisor/arch/riscv/Makefile
@@ -12,6 +12,8 @@ CFLAGS +=
 
 ASFLAGS +=
 
+LDFLAGS += -Wl,--no-warn-rwx-segments
+
 # g expands to i, m, a, f, d, zicsr and zifencei.
 # h for hypervisor extension
 RV_ISA += gh
@@ -25,10 +27,10 @@ ARCH_CFLAGS += -mcmodel=medany
 ARCH_ASFLAGS += -march=rv64$(subst $() $(),_,$(RV_ISA))
 
 # HV host assembly sources
-HOST_S_SRCS += arch/riscv/dummy_entry.S
+HOST_S_SRCS += arch/riscv/boot/cpu_entry.S
 
 # HV host C sources
-HOST_C_SRCS += arch/riscv/dummy.c
+HOST_C_SRCS += arch/riscv/init.c
 HOST_C_SRCS += arch/riscv/sbi.c
 HOST_C_SRCS += arch/riscv/notify.c
 

--- a/hypervisor/arch/riscv/boot/cpu_entry.S
+++ b/hypervisor/arch/riscv/boot/cpu_entry.S
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+	.section .text.entry, "ax", %progbits
+
+	/*
+	 * main entry point
+	 *  - a0 = hart ID
+	 *  - a1 = dtb address
+	 */
+	.globl _start
+_start:
+	/* Mask all interrupts */
+	csrw	sie, zero
+
+	/* Disable FPU bit[14:13] */
+	li	t0, 0x00006000
+	csrc	sstatus, t0
+
+	/* Set trap vector to spin forever for debug */
+	lla	a3, _start_hang
+	csrw	stvec, a3
+
+	/* Clear BSS */
+	lla	t3, _bss_start
+	lla	t4, _bss_end
+_clear_bss:
+	sd	zero, (t3)
+	add	t3, t3, __SIZEOF_POINTER__
+	bltu	t3, t4, _clear_bss
+
+	/* Setup cpu0 boot stack (full descending) */
+	lla	sp, _boot_stack_end
+
+	/* a0 = hart_id, a1 = dtb_address */
+	tail	init_primary_pcpu
+
+	.align 2
+	.global _start_secondary_sbi
+_start_secondary_sbi:
+	/* Mask all interrupts */
+	csrw	sie, zero
+
+	/* Disable FPU bit[14:13] */
+	li	t0, 0x00006000
+	csrc	sstatus, t0
+
+	/* Set trap vector to spin forever for debug */
+	lla	a3, _start_hang
+	csrw	stvec, a3
+
+	/* a0 contains the hartid & a1 contains stack physical addr */
+	mv	sp, a1
+
+	tail	init_secondary_pcpu
+
+	.align 2
+_start_hang:
+	wfi
+	j	_start_hang
+

--- a/hypervisor/arch/riscv/init.c
+++ b/hypervisor/arch/riscv/init.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+#include <types.h>
+
+/* C entry point for boot CPU */
+void init_primary_pcpu(uint64_t hart_id, uint64_t fdt_paddr)
+{
+	(void)hart_id;
+	(void)fdt_paddr;
+
+	while (1) {
+		asm volatile("wfi" : : : "memory");
+	}
+}
+
+/* C entry point for AP */
+void init_secondary_pcpu(uint64_t hart_id)
+{
+	(void)hart_id;
+
+	/* to be implemented */
+}

--- a/hypervisor/arch/riscv/link_ram.ld.in
+++ b/hypervisor/arch/riscv/link_ram.ld.in
@@ -1,38 +1,84 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+OUTPUT_ARCH(riscv)
 ENTRY(_start)
 
-MEMORY {
-    RAM : ORIGIN = 0x81000000, LENGTH = 64K
-}
+SECTIONS
+{
+	. = CONFIG_HV_RAM_START;
+	_code_start = .;
 
-SECTIONS {
-	/* TODO: Replace hardcodes with macros defined in config header */
-    . = 0x81000000;
+	.text :
+	{
+		_text_start = .;
+		*(.text.entry)		/* Entry point code first */
+		*(.text)
+		*(.text.*)
+		*(.note.gnu.build-id)	/* Keep build ID for debugging */
 
-    .text : {
-        *(.text)
-        *(.text.*)
-        *(.note.gnu.build-id)
-    } > RAM
+		. = ALIGN(8);
+		_text_end = .;
+	}
 
-    .rodata : {
-        *(.rodata)
-        *(.rodata.*)
-    } > RAM
+	. = ALIGN(0x1000);
+	.rodata :
+	{
+		_rodata_start = .;
+		*(.rodata)
+		*(.rodata.*)
 
-    .data : {
-        *(.data)
-        *(.data.*)
-    } > RAM
+		/* Small rodata sections */
+		*(.srodata)
+		*(.srodata.*)
 
-    .bss (NOLOAD) : {
-        *(.bss)
-        *(.bss.*)
-        *(COMMON)
-    } > RAM
+		. = ALIGN(8);
+		_rodata_end = .;
+	}
 
-    . = ALIGN(8);
-    _end = .;
+	. = ALIGN(0x1000);
+	.data :
+	{
+		_data_start = .;
+		*(.data.page_aligned)
+		*(.data)
+		*(.data.*)
 
-    . = 0x81010000;
-    _stack_top = .;
+		/* Small data sections */
+		*(.sdata)
+		*(.sdata.*)
+
+		. = ALIGN(8);
+		_data_end = .;
+	}
+
+	. = ALIGN(0x1000);
+	.boot_stack :
+	{
+		_boot_stack_start = .;
+		. += 0x1000;
+		. = ALIGN(16);		/* RISC-V ABI requires 16-byte stack alignment */
+		_boot_stack_end = .;
+	}
+
+	. = ALIGN(0x1000);
+	.bss (NOLOAD) :
+	{
+		_bss_start = .;
+		*(.bss)
+		*(.bss.*)
+
+		/* Small BSS sections */
+		*(.sbss)
+		*(.sbss.*)
+
+		. = ALIGN(8);
+		_bss_end = .;
+	}
+
+	. = ALIGN(0x1000);
+	_code_end = .;
 }

--- a/hypervisor/include/arch/riscv/asm/init.h
+++ b/hypervisor/include/arch/riscv/asm/init.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef INIT_H
+#define INIT_H
+
+void init_primary_pcpu(uint64_t hart_id, uint64_t fdt_paddr);
+void init_secondary_pcpu(uint64_t hart_id);
+
+#endif /* INIT_H*/


### PR DESCRIPTION
Assembly code for BSP and AP boot for RISC-V. And dummy C entries for both BSP and AP are provided.

Acked-by: Wang, Yu1 <yu1.wang@intel.com>