### PR TITLE
dm: correct wrong input parameter when printing get edid error message

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_gpu.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpu.c
@@ -566,7 +566,7 @@ virtio_gpu_cmd_get_edid(struct virtio_gpu_command *cmd)
 	memset(&resp, 0, sizeof(resp));
 	virtio_gpu_update_resp_fence(&cmd->hdr, &resp.hdr);
 	if (req.scanout >= gpu->scanout_num) {
-		pr_err("%s: Invalid scanout_id %d\n", req.scanout);
+		pr_err("%s: Invalid scanout_id %d\n", __func__, req.scanout);
 		resp.hdr.type = VIRTIO_GPU_RESP_ERR_INVALID_SCANOUT_ID;
 		memcpy(cmd->iov[1].iov_base, &resp, sizeof(resp));
 		return;


### PR DESCRIPTION
fix virtio_gpu_cmd_get_edid error print wrong input parameter to avoid devicemodel crash.

Tracked-On: #8797