### PR TITLE
hv: ipi: drop arch_ prefix from IPI functions

### DIFF
--- a/hypervisor/arch/riscv/notify.c
+++ b/hypervisor/arch/riscv/notify.c
@@ -18,5 +18,5 @@ void arch_init_smp_call(void)
 
 void arch_smp_call_kick_pcpu(uint16_t pcpu_id)
 {
-	arch_send_single_ipi(pcpu_id, IPI_NOTIFY_CPU);
+	send_single_ipi(pcpu_id, IPI_NOTIFY_CPU);
 }

--- a/hypervisor/arch/riscv/sbi.c
+++ b/hypervisor/arch/riscv/sbi.c
@@ -82,23 +82,23 @@ static int64_t sbi_send_ipi(uint64_t mask, uint64_t mask_base)
  *  - Kick pCPU out of non-root mode
  *
  * Callers should invoke this function with:
- *      arch_send_single_ipi(pcpu_id, IPI_NOTIFY_CPU);
+ *      send_single_ipi(pcpu_id, IPI_NOTIFY_CPU);
  *
  * msg_type is retained for future extensions and to stay aligned with
  * the function prototype used on other architectures (e.g. x86).
  */
-void arch_send_single_ipi(uint16_t pcpu_id, __unused uint32_t msg_type)
+void send_single_ipi(uint16_t pcpu_id, __unused uint32_t msg_type)
 {
 	sbi_send_ipi((1UL << pcpu_id), 0UL);
 }
 
 /**
- * Similar to arch_send_single_ipi() regards to msg_type.
+ * Similar to send_single_ipi() regards to msg_type.
  *
  * Callers should invoke this function with:
- *      arch_send_dest_ipi_mask(dest_mask, IPI_NOTIFY_CPU);
+ *      send_dest_ipi_mask(dest_mask, IPI_NOTIFY_CPU);
  */
-void arch_send_dest_ipi_mask(uint64_t dest_mask, __unused uint32_t msg_type)
+void send_dest_ipi_mask(uint64_t dest_mask, __unused uint32_t msg_type)
 {
 	sbi_send_ipi(dest_mask, 0UL);
 }

--- a/hypervisor/arch/x86/guest/optee.c
+++ b/hypervisor/arch/x86/guest/optee.c
@@ -93,7 +93,7 @@ static int32_t tee_switch_to_ree(struct acrn_vcpu *vcpu)
 			 * after VM Entry and will go through the secure interrupt handling
 			 * flow in handle_x86_tee_int.
 			 */
-			arch_send_single_ipi(pcpuid_from_vcpu(ree_vcpu),
+			send_single_ipi(pcpuid_from_vcpu(ree_vcpu),
 				(uint32_t)(vcpu->arch.pid.control.bits.nv));
 		} else if (prio(pending_intr) == prio(TEE_FIXED_NONSECURE_VECTOR)) {
 			/* The TEE_FIXED_NONSECURE_VECTOR needs to be cleared as the

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -550,7 +550,7 @@ static void vlapic_accept_intr(struct acrn_vlapic *vlapic, uint32_t vector, bool
  */
 static void apicv_trigger_pi_anv(uint16_t dest_pcpu_id, uint32_t anv)
 {
-	arch_send_single_ipi(dest_pcpu_id, anv);
+	send_single_ipi(dest_pcpu_id, anv);
 }
 
 /**

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -240,7 +240,7 @@ send_startup_ipi(uint16_t dest_pcpu_id, uint64_t cpu_startup_start_address)
 	msr_write(MSR_IA32_EXT_APIC_ICR, icr.value);
 }
 
-void arch_send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector)
+void send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector)
 {
 	uint16_t pcpu_id;
 	uint64_t mask = dest_mask;
@@ -248,12 +248,12 @@ void arch_send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector)
 	pcpu_id = ffs64(mask);
 	while (pcpu_id < MAX_PCPU_NUM) {
 		bitmap_clear_nolock(pcpu_id, &mask);
-		arch_send_single_ipi(pcpu_id, vector);
+		send_single_ipi(pcpu_id, vector);
 		pcpu_id = ffs64(mask);
 	}
 }
 
-void arch_send_single_ipi(uint16_t pcpu_id, uint32_t vector)
+void send_single_ipi(uint16_t pcpu_id, uint32_t vector)
 {
 	union apic_icr icr;
 
@@ -299,6 +299,6 @@ void kick_pcpu(uint16_t pcpu_id)
 	if (per_cpu(mode_to_kick_pcpu, pcpu_id) == DEL_MODE_INIT) {
 		send_single_init(pcpu_id);
 	} else {
-		arch_send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);
+		send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);
 	}
 }

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -91,6 +91,6 @@ void arch_smp_call_kick_pcpu(uint16_t pcpu_id)
 	if ((vcpu != NULL) && (is_lapic_pt_enabled(vcpu))) {
 		vcpu_make_request(vcpu, ACRN_REQUEST_SMP_CALL);
 	} else {
-		arch_send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);
+		send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);
 	}
 }

--- a/hypervisor/include/arch/riscv/asm/sbi.h
+++ b/hypervisor/include/arch/riscv/asm/sbi.h
@@ -97,8 +97,8 @@ typedef struct {
 	};
 } sbiret;
 
-void arch_send_single_ipi(uint16_t pcpu_id, __unused uint32_t msg_type);
-void arch_send_dest_ipi_mask(uint64_t dest_mask, __unused uint32_t msg_type);
+void send_single_ipi(uint16_t pcpu_id, __unused uint32_t msg_type);
+void send_dest_ipi_mask(uint64_t dest_mask, __unused uint32_t msg_type);
 
 int sbi_set_timer(uint64_t stime_value);
 

--- a/hypervisor/include/arch/x86/asm/lapic.h
+++ b/hypervisor/include/arch/x86/asm/lapic.h
@@ -102,7 +102,7 @@ void send_startup_ipi(uint16_t dest_pcpu_id, uint64_t cpu_startup_start_address)
  * @param[in]	dest_mask The mask of destination physical cpus
  * @param[in]	vector The vector of interrupt
  */
-void arch_send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector);
+void send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector);
 
 /**
  * @brief Send an IPI to a single pCPU
@@ -110,7 +110,7 @@ void arch_send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector);
  * @param[in]	pcpu_id The id of destination physical cpu
  * @param[in]	vector The vector of interrupt
  */
-void arch_send_single_ipi(uint16_t pcpu_id, uint32_t vector);
+void send_single_ipi(uint16_t pcpu_id, uint32_t vector);
 
 /**
  * @}


### PR DESCRIPTION
Since there is no common IPI abstraction, the arch_ prefix is redundant. This patch renames the functions as follows:
    - arch_send_dest_ipi_mask -> send_dest_ipi_mask
    - arch_send_single_ipi   -> send_single_ipi

Tracked-On: #8799