### PR TITLE
hv: multiarch: percpu and pcpu related data structure and interface support

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -151,6 +151,7 @@ endif
 COMMON_C_SRCS += common/notify.c
 COMMON_C_SRCS += lib/memory.c
 COMMON_C_SRCS += common/percpu.c
+COMMON_C_SRCS += common/cpu.c
 
 ifeq ($(ARCH),x86)
 COMMON_C_SRCS += common/ticks.c

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -218,11 +218,7 @@ COMMON_C_OBJS := $(patsubst %.c,$(HV_OBJDIR)/%.o,$(COMMON_C_SRCS))
 
 COMMON_MOD = $(HV_MODDIR)/common_mod.a
 
-# TODO: Remove this check when the first riscv common file
-# is moved out from above block
-ifeq ($(ARCH),x86)
 MODULES += $(COMMON_MOD)
-endif
 
 ifeq ($(CONFIG_RELEASE),y)
 MODULES += $(LIB_RELEASE)

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -150,6 +150,7 @@ endif
 #
 COMMON_C_SRCS += common/notify.c
 COMMON_C_SRCS += lib/memory.c
+COMMON_C_SRCS += common/percpu.c
 
 ifeq ($(ARCH),x86)
 COMMON_C_SRCS += common/ticks.c

--- a/hypervisor/arch/riscv/Makefile
+++ b/hypervisor/arch/riscv/Makefile
@@ -35,6 +35,7 @@ HOST_C_SRCS += arch/riscv/sbi.c
 HOST_C_SRCS += arch/riscv/notify.c
 HOST_C_SRCS += arch/riscv/timer.c
 HOST_C_SRCS += arch/riscv/trap.c
+HOST_C_SRCS += arch/riscv/cpu.c
 
 # Virtual platform assembly sources
 VP_S_SRCS +=

--- a/hypervisor/arch/riscv/cpu.c
+++ b/hypervisor/arch/riscv/cpu.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2018-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ *
+ */
+
+
+#include <types.h>
+#include <cpu.h>
+
+/* wait until *sync == wake_sync */
+void wait_sync_change(volatile const uint64_t *sync, uint64_t wake_sync)
+{
+	while ((*sync) != wake_sync) {
+		cpu_relax();
+	}
+}
+
+uint16_t arch_get_pcpu_num(void)
+{
+	return NR_CPUS;
+}

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -14,7 +14,7 @@
 #include <asm/vtd.h>
 #include <asm/lapic.h>
 #include <asm/irq.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/cpufeatures.h>
 #include <asm/cpu_caps.h>
 #include <acpi.h>
@@ -43,7 +43,6 @@
 #define CPU_UP_TIMEOUT		100U /* millisecond */
 #define CPU_DOWN_TIMEOUT	100U /* millisecond */
 
-struct per_cpu_region per_cpu_data[MAX_PCPU_NUM] __aligned(PAGE_SIZE);
 static uint16_t phys_cpu_num = 0U;
 static uint64_t pcpu_sync = 0UL;
 static uint64_t startup_paddr = 0UL;
@@ -72,7 +71,7 @@ static bool init_percpu_lapic_id(void)
 
 	if ((phys_cpu_num != 0U) && (phys_cpu_num <= MAX_PCPU_NUM)) {
 		for (i = 0U; i < phys_cpu_num; i++) {
-			per_cpu(lapic_id, i) = lapic_id_array[i];
+			per_cpu(arch.lapic_id, i) = lapic_id_array[i];
 		}
 		success = true;
 	}
@@ -344,7 +343,7 @@ static uint16_t get_pcpu_id_from_lapic_id(uint32_t lapic_id)
 	uint16_t pcpu_id = INVALID_CPU_ID;
 
 	for (i = 0U; i < phys_cpu_num; i++) {
-		if (per_cpu(lapic_id, i) == lapic_id) {
+		if (per_cpu(arch.lapic_id, i) == lapic_id) {
 			pcpu_id = i;
 			break;
 		}

--- a/hypervisor/arch/x86/gdt.c
+++ b/hypervisor/arch/x86/gdt.c
@@ -6,7 +6,7 @@
 
 #include <types.h>
 #include <asm/gdt.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 
 static void set_tss_desc(struct tss_64_descriptor *desc,
 		uint64_t tss, size_t tss_limit, uint32_t type)
@@ -32,9 +32,9 @@ static inline void load_gdt(struct host_gdt_descriptor *gdtr)
 
 void load_gdtr_and_tr(void)
 {
-	struct host_gdt *gdt = &get_cpu_var(gdt);
+	struct host_gdt *gdt = &get_cpu_var(arch.gdt);
 	struct host_gdt_descriptor gdtr;
-	struct tss_64 *tss = &get_cpu_var(tss);
+	struct tss_64 *tss = &get_cpu_var(arch.tss);
 
 	/* first entry is not used */
 	gdt->rsvd = 0xAAAAAAAAAAAAAAAAUL;
@@ -43,9 +43,9 @@ void load_gdtr_and_tr(void)
 	/* ring 0 data sel descriptor */
 	gdt->data_segment_descriptor = 0x00cf93000000ffffUL;
 
-	tss->ist1 = (uint64_t)get_cpu_var(mc_stack) + CONFIG_STACK_SIZE;
-	tss->ist2 = (uint64_t)get_cpu_var(df_stack) + CONFIG_STACK_SIZE;
-	tss->ist3 = (uint64_t)get_cpu_var(sf_stack) + CONFIG_STACK_SIZE;
+	tss->ist1 = (uint64_t)get_cpu_var(arch.mc_stack) + CONFIG_STACK_SIZE;
+	tss->ist2 = (uint64_t)get_cpu_var(arch.df_stack) + CONFIG_STACK_SIZE;
+	tss->ist3 = (uint64_t)get_cpu_var(arch.sf_stack) + CONFIG_STACK_SIZE;
 	tss->ist4 = 0UL;
 
 	/* tss descriptor */

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -10,7 +10,7 @@
 #include <asm/guest/vm.h>
 #include <asm/vtd.h>
 #include <ptdev.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/ioapic.h>
 #include <asm/pgtable.h>
 #include <asm/irq.h>
@@ -65,12 +65,12 @@ static uint32_t calculate_logical_dest_mask(uint64_t pdmask)
 		 * one Cluster. So some pCPUs may not be included.
 		 * Here we use the first Cluster of all the requested pCPUs.
 		 */
-		dest_cluster_id = per_cpu(lapic_ldr, pcpu_id) & X2APIC_LDR_CLUSTER_ID_MASK;
+		dest_cluster_id = per_cpu(arch.lapic_ldr, pcpu_id) & X2APIC_LDR_CLUSTER_ID_MASK;
 		do {
 			bitmap_clear_nolock(pcpu_id, &pcpu_mask);
-			cluster_id = per_cpu(lapic_ldr, pcpu_id) & X2APIC_LDR_CLUSTER_ID_MASK;
+			cluster_id = per_cpu(arch.lapic_ldr, pcpu_id) & X2APIC_LDR_CLUSTER_ID_MASK;
 			if (cluster_id == dest_cluster_id) {
-				logical_id_mask |= (per_cpu(lapic_ldr, pcpu_id) & X2APIC_LDR_LOGICAL_ID_MASK);
+				logical_id_mask |= (per_cpu(arch.lapic_ldr, pcpu_id) & X2APIC_LDR_LOGICAL_ID_MASK);
 			} else {
 				pr_warn("The cluster ID of pCPU %d is %d which differs from that (%d) of "
 					"the previous cores in the guest logical destination.\n"

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -11,7 +11,7 @@
 #include <logmsg.h>
 #include <platform_acpi_info.h>
 #include <asm/guest/guest_pm.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 
 int32_t validate_pstate(const struct acrn_vm *vm, uint64_t perf_ctl)
 {

--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -18,6 +18,7 @@
 #include <trace.h>
 #include <logmsg.h>
 #include <asm/irq.h>
+#include <common/notify.h>
 
 #define EXCEPTION_ERROR_CODE_VALID  8U
 

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -32,7 +32,7 @@
 #include <errno.h>
 #include <asm/lib/bits.h>
 #include <asm/lib/atomic.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/pgtable.h>
 #include <asm/lapic.h>
 #include <asm/guest/vmcs.h>
@@ -1917,7 +1917,7 @@ static void inject_msi_for_lapic_pt(struct acrn_vm *vm, uint64_t addr, uint64_t 
 		while (vcpu_id != INVALID_BIT_INDEX) {
 			bitmap_clear_nolock(vcpu_id, &vdmask);
 			vcpu = vcpu_from_vid(vm, vcpu_id);
-			dest |= per_cpu(lapic_ldr, pcpuid_from_vcpu(vcpu));
+			dest |= per_cpu(arch.lapic_ldr, pcpuid_from_vcpu(vcpu));
 			vcpu_id = ffs64(vdmask);
 		}
 
@@ -2072,7 +2072,7 @@ vlapic_x2apic_pt_icr_access(struct acrn_vcpu *vcpu, uint64_t val)
 				default:
 					/* convert the dest from virtual apic_id to physical apic_id */
 					if (is_x2apic_enabled(vcpu_vlapic(target_vcpu))) {
-						papic_id = per_cpu(lapic_id, pcpuid_from_vcpu(target_vcpu));
+						papic_id = per_cpu(arch.lapic_id, pcpuid_from_vcpu(target_vcpu));
 							dev_dbg(DBG_LEVEL_LAPICPT,
 							"%s vapic_id: 0x%08lx papic_id: 0x%08lx icr_low:0x%08lx",
 							 __func__, target_vcpu->arch.vlapic.vapic_id, papic_id, icr_low);
@@ -2203,7 +2203,7 @@ void vlapic_create(struct acrn_vcpu *vcpu, uint16_t pcpu_id)
 	vlapic_init_timer(vlapic);
 
 	/* Set vLAPIC ID to be same as pLAPIC ID */
-	vlapic->vapic_id = per_cpu(lapic_id, pcpu_id);
+	vlapic->vapic_id = per_cpu(arch.lapic_id, pcpu_id);
 
 	dev_dbg(DBG_LEVEL_VLAPIC, "vlapic APIC ID : 0x%04x", vlapic->vapic_id);
 }

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -7,7 +7,7 @@
 #include <types.h>
 #include <errno.h>
 #include <sprintf.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/lapic.h>
 #include <asm/guest/vm.h>
 #include <asm/guest/vm_reset.h>

--- a/hypervisor/arch/x86/guest/vm_reset.c
+++ b/hypervisor/arch/x86/guest/vm_reset.c
@@ -8,7 +8,7 @@
 #include <asm/io.h>
 #include <asm/host_pm.h>
 #include <logmsg.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/guest/vm_reset.h>
 #include <vm_event.h>
 

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -13,7 +13,7 @@
 #include <asm/vmx.h>
 #include <asm/gdt.h>
 #include <asm/pgtable.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/cpu_caps.h>
 #include <asm/cpufeatures.h>
 #include <asm/guest/vmexit.h>
@@ -146,7 +146,7 @@ void init_host_state(void)
 	exec_vmwrite(VMX_HOST_GDTR_BASE, gdt_base);
 	pr_dbg("VMX_HOST_GDTR_BASE: 0x%x ", gdt_base);
 
-	tss_addr = hva2hpa((void *)&get_cpu_var(tss));
+	tss_addr = hva2hpa((void *)&get_cpu_var(arch.tss));
 	/* Set up host TR base fields */
 	exec_vmwrite(VMX_HOST_TR_BASE, tss_addr);
 	pr_dbg("VMX_HOST_TR_BASE: 0x%016lx ", tss_addr);
@@ -558,7 +558,7 @@ static void init_exit_ctrl(const struct acrn_vcpu *vcpu)
 void init_vmcs(struct acrn_vcpu *vcpu)
 {
 	uint64_t vmx_rev_id;
-	void **vmcs_ptr = &get_cpu_var(vmcs_run);
+	void **vmcs_ptr = &get_cpu_var(arch.vmcs_run);
 
 	/* Log message */
 	pr_dbg("Initializing VMCS");
@@ -588,7 +588,7 @@ void init_vmcs(struct acrn_vcpu *vcpu)
  */
 void load_vmcs(const struct acrn_vcpu *vcpu)
 {
-	void **vmcs_ptr = &get_cpu_var(vmcs_run);
+	void **vmcs_ptr = &get_cpu_var(arch.vmcs_run);
 
 	if (vcpu->launched && (*vmcs_ptr != (void *)vcpu->arch.vmcs)) {
 		load_va_vmcs(vcpu->arch.vmcs);

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -23,6 +23,7 @@
 #include <trace.h>
 #include <asm/rtcm.h>
 #include <debug/console.h>
+#include <per_cpu.h>
 
 /*
  * According to "SDM APPENDIX C VMX BASIC EXIT REASONS",
@@ -487,7 +488,7 @@ static int32_t loadiwkey_vmexit_handler(struct acrn_vcpu *vcpu)
 		vcpu->arch.IWKey.integrity_key[1] = xmm[1];
 
 		asm_loadiwkey(0);
-		get_cpu_var(whose_iwkey) = vcpu;
+		get_cpu_var(arch.whose_iwkey) = vcpu;
 	}
 
 	return 0;

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -23,6 +23,7 @@
 #include <trace.h>
 #include <logmsg.h>
 #include <asm/guest/vcat.h>
+#include <per_cpu.h>
 
 #define INTERCEPT_DISABLE		(0U)
 #define INTERCEPT_READ			(1U << 0U)
@@ -1295,7 +1296,7 @@ int32_t wrmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 				vcpu->arch.IWKey = vcpu->vm->arch_vm.iwkey_backup;
 				spinlock_release(&vcpu->vm->arch_vm.iwkey_backup_lock);
 				/* Load the new iwkey for this vcpu */
-				get_cpu_var(whose_iwkey) = NULL;
+				get_cpu_var(arch.whose_iwkey) = NULL;
 				load_iwkey(vcpu);
 				vcpu->arch.iwkey_copy_status = 1UL;
 			}

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -7,7 +7,7 @@
 #include <types.h>
 #include <asm/init.h>
 #include <console.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <shell.h>
 #include <asm/vmx.h>
 #include <asm/guest/vm.h>

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -6,6 +6,7 @@
 
 #include <types.h>
 #include <errno.h>
+#include <cpu.h>
 #include <irq.h>
 #include <asm/lib/spinlock.h>
 #include <asm/ioapic.h>

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -7,7 +7,7 @@
 #include <types.h>
 #include <asm/lib/bits.h>
 #include <asm/lib/spinlock.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/io.h>
 #include <asm/irq.h>
 #include <asm/idt.h>

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -14,6 +14,7 @@
 #include <asm/apicreg.h>
 #include <asm/irq.h>
 #include <delay.h>
+#include <cpu.h>
 
 /* intr_lapic_icr_delivery_mode */
 #define INTR_LAPIC_ICR_FIXED           0x0U

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -8,7 +8,7 @@
 #include <asm/lib/bits.h>
 #include <asm/msr.h>
 #include <asm/cpu.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/cpu_caps.h>
 #include <asm/lapic.h>
 #include <asm/apicreg.h>
@@ -113,7 +113,7 @@ void init_lapic(uint16_t pcpu_id)
 	/* Can not put this to early_init_lapic because logical ID is not
 	 * updated yet.
 	 */
-	per_cpu(lapic_ldr, pcpu_id) = (uint32_t) msr_read(MSR_IA32_EXT_APIC_LDR);
+	per_cpu(arch.lapic_ldr, pcpu_id) = (uint32_t) msr_read(MSR_IA32_EXT_APIC_LDR);
 }
 
 static void save_lapic(struct lapic_regs *regs)
@@ -203,7 +203,7 @@ send_startup_ipi(uint16_t dest_pcpu_id, uint64_t cpu_startup_start_address)
 	struct cpuinfo_x86 *cpu_info = get_pcpu_info();
 
 	icr.value = 0U;
-	icr.value_32.hi_32 = per_cpu(lapic_id, dest_pcpu_id);
+	icr.value_32.hi_32 = per_cpu(arch.lapic_id, dest_pcpu_id);
 
 	/* Assert INIT IPI */
 	icr.bits.destination_mode = INTR_LAPIC_ICR_PHYSICAL;
@@ -262,7 +262,7 @@ void arch_send_single_ipi(uint16_t pcpu_id, uint32_t vector)
 			msr_write(MSR_IA32_EXT_APIC_SELF_IPI, vector);
 		} else {
 			/* Set the destination field to the target processor. */
-			icr.value_32.hi_32 = per_cpu(lapic_id, pcpu_id);
+			icr.value_32.hi_32 = per_cpu(arch.lapic_id, pcpu_id);
 
 			/* Write the vector ID to ICR. */
 			icr.value_32.lo_32 = vector | (INTR_LAPIC_ICR_PHYSICAL << 11U);
@@ -287,7 +287,7 @@ void send_single_init(uint16_t pcpu_id)
 	 *   It is not blocked in VMX non-root operation. Instead, INITs cause VM exits
 	 */
 
-	icr.value_32.hi_32 = per_cpu(lapic_id, pcpu_id);
+	icr.value_32.hi_32 = per_cpu(arch.lapic_id, pcpu_id);
 	icr.value_32.lo_32 = (INTR_LAPIC_ICR_PHYSICAL << 11U) | (INTR_LAPIC_ICR_INIT << 8U);
 
 	msr_write(MSR_IA32_EXT_APIC_ICR, icr.value);

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -15,6 +15,8 @@
 #include <asm/guest/vm.h>
 #include <asm/guest/virq.h>
 #include <common/notify.h>
+#include <irq.h>
+#include <debug/logmsg.h>
 
 static uint32_t notification_irq = IRQ_INVALID;
 

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -21,6 +21,7 @@
 #include <delay.h>
 #include <asm/board.h>
 #include <asm/cpuid.h>
+#include <cpu.h>
 
 struct cpu_context cpu_ctx;
 

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -6,7 +6,7 @@
 #include <acrn_common.h>
 #include <asm/default_acpi_info.h>
 #include <platform_acpi_info.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/io.h>
 #include <asm/msr.h>
 #include <asm/pgtable.h>
@@ -167,12 +167,12 @@ void shutdown_system(void)
 
 static void suspend_tsc(__unused void *data)
 {
-	per_cpu(tsc_suspend, get_pcpu_id()) = rdtsc();
+	per_cpu(arch.tsc_suspend, get_pcpu_id()) = rdtsc();
 }
 
 static void resume_tsc(__unused void *data)
 {
-	msr_write(MSR_IA32_TIME_STAMP_COUNTER, per_cpu(tsc_suspend, get_pcpu_id()));
+	msr_write(MSR_IA32_TIME_STAMP_COUNTER, per_cpu(arch.tsc_suspend, get_pcpu_id()));
 }
 
 void host_enter_s3(const struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val)

--- a/hypervisor/arch/x86/rtcm.c
+++ b/hypervisor/arch/x86/rtcm.c
@@ -12,6 +12,7 @@
 #include <asm/mmu.h>
 #include <asm/cpu_caps.h>
 #include <asm/rtcm.h>
+#include <cpu.h>
 
 
 static uint64_t ssram_bottom_hpa;

--- a/hypervisor/arch/x86/security.c
+++ b/hypervisor/arch/x86/security.c
@@ -8,7 +8,7 @@
 #include <asm/msr.h>
 #include <asm/cpufeatures.h>
 #include <asm/cpu.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/cpu_caps.h>
 #include <asm/security.h>
 #include <logmsg.h>

--- a/hypervisor/arch/x86/trampoline.c
+++ b/hypervisor/arch/x86/trampoline.c
@@ -6,7 +6,7 @@
 
 #include <types.h>
 #include <asm/mmu.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/trampoline.h>
 #include <reloc.h>
 #include <asm/boot/ld_sym.h>

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -8,7 +8,7 @@
 
 #include <types.h>
 #include <asm/msr.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/pgtable.h>
 #include <asm/vmx.h>
 
@@ -40,7 +40,7 @@ void vmx_on(void)
 {
 	uint64_t tmp64;
 	uint32_t tmp32;
-	void *vmxon_region_va = (void *)get_cpu_var(vmxon_region);
+	void *vmxon_region_va = (void *)get_cpu_var(arch.vmxon_region);
 	uint64_t vmxon_region_pa;
 
 	/* Initialize vmxon page with revision id from IA32 VMX BASIC MSR */
@@ -136,7 +136,7 @@ void clear_va_vmcs(const uint8_t *vmcs_va)
  */
 void vmx_off(void)
 {
-	void **vmcs_ptr = &get_cpu_var(vmcs_run);
+	void **vmcs_ptr = &get_cpu_var(arch.vmcs_run);
 
 	if (*vmcs_ptr != NULL) {
 		clear_va_vmcs(*vmcs_ptr);

--- a/hypervisor/common/cpu.c
+++ b/hypervisor/common/cpu.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <cpu.h>
+#include <asm/lib/bits.h>
+
+
+static volatile uint64_t pcpu_active_bitmap = 0UL;
+
+/*
+ * @post return <= MAX_PCPU_NUM
+ */
+uint16_t get_pcpu_nums(void)
+{
+	return arch_get_pcpu_num();
+}
+
+bool is_pcpu_active(uint16_t pcpu_id)
+{
+	return bitmap_test(pcpu_id, &pcpu_active_bitmap);
+}
+
+void set_pcpu_active(uint16_t pcpu_id)
+{
+	bitmap_set_lock(pcpu_id, &pcpu_active_bitmap);
+}
+
+void clear_pcpu_active(uint16_t pcpu_id)
+{
+
+	bitmap_clear_lock(pcpu_id, &pcpu_active_bitmap);
+}
+
+bool check_pcpus_active(uint64_t mask)
+{
+	return ((pcpu_active_bitmap & mask) == mask);
+}
+
+bool check_pcpus_inactive(uint64_t mask)
+{
+	return ((pcpu_active_bitmap & mask) != 0UL);
+}
+
+uint64_t get_active_pcpu_bitmap(void)
+{
+	return pcpu_active_bitmap;
+}

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -14,6 +14,7 @@
 #include <sprintf.h>
 #include <trace.h>
 #include <logmsg.h>
+#include <per_cpu.h>
 
 void vcpu_thread(struct thread_object *obj)
 {

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -10,7 +10,7 @@
 #include <version.h>
 #include <reloc.h>
 #include <asm/vtd.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/lapic.h>
 #include <asm/guest/assign.h>
 #include <asm/guest/ept.h>

--- a/hypervisor/common/irq.c
+++ b/hypervisor/common/irq.c
@@ -9,7 +9,7 @@
 #include <irq.h>
 #include <common/softirq.h>
 #include <asm/irq.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 
 static spinlock_t irq_alloc_spinlock = { .head = 0U, .tail = 0U, };
 

--- a/hypervisor/common/notify.c
+++ b/hypervisor/common/notify.c
@@ -12,6 +12,7 @@
 #include <common/notify.h>
 #include <debug/logmsg.h>
 #include <asm/cpu.h>
+#include <cpu.h>
 
 static volatile uint64_t smp_call_mask = 0UL;
 

--- a/hypervisor/common/notify.c
+++ b/hypervisor/common/notify.c
@@ -7,10 +7,11 @@
 #include <asm/cpu.h>
 #include <asm/lib/atomic.h>
 #include <asm/lib/bits.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/notify.h>
 #include <common/notify.h>
 #include <debug/logmsg.h>
+#include <asm/cpu.h>
 
 static volatile uint64_t smp_call_mask = 0UL;
 

--- a/hypervisor/common/notify.c
+++ b/hypervisor/common/notify.c
@@ -10,6 +10,7 @@
 #include <asm/per_cpu.h>
 #include <asm/notify.h>
 #include <common/notify.h>
+#include <debug/logmsg.h>
 
 static volatile uint64_t smp_call_mask = 0UL;
 

--- a/hypervisor/common/percpu.c
+++ b/hypervisor/common/percpu.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2023-2024 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+#include <types.h>
+#include <per_cpu.h>
+
+struct per_cpu_region per_cpu_data[MAX_PCPU_NUM] __aligned(PAGE_SIZE);

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -5,7 +5,7 @@
  */
 
 #include <hash.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/guest/vm.h>
 #include <softirq.h>
 #include <ptdev.h>

--- a/hypervisor/common/sbuf.c
+++ b/hypervisor/common/sbuf.c
@@ -13,7 +13,7 @@
 #include <rtl.h>
 #include <errno.h>
 #include <asm/cpu.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <vm_event.h>
 
 uint32_t sbuf_next_ptr(uint32_t pos_arg,

--- a/hypervisor/common/sched_bvt.c
+++ b/hypervisor/common/sched_bvt.c
@@ -5,7 +5,7 @@
  */
 
 #include <list.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <schedule.h>
 #include <ticks.h>
 

--- a/hypervisor/common/sched_iorr.c
+++ b/hypervisor/common/sched_iorr.c
@@ -5,7 +5,7 @@
  */
 
 #include <list.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <schedule.h>
 #include <ticks.h>
 

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -8,7 +8,7 @@
 #include <list.h>
 #include <asm/lib/bits.h>
 #include <asm/cpu.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/lapic.h>
 #include <schedule.h>
 #include <sprintf.h>

--- a/hypervisor/common/softirq.c
+++ b/hypervisor/common/softirq.c
@@ -7,7 +7,7 @@
 #include <types.h>
 #include <asm/lib/bits.h>
 #include <asm/cpu.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <softirq.h>
 
 static softirq_handler softirq_handlers[NR_SOFTIRQS];

--- a/hypervisor/common/thermal.c
+++ b/hypervisor/common/thermal.c
@@ -9,6 +9,7 @@
 #include <trace.h>
 #include <asm/guest/virq.h>
 #include <hw/hw_thermal.h>
+#include <per_cpu.h>
 
 static void thermal_softirq(uint16_t pcpu_id)
 {

--- a/hypervisor/common/timer.c
+++ b/hypervisor/common/timer.c
@@ -6,6 +6,7 @@
 
 #include <types.h>
 #include <errno.h>
+#include <per_cpu.h>
 #include <asm/io.h>
 #include <asm/msr.h>
 #include <asm/apicreg.h>

--- a/hypervisor/debug/hypercall.c
+++ b/hypervisor/debug/hypercall.c
@@ -12,6 +12,7 @@
 #include <npk_log.h>
 #include <asm/guest/vm.h>
 #include <logmsg.h>
+#include <cpu.h>
 
 #ifdef PROFILING_ON
 /**

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -5,10 +5,11 @@
  */
 
 #include <types.h>
+
+#include <per_cpu.h>
 #include <asm/lib/atomic.h>
 #include <sprintf.h>
 #include <asm/lib/spinlock.h>
-#include <asm/per_cpu.h>
 #include <npk_log.h>
 #include <logmsg.h>
 #include <ticks.h>

--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -7,7 +7,7 @@
 #include <asm/lib/atomic.h>
 #include <acrn_hv_defs.h>
 #include <asm/io.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/mmu.h>
 #include <logmsg.h>
 #include <npk_log.h>

--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -11,6 +11,7 @@
 #include <asm/mmu.h>
 #include <logmsg.h>
 #include <npk_log.h>
+#include <cpu.h>
 
 static int32_t npk_log_setup_ref;
 static bool npk_log_enabled;

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -16,6 +16,7 @@
 #include <sprintf.h>
 #include <logmsg.h>
 #include <ticks.h>
+#include <cpu.h>
 
 #define DBG_LEVEL_PROFILING		5U
 #define DBG_LEVEL_ERR_PROFILING		3U

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -13,7 +13,7 @@
 #include <rtl.h>
 #include <errno.h>
 #include <asm/cpu.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 
 int32_t sbuf_share_setup(uint16_t pcpu_id, uint32_t sbuf_id, uint64_t *hva)
 {

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <asm/cpu.h>
 #include <per_cpu.h>
+#include <cpu.h>
 
 int32_t sbuf_share_setup(uint16_t pcpu_id, uint32_t sbuf_id, uint64_t *hva)
 {

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -10,7 +10,7 @@
 #include "shell_priv.h"
 #include <asm/irq.h>
 #include <console.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <asm/vmx.h>
 #include <asm/cpuid.h>
 #include <asm/ioapic.h>

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -22,6 +22,7 @@
 #include <shell.h>
 #include <asm/guest/vmcs.h>
 #include <asm/host_pm.h>
+#include <cpu.h>
 
 #define TEMP_STR_SIZE		60U
 #define MAX_STR_SIZE		256U

--- a/hypervisor/debug/trace.c
+++ b/hypervisor/debug/trace.c
@@ -5,7 +5,7 @@
  */
 
 #include <types.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <ticks.h>
 #include <trace.h>
 

--- a/hypervisor/include/arch/riscv/asm/cpu.h
+++ b/hypervisor/include/arch/riscv/asm/cpu.h
@@ -11,30 +11,12 @@
 #include <types.h>
 #include <lib/util.h>
 
-/* CPU states defined */
-enum pcpu_boot_state {
-        PCPU_STATE_RESET = 0U,
-        PCPU_STATE_INITIALIZING,
-        PCPU_STATE_RUNNING,
-        PCPU_STATE_HALTED,
-        PCPU_STATE_DEAD,
-};
-
 static inline void wait_sync_change(__unused volatile const uint64_t *sync, __unused uint64_t wake_sync)
 {
 	/**
 	 * Dummy implementation.
 	 * Official implementations are to be provided in the platform initialization patchset (by Hang).
 	 */
-}
-
-static inline bool is_pcpu_active(__unused uint16_t pcpu_id)
-{
-	/**
-	 * Dummy implementation.
-	 * Official implementations are to be provided in the platform initialization patchset (by Hang).
-	 */
-	return true;
 }
 
 static inline uint16_t get_pcpu_id(void)

--- a/hypervisor/include/arch/riscv/asm/cpu.h
+++ b/hypervisor/include/arch/riscv/asm/cpu.h
@@ -10,14 +10,12 @@
 
 #include <types.h>
 #include <lib/util.h>
+#include <debug/logmsg.h>
+#include <board_info.h>
 
-static inline void wait_sync_change(__unused volatile const uint64_t *sync, __unused uint64_t wake_sync)
-{
-	/**
-	 * Dummy implementation.
-	 * Official implementations are to be provided in the platform initialization patchset (by Hang).
-	 */
-}
+#define barrier()	__asm__ __volatile__("fence": : :"memory")
+#define cpu_relax()	barrier() /* TODO: replace with yield instruction */
+#define NR_CPUS		MAX_PCPU_NUM
 
 static inline uint16_t get_pcpu_id(void)
 {
@@ -35,5 +33,7 @@ static inline uint16_t get_pcpu_id(void)
 	asm volatile (" csrw " STRINGIFY(reg) ", %0 \n\t"		\
 			:: "r"(val): "memory");	 			\
 })
+
+void wait_sync_change(volatile const uint64_t *sync, uint64_t wake_sync);
 
 #endif /* RISCV_CPU_H */

--- a/hypervisor/include/arch/riscv/asm/cpu.h
+++ b/hypervisor/include/arch/riscv/asm/cpu.h
@@ -11,6 +11,15 @@
 #include <types.h>
 #include <lib/util.h>
 
+/* CPU states defined */
+enum pcpu_boot_state {
+        PCPU_STATE_RESET = 0U,
+        PCPU_STATE_INITIALIZING,
+        PCPU_STATE_RUNNING,
+        PCPU_STATE_HALTED,
+        PCPU_STATE_DEAD,
+};
+
 static inline void wait_sync_change(__unused volatile const uint64_t *sync, __unused uint64_t wake_sync)
 {
 	/**

--- a/hypervisor/include/arch/riscv/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/riscv/asm/guest/vcpu.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2023-2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef RISCV_VCPU_H
+#define RISCV_VCPU_H
+
+struct acrn_vcpu {
+
+};
+
+#endif /* RISCV_VCPU_H */

--- a/hypervisor/include/arch/riscv/asm/guest/vm.h
+++ b/hypervisor/include/arch/riscv/asm/guest/vm.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2023-2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef VM_H_
+#define VM_H_
+
+struct acrn_vm {
+
+};
+
+#endif /* VM_H_ */

--- a/hypervisor/include/arch/riscv/asm/lib/bits.h
+++ b/hypervisor/include/arch/riscv/asm/lib/bits.h
@@ -28,6 +28,14 @@ bool bitmap_test(__unused uint16_t nr, __unused const volatile uint64_t *addr)
 	return true;
 }
 
+void bitmap_set_lock(__unused uint16_t nr_arg, __unused volatile uint64_t *addr)
+{
+	/**
+	 * Dummy implementation.
+	 * Official implementations are to be provided in the library patchset (by Haoyu).
+	 */
+}
+
 void bitmap_clear_lock(__unused uint16_t nr_arg, __unused volatile uint64_t *addr)
 {
 	/**

--- a/hypervisor/include/arch/riscv/asm/lib/spinlock.h
+++ b/hypervisor/include/arch/riscv/asm/lib/spinlock.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2023-2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+#ifndef __RISCV_LIB_SPINLOCK_H__
+#define __RISCV_LIB_SPINLOCK_H__
+
+typedef struct _spinlock {
+
+} spinlock_t;
+
+#endif /* __RISCV_LIB_SPINLOCK_H__ */

--- a/hypervisor/include/arch/riscv/asm/page.h
+++ b/hypervisor/include/arch/riscv/asm/page.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2023-2024 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+#ifndef __RISCV_PAGE_H__
+#define __RISCV_PAGE_H__
+
+#define PAGE_SHIFT		12
+#define PAGE_SIZE		(1 << PAGE_SHIFT)
+
+#endif /* __RISCV_PAGE_H__ */

--- a/hypervisor/include/arch/riscv/asm/per_cpu.h
+++ b/hypervisor/include/arch/riscv/asm/per_cpu.h
@@ -12,6 +12,8 @@
 
 #include <common/notify.h>
 #include <types.h>
+#include <board_info.h>
+#include <asm/page.h>
 
 struct per_cpu_region {
 	struct smp_call_info_data smp_call_info;

--- a/hypervisor/include/arch/riscv/asm/per_cpu.h
+++ b/hypervisor/include/arch/riscv/asm/per_cpu.h
@@ -10,20 +10,12 @@
 #ifndef RISCV_PERCPU_H
 #define RISCV_PERCPU_H
 
-#include <common/notify.h>
 #include <types.h>
-#include <board_info.h>
 #include <asm/page.h>
 
-struct per_cpu_region {
-	struct smp_call_info_data smp_call_info;
+struct per_cpu_arch {
+
 } __aligned(PAGE_SIZE); /* per_cpu_region size aligned with PAGE_SIZE */
 
-extern struct per_cpu_region per_cpu_data[MAX_PCPU_NUM];
-/*
- * get percpu data for pcpu_id.
- */
-#define per_cpu(name, pcpu_id)	\
-	(per_cpu_data[(pcpu_id)].name)
 
 #endif /* RISCV_PERCPU_H */

--- a/hypervisor/include/arch/riscv/asm/security.h
+++ b/hypervisor/include/arch/riscv/asm/security.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2023-2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef SECURITY_H
+#define SECURITY_H
+
+
+struct stack_canary {
+
+};
+
+
+
+#endif /* SECURITY_H */

--- a/hypervisor/include/arch/riscv/asm/vm_config.h
+++ b/hypervisor/include/arch/riscv/asm/vm_config.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2023-2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+#ifndef VM_CONFIG_H_
+#define VM_CONFIG_H_
+#include <board_info.h>
+
+#define MAX_VCPUS_PER_VM  MAX_PCPU_NUM
+#define CONFIG_MAX_VM_NUM 16U
+
+#endif /* VM_CONFIG_H_ */

--- a/hypervisor/include/arch/x86/asm/cpu.h
+++ b/hypervisor/include/arch/x86/asm/cpu.h
@@ -201,9 +201,6 @@
 
 #ifndef ASSEMBLER
 
-#define ALL_CPUS_MASK		((1UL << get_pcpu_nums()) - 1UL)
-#define AP_MASK			(ALL_CPUS_MASK & ~(1UL << BSP_CPU_ID))
-
 /**
  *
  * Identifiers for architecturally defined registers.
@@ -310,15 +307,6 @@ struct descriptor_table {
 	uint16_t limit;
 	uint64_t base;
 } __packed;
-
-/* CPU states defined */
-enum pcpu_boot_state {
-	PCPU_STATE_RESET = 0U,
-	PCPU_STATE_INITIALIZING,
-	PCPU_STATE_RUNNING,
-	PCPU_STATE_HALTED,
-	PCPU_STATE_DEAD,
-};
 
 #define	NEED_OFFLINE		(1U)
 #define	NEED_SHUTDOWN_VM	(2U)
@@ -808,12 +796,6 @@ static inline void clac(void)
 	asm volatile ("clac" : : : "memory");
 }
 
-/*
- * @post return <= MAX_PCPU_NUM
- */
-uint16_t get_pcpu_nums(void);
-bool is_pcpu_active(uint16_t pcpu_id);
-uint64_t get_active_pcpu_bitmap(void);
 #else /* ASSEMBLER defined */
 
 #endif /* ASSEMBLER defined */

--- a/hypervisor/include/arch/x86/asm/per_cpu.h
+++ b/hypervisor/include/arch/x86/asm/per_cpu.h
@@ -4,84 +4,34 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef PER_CPU_H
-#define PER_CPU_H
+#ifndef PER_CPU_X86_H
+#define PER_CPU_X86_H
 
 #include <types.h>
-#include <sbuf.h>
-#include <irq.h>
-#include <timer.h>
-#include <profiling.h>
-#include <logmsg.h>
-#include <schedule.h>
 #include <asm/page.h>
+#include <profiling.h>
 #include <asm/gdt.h>
 #include <asm/security.h>
 #include <asm/vm_config.h>
-#include <common/notify.h>
 
-struct per_cpu_region {
+struct per_cpu_arch {
 	/* vmxon_region MUST be 4KB-aligned */
 	uint8_t vmxon_region[PAGE_SIZE];
 	void *vmcs_run;
-#ifdef HV_DEBUG
-	struct shared_buf *sbuf[ACRN_SBUF_PER_PCPU_ID_MAX];
-	char logbuf[LOG_MESSAGE_MAX_SIZE];
-	uint32_t npk_log_ref;
-#endif
-	uint64_t irq_count[NR_IRQS];
-	uint64_t softirq_pending;
-	uint64_t spurious;
-	struct acrn_vcpu *ever_run_vcpu;
-#ifdef STACK_PROTECTOR
-	struct stack_canary stk_canary;
-#endif
-	struct per_cpu_timers cpu_timers;
-	struct sched_control sched_ctl;
-	struct sched_noop_control sched_noop_ctl;
-	struct sched_iorr_control sched_iorr_ctl;
-	struct sched_bvt_control sched_bvt_ctl;
-	struct sched_prio_control sched_prio_ctl;
-	struct thread_object idle;
 	struct host_gdt gdt;
 	struct tss_64 tss;
-	enum pcpu_boot_state boot_state;
-	uint64_t pcpu_flag;
 	uint8_t mc_stack[CONFIG_STACK_SIZE] __aligned(16);
 	uint8_t df_stack[CONFIG_STACK_SIZE] __aligned(16);
 	uint8_t sf_stack[CONFIG_STACK_SIZE] __aligned(16);
-	uint8_t stack[CONFIG_STACK_SIZE] __aligned(16);
 	uint32_t lapic_id;
 	uint32_t lapic_ldr;
-	uint32_t softirq_servicing;
-	uint32_t mode_to_kick_pcpu;
-	uint32_t mode_to_idle;
-	struct smp_call_info_data smp_call_info;
-	struct list_head softirq_dev_entry_list;
 #ifdef PROFILING_ON
 	struct profiling_info_wrapper profiling_info;
 #endif
-	uint64_t shutdown_vm_bitmap;
 	uint64_t tsc_suspend;
 	struct acrn_vcpu *whose_iwkey;
-	/*
-	 * We maintain a per-pCPU array of vCPUs. vCPUs of a VM won't
-	 * share same pCPU. So the maximum possible # of vCPUs that can
-	 * run on a pCPU is CONFIG_MAX_VM_NUM.
-	 * vcpu_array address must be aligned to 64-bit for atomic access
-	 * to avoid contention between offline_vcpu and posted interrupt handler
-	 */
-	struct acrn_vcpu *vcpu_array[CONFIG_MAX_VM_NUM] __aligned(8);
+
 } __aligned(PAGE_SIZE); /* per_cpu_region size aligned with PAGE_SIZE */
 
-extern struct per_cpu_region per_cpu_data[MAX_PCPU_NUM];
-/*
- * get percpu data for pcpu_id.
- */
-#define per_cpu(name, pcpu_id)	\
-	(per_cpu_data[(pcpu_id)].name)
-
-/* get percpu data for current pcpu */
-#define get_cpu_var(name)	per_cpu(name, get_pcpu_id())
 
 #endif

--- a/hypervisor/include/common/cpu.h
+++ b/hypervisor/include/common/cpu.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef COMMON_CPU_H
+#define COMMON_CPU_H
+
+#include <types.h>
+#include <asm/cpu.h>
+
+/* CPU states defined */
+enum pcpu_boot_state {
+        PCPU_STATE_RESET = 0U,
+        PCPU_STATE_INITIALIZING,
+        PCPU_STATE_RUNNING,
+        PCPU_STATE_HALTED,
+        PCPU_STATE_DEAD,
+};
+uint16_t arch_get_pcpu_num(void);
+uint16_t get_pcpu_nums(void);
+bool is_pcpu_active(uint16_t pcpu_id);
+void set_pcpu_active(uint16_t pcpu_id);
+void clear_pcpu_active(uint16_t pcpu_id);
+bool check_pcpus_active(uint64_t mask);
+bool check_pcpus_inactive(uint64_t mask);
+uint64_t get_active_pcpu_bitmap(void);
+
+#define ALL_CPUS_MASK		((1UL << get_pcpu_nums()) - 1UL)
+#define AP_MASK			(ALL_CPUS_MASK & ~(1UL << BSP_CPU_ID))
+
+#endif /* COMMON_CPU_H */

--- a/hypervisor/include/common/per_cpu.h
+++ b/hypervisor/include/common/per_cpu.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2018-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PER_CPU_H
+#define PER_CPU_H
+
+#include <types.h>
+#include <sbuf.h>
+#include <irq.h>
+#include <timer.h>
+#include <logmsg.h>
+#include <schedule.h>
+#include <asm/page.h>
+#include <asm/vm_config.h>
+#include <asm/per_cpu.h>
+#include <asm/security.h>
+#include <notify.h>
+#include <asm/cpu.h>
+#include <board_info.h>
+
+
+struct per_cpu_region {
+	/*
+	 * X86 arch percpu struct member vmxon_region
+	 * need to be page size aligned, so we keep it
+	 * on top to same memory,
+	 */
+	struct per_cpu_arch arch;
+	uint64_t irq_count[NR_IRQS];
+	uint64_t softirq_pending;
+	uint64_t spurious;
+	struct acrn_vcpu *ever_run_vcpu;
+#ifdef STACK_PROTECTOR
+	struct stack_canary stk_canary;
+#endif
+	struct per_cpu_timers cpu_timers;
+	/*TODO: we only need sched_ctl as configured,
+	  not neccessarily to have them all */
+	struct sched_control sched_ctl;
+	struct sched_noop_control sched_noop_ctl;
+	struct sched_iorr_control sched_iorr_ctl;
+	struct sched_bvt_control sched_bvt_ctl;
+	struct sched_prio_control sched_prio_ctl;
+	struct thread_object idle;
+	uint64_t pcpu_flag;
+	uint32_t softirq_servicing;
+	uint32_t mode_to_kick_pcpu;
+	uint32_t mode_to_idle;
+	struct smp_call_info_data smp_call_info;
+	struct list_head softirq_dev_entry_list;
+	enum pcpu_boot_state boot_state;
+	uint8_t stack[CONFIG_STACK_SIZE] __aligned(16);
+	uint64_t shutdown_vm_bitmap;
+	/*
+	 * We maintain a per-pCPU array of vCPUs. vCPUs of a VM won't
+	 * share same pCPU. So the maximum possible # of vCPUs that can
+	 * run on a pCPU is CONFIG_MAX_VM_NUM.
+	 * vcpu_array address must be aligned to 64-bit for atomic access
+	 * to avoid contention between offline_vcpu and posted interrupt handler
+	 */
+	struct acrn_vcpu *vcpu_array[CONFIG_MAX_VM_NUM] __aligned(8);
+#ifdef HV_DEBUG
+	struct shared_buf *sbuf[ACRN_SBUF_PER_PCPU_ID_MAX];
+	char logbuf[LOG_MESSAGE_MAX_SIZE];
+	uint32_t npk_log_ref;
+#endif
+
+} __aligned(PAGE_SIZE); /* per_cpu_region size aligned with PAGE_SIZE */
+
+extern struct per_cpu_region per_cpu_data[MAX_PCPU_NUM];
+/*
+ * get percpu data for pcpu_id.
+ */
+#define per_cpu(member_path, pcpu_id)	\
+	(per_cpu_data[(pcpu_id)].member_path)
+
+/* get percpu data for current pcpu */
+#define get_cpu_var(member_path)	per_cpu(member_path, get_pcpu_id())
+
+#endif /* PER_CPU_H */

--- a/hypervisor/include/common/per_cpu.h
+++ b/hypervisor/include/common/per_cpu.h
@@ -18,7 +18,7 @@
 #include <asm/per_cpu.h>
 #include <asm/security.h>
 #include <notify.h>
-#include <asm/cpu.h>
+#include <cpu.h>
 #include <board_info.h>
 
 


### PR DESCRIPTION
this pull request combine two patch sets.
HV: multiarch: percpu structure abstraction:

Enable common riscv code compile, and compile passed. Move arch independent percpu member to common code, and add struct per_cpu_arch for x86 and riscv to define, by now, a dummy struct has been added for riscv. Move boot_state structure to common cpu.h.

Changelog:
v2->v3:
move whose_iwkey, profiling_info and tsc_suspend to x86
v1->v2:
1. add dummy header to pass compilation
2. rebased on latest repo
3. remove function init_percpu_areas
4. move stack and boot_state member back to common

HV: multiarch: abstract some pcpu data to common

This patch-set move x86 arch dependent pcpu related data like pcpu_active_map to common
and add some functions to access them. Change function name arch_get_num_available_cpus to arch_get_pcpu_num.
Changelog:
v2-> v3:
1. move ALL_CPUS_MASK/AP_MASK to common cpu.h
2. remove include asm/cpu.h in riscv cpu.c

v1-> v2:
1. preserve phys_cpu_num in x86 but implement arch_get_num_available_cpus()
   for both arch to provide interface for common code to access.
2. change function name test_xx to check_xx

Tracked-On: #8801


