### PR TITLE
enable library support for risc-v arch

### DIFF
--- a/doc/developer-guides/hld/hv-cpu-virt.rst
+++ b/doc/developer-guides/hld/hv-cpu-virt.rst
@@ -465,7 +465,7 @@ running). See :ref:`vcpu-request-interrupt-injection` for details.
    {
       uint16_t pcpu_id = pcpuid_from_vcpu(vcpu);
 
-      bitmap_set_lock(eventid, &vcpu->arch_vcpu.pending_req);
+      bitmap_set(eventid, &vcpu->arch_vcpu.pending_req);
       /*
        * if current hostcpu is not the target vcpu's hostcpu, we need
        * to invoke IPI to wake up target vcpu

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -149,9 +149,11 @@ endif
 # all the work.
 #
 COMMON_C_SRCS += common/notify.c
-COMMON_C_SRCS += lib/memory.c
 COMMON_C_SRCS += common/percpu.c
 COMMON_C_SRCS += common/cpu.c
+COMMON_C_SRCS += lib/memory.c
+COMMON_C_SRCS += lib/bits.c
+
 
 ifeq ($(ARCH),x86)
 COMMON_C_SRCS += common/ticks.c

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -154,6 +154,17 @@ COMMON_C_SRCS += common/cpu.c
 COMMON_C_SRCS += lib/memory.c
 COMMON_C_SRCS += lib/bits.c
 
+# library componment
+COMMON_C_SRCS += lib/string.c
+COMMON_C_SRCS += lib/crypto/crypto_api.c
+COMMON_C_SRCS += lib/crypto/mbedtls/hkdf.c
+COMMON_C_SRCS += lib/crypto/mbedtls/sha256.c
+COMMON_C_SRCS += lib/crypto/mbedtls/md.c
+COMMON_C_SRCS += lib/crypto/mbedtls/md_wrap.c
+COMMON_C_SRCS += lib/sprintf.c
+ifdef STACK_PROTECTOR
+COMMON_C_SRCS += lib/stack_protector.c
+endif
 
 ifeq ($(ARCH),x86)
 COMMON_C_SRCS += common/ticks.c

--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,7 +7,7 @@
 #include <types.h>
 #include <logmsg.h>
 #include <asm/io.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <asm/cpu_caps.h>
 #include <pci.h>
 #include <asm/vtd.h>

--- a/hypervisor/arch/x86/Makefile
+++ b/hypervisor/arch/x86/Makefile
@@ -40,17 +40,7 @@ endif
 ASFLAGS += -m64 -nostdinc -nostdlib
 
 # library componment
-LIB_C_SRCS += lib/string.c
-LIB_C_SRCS += lib/crypto/crypto_api.c
-LIB_C_SRCS += lib/crypto/mbedtls/hkdf.c
-LIB_C_SRCS += lib/crypto/mbedtls/sha256.c
-LIB_C_SRCS += lib/crypto/mbedtls/md.c
-LIB_C_SRCS += lib/crypto/mbedtls/md_wrap.c
-LIB_C_SRCS += lib/sprintf.c
 LIB_C_SRCS += arch/x86/lib/memory.c
-ifdef STACK_PROTECTOR
-LIB_C_SRCS += lib/stack_protector.c
-endif
 
 # retpoline support
 ifeq (true, $(shell [ $(GCC_MAJOR) -eq 7 ] && [ $(GCC_MINOR) -ge 3 ] && echo true))

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -1,12 +1,12 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <types.h>
 #include <errno.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <asm/guest/vm.h>
 #include <asm/vtd.h>
 #include <ptdev.h>
@@ -67,7 +67,7 @@ static uint32_t calculate_logical_dest_mask(uint64_t pdmask)
 		 */
 		dest_cluster_id = per_cpu(arch.lapic_ldr, pcpu_id) & X2APIC_LDR_CLUSTER_ID_MASK;
 		do {
-			bitmap_clear_nolock(pcpu_id, &pcpu_mask);
+			bitmap_clear_non_atomic(pcpu_id, &pcpu_mask);
 			cluster_id = per_cpu(arch.lapic_ldr, pcpu_id) & X2APIC_LDR_CLUSTER_ID_MASK;
 			if (cluster_id == dest_cluster_id) {
 				logical_id_mask |= (per_cpu(arch.lapic_ldr, pcpu_id) & X2APIC_LDR_LOGICAL_ID_MASK);

--- a/hypervisor/arch/x86/guest/nested.c
+++ b/hypervisor/arch/x86/guest/nested.c
@@ -398,7 +398,7 @@ static void setup_vmcs_shadowing_bitmap(void)
 	for (field_index = 0U; field_index < MAX_SHADOW_VMCS_FIELDS; field_index++) {
 		bit_pos = vmcs_shadowing_fields[field_index] % 64U;
 		array_index = vmcs_shadowing_fields[field_index] / 64U;
-		bitmap_clear_nolock(bit_pos, &vmcs_shadowing_bitmap[array_index]);
+		bitmap_clear_non_atomic(bit_pos, &vmcs_shadowing_bitmap[array_index]);
 	}
 }
 
@@ -1338,8 +1338,8 @@ static void set_vmcs01_guest_state(struct acrn_vcpu *vcpu)
 		 */
 		exec_vmwrite(VMX_GUEST_CR0, vmcs12->host_cr0);
 		exec_vmwrite(VMX_GUEST_CR4, vmcs12->host_cr4);
-		bitmap_clear_nolock(CPU_REG_CR0, &vcpu->reg_cached);
-		bitmap_clear_nolock(CPU_REG_CR4, &vcpu->reg_cached);
+		bitmap_clear_non_atomic(CPU_REG_CR0, &vcpu->reg_cached);
+		bitmap_clear_non_atomic(CPU_REG_CR4, &vcpu->reg_cached);
 
 		exec_vmwrite(VMX_GUEST_CR3, vmcs12->host_cr3);
 		exec_vmwrite(VMX_GUEST_DR7, DR7_INIT_VALUE);

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -167,7 +167,7 @@ static inline void enter_s5(struct acrn_vcpu *vcpu, uint32_t pm1a_cnt_val, uint3
 	pause_vm(vm);
 	put_vm_lock(vm);
 
-	bitmap_set_nolock(vm->vm_id, &per_cpu(shutdown_vm_bitmap, pcpu_id));
+	bitmap_set_non_atomic(vm->vm_id, &per_cpu(shutdown_vm_bitmap, pcpu_id));
 	make_shutdown_vm_request(pcpu_id);
 }
 
@@ -352,7 +352,7 @@ static bool prelaunched_vm_sleep_io_write(struct acrn_vcpu *vcpu, uint16_t addr,
 			pause_vm(vm);
 			put_vm_lock(vm);
 
-			bitmap_set_nolock(vm->vm_id, &per_cpu(shutdown_vm_bitmap, pcpuid_from_vcpu(vcpu)));
+			bitmap_set_non_atomic(vm->vm_id, &per_cpu(shutdown_vm_bitmap, pcpuid_from_vcpu(vcpu)));
 			make_shutdown_vm_request(pcpuid_from_vcpu(vcpu));
 		}
 	}

--- a/hypervisor/arch/x86/guest/trusty.c
+++ b/hypervisor/arch/x86/guest/trusty.c
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <types.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <crypto_api.h>
 #include <asm/guest/trusty.h>
 #include <asm/page.h>
@@ -165,12 +165,12 @@ static void load_world_ctx(struct acrn_vcpu *vcpu, const struct ext_context *ext
 	uint32_t i;
 
 	/* mark to update on-demand run_context for efer/rflags/rsp/rip/cr0/cr4 */
-	bitmap_set_nolock(CPU_REG_EFER, &vcpu->reg_updated);
-	bitmap_set_nolock(CPU_REG_RFLAGS, &vcpu->reg_updated);
-	bitmap_set_nolock(CPU_REG_RSP, &vcpu->reg_updated);
-	bitmap_set_nolock(CPU_REG_RIP, &vcpu->reg_updated);
-	bitmap_set_nolock(CPU_REG_CR0, &vcpu->reg_updated);
-	bitmap_set_nolock(CPU_REG_CR4, &vcpu->reg_updated);
+	bitmap_set_non_atomic(CPU_REG_EFER, &vcpu->reg_updated);
+	bitmap_set_non_atomic(CPU_REG_RFLAGS, &vcpu->reg_updated);
+	bitmap_set_non_atomic(CPU_REG_RSP, &vcpu->reg_updated);
+	bitmap_set_non_atomic(CPU_REG_RIP, &vcpu->reg_updated);
+	bitmap_set_non_atomic(CPU_REG_CR0, &vcpu->reg_updated);
+	bitmap_set_non_atomic(CPU_REG_CR4, &vcpu->reg_updated);
 
 	/* VMCS Execution field */
 	exec_vmwrite64(VMX_TSC_OFFSET_FULL, ext_ctx->tsc_offset);

--- a/hypervisor/arch/x86/guest/ucode.c
+++ b/hypervisor/arch/x86/guest/ucode.c
@@ -1,12 +1,12 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <types.h>
 #include <errno.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <asm/cpu.h>
 #include <asm/msr.h>
 #include <asm/cpuid.h>

--- a/hypervisor/arch/x86/guest/vcat.c
+++ b/hypervisor/arch/x86/guest/vcat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Intel Corporation.
+ * Copyright (C) 2021-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,7 +10,7 @@
 #include <asm/cpufeatures.h>
 #include <asm/cpuid.h>
 #include <asm/rdt.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <asm/board.h>
 #include <asm/vm_config.h>
 #include <asm/msr.h>

--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -1,12 +1,12 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <types.h>
 #include <errno.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <asm/guest/vcpu.h>
 #include <asm/guest/vm.h>
 #include <asm/cpuid.h>

--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -8,7 +8,7 @@
 
 #include <types.h>
 #include <errno.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <asm/guest/virq.h>
 #include <asm/mmu.h>
 #include <asm/guest/vcpu.h>
@@ -318,7 +318,7 @@ static void vmx_write_cr0(struct acrn_vcpu *vcpu, uint64_t value)
 			exec_vmwrite(VMX_CR0_READ_SHADOW, effective_cr0);
 
 			/* clear read cache, next time read should from VMCS */
-			bitmap_clear_nolock(CPU_REG_CR0, &vcpu->reg_cached);
+			bitmap_clear_non_atomic(CPU_REG_CR0, &vcpu->reg_cached);
 
 			pr_dbg("VMM: Try to write %016lx, allow to write 0x%016lx to CR0", effective_cr0, tmp);
 		}
@@ -420,7 +420,7 @@ static void vmx_write_cr4(struct acrn_vcpu *vcpu, uint64_t cr4)
 			exec_vmwrite(VMX_CR4_READ_SHADOW, cr4);
 
 			/* clear read cache, next time read should from VMCS */
-			bitmap_clear_nolock(CPU_REG_CR4, &vcpu->reg_cached);
+			bitmap_clear_non_atomic(CPU_REG_CR4, &vcpu->reg_cached);
 
 			pr_dbg("VMM: Try to write %016lx, allow to write 0x%016lx to CR4", cr4, tmp);
 		}
@@ -521,7 +521,7 @@ uint64_t vcpu_get_cr0(struct acrn_vcpu *vcpu)
 {
 	struct run_context *ctx = &vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
-	if (bitmap_test_and_set_nolock(CPU_REG_CR0, &vcpu->reg_cached) == 0) {
+	if (bitmap_test_and_set_non_atomic(CPU_REG_CR0, &vcpu->reg_cached) == 0) {
 		ctx->cr0 = (exec_vmread(VMX_CR0_READ_SHADOW) & ~cr0_passthru_mask) |
 			(exec_vmread(VMX_GUEST_CR0) & cr0_passthru_mask);
 	}
@@ -549,7 +549,7 @@ uint64_t vcpu_get_cr4(struct acrn_vcpu *vcpu)
 {
 	struct run_context *ctx = &vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
-	if (bitmap_test_and_set_nolock(CPU_REG_CR4, &vcpu->reg_cached) == 0) {
+	if (bitmap_test_and_set_non_atomic(CPU_REG_CR4, &vcpu->reg_cached) == 0) {
 		ctx->cr4 = (exec_vmread(VMX_CR4_READ_SHADOW) & ~cr4_passthru_mask) |
 			(exec_vmread(VMX_GUEST_CR4) & cr4_passthru_mask);
 	}

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2017-2022 Intel Corporation.
+ * Copyright (c) 2017-2025 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,7 +31,7 @@
 #include <types.h>
 #include <errno.h>
 #include <asm/lib/bits.h>
-#include <asm/lib/atomic.h>
+#include <atomic.h>
 #include <per_cpu.h>
 #include <asm/pgtable.h>
 #include <asm/lapic.h>

--- a/hypervisor/arch/x86/guest/vm_reset.c
+++ b/hypervisor/arch/x86/guest/vm_reset.c
@@ -59,7 +59,7 @@ void triple_fault_shutdown_vm(struct acrn_vcpu *vcpu)
 		pause_vm(vm);
 		put_vm_lock(vm);
 
-		bitmap_set_nolock(vm->vm_id,
+		bitmap_set_non_atomic(vm->vm_id,
 				&per_cpu(shutdown_vm_bitmap, pcpuid_from_vcpu(vcpu)));
 		make_shutdown_vm_request(pcpuid_from_vcpu(vcpu));
 	}
@@ -109,7 +109,7 @@ static bool handle_common_reset_reg_write(struct acrn_vcpu *vcpu, bool reset, bo
 			 * ACRN doesn't support re-launch, just shutdown the guest.
 			 */
 			pause_vm(vm);
-			bitmap_set_nolock(vm->vm_id,
+			bitmap_set_non_atomic(vm->vm_id,
 					&per_cpu(shutdown_vm_bitmap, pcpuid_from_vcpu(vcpu)));
 			make_shutdown_vm_request(pcpuid_from_vcpu(vcpu));
 		}
@@ -250,6 +250,6 @@ void shutdown_vm_from_idle(uint16_t pcpu_id)
 			(void)shutdown_vm(vm);
 		}
 		put_vm_lock(vm);
-		bitmap_clear_nolock(vm_id, vms);
+		bitmap_clear_non_atomic(vm_id, vms);
 	}
 }

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -1,12 +1,12 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <types.h>
 #include <errno.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <asm/guest/vcpu.h>
 #include <asm/guest/vm.h>
 #include <asm/guest/virq.h>

--- a/hypervisor/arch/x86/guest/vmx_io.c
+++ b/hypervisor/arch/x86/guest/vmx_io.c
@@ -1,12 +1,12 @@
 /*
- * Copyright (C) 2019-2022 Intel Corporation.
+ * Copyright (C) 2019-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <types.h>
 #include <errno.h>
-#include <asm/lib/atomic.h>
+#include <atomic.h>
 #include <io_req.h>
 #include <asm/guest/vcpu.h>
 #include <asm/guest/vm.h>

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -8,7 +8,7 @@
 #include <errno.h>
 #include <cpu.h>
 #include <irq.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <asm/ioapic.h>
 #include <asm/irq.h>
 #include <asm/pgtable.h>

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -1,12 +1,12 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <types.h>
 #include <asm/lib/bits.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <per_cpu.h>
 #include <asm/io.h>
 #include <asm/irq.h>

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -5,7 +5,7 @@
  */
 
 #include <types.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <spinlock.h>
 #include <per_cpu.h>
 #include <asm/io.h>

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <types.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <asm/msr.h>
 #include <asm/cpu.h>
 #include <per_cpu.h>
@@ -248,7 +248,7 @@ void send_dest_ipi_mask(uint64_t dest_mask, uint32_t vector)
 
 	pcpu_id = ffs64(mask);
 	while (pcpu_id < MAX_PCPU_NUM) {
-		bitmap_clear_nolock(pcpu_id, &mask);
+		bitmap_clear_non_atomic(pcpu_id, &mask);
 		send_single_ipi(pcpu_id, vector);
 		pcpu_id = ffs64(mask);
 	}

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2017-2024 Intel Corporation.
+ * Copyright (c) 2017-2025 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,7 +27,7 @@
  */
 
 #include <types.h>
-#include <asm/lib/atomic.h>
+#include <atomic.h>
 #include <asm/cpufeatures.h>
 #include <asm/pgtable.h>
 #include <asm/cpu_caps.h>

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -7,7 +7,7 @@
 #include <types.h>
 #include <errno.h>
 #include <asm/lib/bits.h>
-#include <asm/lib/atomic.h>
+#include <atomic.h>
 #include <asm/irq.h>
 #include <asm/cpu.h>
 #include <asm/per_cpu.h>

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -6,8 +6,8 @@
 
 #include <types.h>
 #include <errno.h>
-#include <asm/lib/bits.h>
 #include <atomic.h>
+#include <bits.h>
 #include <asm/irq.h>
 #include <asm/cpu.h>
 #include <asm/per_cpu.h>

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2018-2024 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <types.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <asm/page.h>
 #include <logmsg.h>
 
@@ -33,7 +33,7 @@ struct page *alloc_page(struct page_pool *pool)
 		idx = loop_idx % pool->bitmap_size;
 		if (*(pool->bitmap + idx) != ~0UL) {
 			bit = ffz64(*(pool->bitmap + idx));
-			bitmap_set_nolock(bit, pool->bitmap + idx);
+			bitmap_set_non_atomic(bit, pool->bitmap + idx);
 			page = pool->start_page + ((idx << 6U) + bit);
 
 			pool->last_hint_id = idx;
@@ -67,7 +67,7 @@ void free_page(struct page_pool *pool, struct page *page)
 	spinlock_obtain(&pool->lock);
 	idx = (page - pool->start_page) >> 6U;
 	bit = (page - pool->start_page) & 0x3fUL;
-	bitmap_clear_nolock(bit, pool->bitmap + idx);
+	bitmap_clear_non_atomic(bit, pool->bitmap + idx);
 	spinlock_release(&pool->lock);
 }
 

--- a/hypervisor/arch/x86/rdt.c
+++ b/hypervisor/arch/x86/rdt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Intel Corporation.
+ * Copyright (C) 2020-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -12,7 +12,7 @@
 #include <errno.h>
 #include <logmsg.h>
 #include <asm/rdt.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <asm/board.h>
 #include <asm/vm_config.h>
 #include <asm/msr.h>

--- a/hypervisor/arch/x86/rtcm.c
+++ b/hypervisor/arch/x86/rtcm.c
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2020-2022 Intel Corporation.
+ * Copyright (C) 2020-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <types.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <rtl.h>
 #include <util.h>
 #include <logmsg.h>
@@ -142,7 +142,7 @@ bool init_software_sram(bool is_bsp)
 				/* Clear the NX bit of PTCM area */
 				set_paging_x((uint64_t)hpa2hva(rtcm_binary->address), rtcm_binary->size);
 			}
-			bitmap_clear_lock(get_pcpu_id(), &init_sw_sram_cpus_mask);
+			bitmap_clear(get_pcpu_id(), &init_sw_sram_cpus_mask);
 		}
 
 		wait_sync_change(&init_sw_sram_cpus_mask, 0UL);
@@ -167,7 +167,7 @@ bool init_software_sram(bool is_bsp)
 				set_paging_nx((uint64_t)hpa2hva(rtcm_binary->address), rtcm_binary->size);
 			}
 
-			bitmap_set_lock(get_pcpu_id(), &init_sw_sram_cpus_mask);
+			bitmap_set(get_pcpu_id(), &init_sw_sram_cpus_mask);
 			wait_sync_change(&init_sw_sram_cpus_mask, ALL_CPUS_MASK);
 			/* Flush the TLB on BSP and all APs to restore the NX for Software SRAM area */
 			flush_tlb_range((uint64_t)hpa2hva(rtcm_binary->address), rtcm_binary->size);

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -9,7 +9,7 @@
 #include <types.h>
 #include <errno.h>
 #include <asm/lib/bits.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <asm/cpu_caps.h>
 #include <irq.h>
 #include <asm/irq.h>

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -8,7 +8,7 @@
 
 #include <types.h>
 #include <errno.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <spinlock.h>
 #include <asm/cpu_caps.h>
 #include <irq.h>
@@ -1413,7 +1413,7 @@ void dmar_free_irte(const struct intr_source *intr_src, uint16_t index)
 
 		if (!is_irte_reserved(dmar_unit, index)) {
 			spinlock_obtain(&dmar_unit->lock);
-			bitmap_clear_nolock(index & 0x3FU, &dmar_unit->irte_alloc_bitmap[index >> 6U]);
+			bitmap_clear_non_atomic(index & 0x3FU, &dmar_unit->irte_alloc_bitmap[index >> 6U]);
 			spinlock_release(&dmar_unit->lock);
 		}
 	}

--- a/hypervisor/common/cpu.c
+++ b/hypervisor/common/cpu.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cpu.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 
 
 static volatile uint64_t pcpu_active_bitmap = 0UL;
@@ -24,13 +24,13 @@ bool is_pcpu_active(uint16_t pcpu_id)
 
 void set_pcpu_active(uint16_t pcpu_id)
 {
-	bitmap_set_lock(pcpu_id, &pcpu_active_bitmap);
+	bitmap_set(pcpu_id, &pcpu_active_bitmap);
 }
 
 void clear_pcpu_active(uint16_t pcpu_id)
 {
 
-	bitmap_clear_lock(pcpu_id, &pcpu_active_bitmap);
+	bitmap_clear(pcpu_id, &pcpu_active_bitmap);
 }
 
 bool check_pcpus_active(uint64_t mask)

--- a/hypervisor/common/irq.c
+++ b/hypervisor/common/irq.c
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2021-2022 Intel Corporation.
+ * Copyright (C) 2021-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <errno.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <irq.h>
 #include <common/softirq.h>
 #include <asm/irq.h>
@@ -40,10 +40,10 @@ static uint32_t alloc_irq_num(uint32_t req_irq, bool reserve)
 		if (irq >= NR_IRQS) {
 			irq = IRQ_INVALID;
 		} else {
-			bitmap_set_nolock((uint16_t)(irq & 0x3FU),
+			bitmap_set_non_atomic((uint16_t)(irq & 0x3FU),
 					irq_alloc_bitmap + (irq >> 6U));
 			if (reserve) {
-				bitmap_set_nolock((uint16_t)(irq & 0x3FU),
+				bitmap_set_non_atomic((uint16_t)(irq & 0x3FU),
 						irq_rsvd_bitmap + (irq >> 6U));
 			}
 		}
@@ -71,7 +71,7 @@ static void free_irq_num(uint32_t irq)
 
 		if (bitmap_test((uint16_t)(irq & 0x3FU),
 			irq_rsvd_bitmap + (irq >> 6U)) == false) {
-			bitmap_clear_nolock((uint16_t)(irq & 0x3FU),
+			bitmap_clear_non_atomic((uint16_t)(irq & 0x3FU),
 					irq_alloc_bitmap + (irq >> 6U));
 		}
 		spinlock_irqrestore_release(&irq_alloc_spinlock, rflags);

--- a/hypervisor/common/notify.c
+++ b/hypervisor/common/notify.c
@@ -5,7 +5,7 @@
  */
 
 #include <asm/cpu.h>
-#include <asm/lib/atomic.h>
+#include <atomic.h>
 #include <asm/lib/bits.h>
 #include <per_cpu.h>
 #include <asm/notify.h>

--- a/hypervisor/common/notify.c
+++ b/hypervisor/common/notify.c
@@ -6,7 +6,7 @@
 
 #include <asm/cpu.h>
 #include <atomic.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <per_cpu.h>
 #include <asm/notify.h>
 #include <common/notify.h>
@@ -38,7 +38,7 @@ void kick_notification(__unused uint32_t irq, __unused void *data)
 		if (smp_call->func != NULL) {
 			smp_call->func(smp_call->data);
 		}
-		bitmap_clear_lock(pcpu_id, &smp_call_mask);
+		bitmap_clear(pcpu_id, &smp_call_mask);
 	}
 }
 
@@ -63,10 +63,10 @@ void smp_call_function(uint64_t mask, smp_call_func_t func, void *data)
 
 	pcpu_id = ffs64(mask);
 	while (pcpu_id < MAX_PCPU_NUM) {
-		bitmap_clear_nolock(pcpu_id, &mask);
+		bitmap_clear_non_atomic(pcpu_id, &mask);
 		if (pcpu_id == get_pcpu_id()) {
 			func(data);
-			bitmap_clear_nolock(pcpu_id, &smp_call_mask);
+			bitmap_clear_non_atomic(pcpu_id, &smp_call_mask);
 		} else if (is_pcpu_active(pcpu_id)) {
 			smp_call = &per_cpu(smp_call_info, pcpu_id);
 
@@ -81,8 +81,8 @@ void smp_call_function(uint64_t mask, smp_call_func_t func, void *data)
 			arch_smp_call_kick_pcpu(pcpu_id);
 		} else {
 			/* pcpu is not in active, print error */
-			pr_err("pcpu_id %d not in active!", pcpu_id);
-			bitmap_clear_nolock(pcpu_id, &smp_call_mask);
+			//pr_err("pcpu_id %d not in active!", pcpu_id);
+			bitmap_clear_non_atomic(pcpu_id, &smp_call_mask);
 		}
 		pcpu_id = ffs64(mask);
 	}

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -32,7 +32,7 @@ static inline uint16_t ptirq_alloc_entry_id(void)
 	uint16_t id = (uint16_t)ffz64_ex(ptirq_entry_bitmaps, CONFIG_MAX_PT_IRQ_ENTRIES);
 
 	while (id < CONFIG_MAX_PT_IRQ_ENTRIES) {
-		if (!bitmap_test_and_set_lock((id & 0x3FU), &ptirq_entry_bitmaps[id >> 6U])) {
+		if (!bitmap_test_and_set((id & 0x3FU), &ptirq_entry_bitmaps[id >> 6U])) {
 			break;
 		}
 		id = (uint16_t)ffz64_ex(ptirq_entry_bitmaps, CONFIG_MAX_PT_IRQ_ENTRIES);
@@ -177,7 +177,7 @@ void ptirq_release_entry(struct ptirq_remapping_info *entry)
 	del_timer(&entry->intr_delay_timer);
 	CPU_INT_ALL_RESTORE(rflags);
 
-	bitmap_clear_lock((entry->ptdev_entry_id) & 0x3FU, &ptirq_entry_bitmaps[entry->ptdev_entry_id >> 6U]);
+	bitmap_clear((entry->ptdev_entry_id) & 0x3FU, &ptirq_entry_bitmaps[entry->ptdev_entry_id >> 6U]);
 
 	(void)memset((void *)entry, 0U, sizeof(struct ptirq_remapping_info));
 }

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -6,7 +6,7 @@
 
 #include <rtl.h>
 #include <list.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <asm/cpu.h>
 #include <per_cpu.h>
 #include <asm/lapic.h>
@@ -153,7 +153,7 @@ void make_reschedule_request(uint16_t pcpu_id)
 {
 	struct sched_control *ctl = &per_cpu(sched_ctl, pcpu_id);
 
-	bitmap_set_lock(NEED_RESCHEDULE, &ctl->flags);
+	bitmap_set(NEED_RESCHEDULE, &ctl->flags);
 	if (get_pcpu_id() != pcpu_id) {
 		kick_pcpu(pcpu_id);
 	}
@@ -179,7 +179,7 @@ void schedule(void)
 	if (ctl->scheduler->pick_next != NULL) {
 		next = ctl->scheduler->pick_next(ctl);
 	}
-	bitmap_clear_lock(NEED_RESCHEDULE, &ctl->flags);
+	bitmap_clear(NEED_RESCHEDULE, &ctl->flags);
 
 	/* If we picked different sched object, switch context */
 	if (prev != next) {

--- a/hypervisor/common/softirq.c
+++ b/hypervisor/common/softirq.c
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <types.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <asm/cpu.h>
 #include <per_cpu.h>
 #include <softirq.h>
@@ -29,7 +29,7 @@ void register_softirq(uint16_t nr, softirq_handler handler)
  */
 void fire_softirq(uint16_t nr)
 {
-	bitmap_set_lock(nr, &per_cpu(softirq_pending, get_pcpu_id()));
+	bitmap_set(nr, &per_cpu(softirq_pending, get_pcpu_id()));
 }
 
 static void do_softirq_internal(uint16_t cpu_id)
@@ -39,7 +39,7 @@ static void do_softirq_internal(uint16_t cpu_id)
 	uint16_t nr = ffs64(*softirq_pending_bitmap);
 
 	while (nr < NR_SOFTIRQS) {
-		bitmap_clear_lock(nr, softirq_pending_bitmap);
+		bitmap_clear(nr, softirq_pending_bitmap);
 		(*softirq_handlers[nr])(cpu_id);
 		nr = ffs64(*softirq_pending_bitmap);
 	}

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -9,7 +9,7 @@
 #include <per_cpu.h>
 #include <asm/lib/atomic.h>
 #include <sprintf.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <npk_log.h>
 #include <logmsg.h>
 #include <ticks.h>

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -5,9 +5,8 @@
  */
 
 #include <types.h>
-
 #include <per_cpu.h>
-#include <asm/lib/atomic.h>
+#include <atomic.h>
 #include <sprintf.h>
 #include <spinlock.h>
 #include <npk_log.h>

--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <types.h>
-#include <asm/lib/atomic.h>
+#include <atomic.h>
 #include <acrn_hv_defs.h>
 #include <asm/io.h>
 #include <per_cpu.h>

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -1,12 +1,12 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <types.h>
 #include <errno.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include "shell_priv.h"
 #include <asm/irq.h>
 #include <console.h>
@@ -1000,7 +1000,7 @@ static int32_t shell_vcpu_dumpreg(int32_t argc, char **argv)
 	dump.vcpu = vcpu;
 	dump.str = shell_log_buf;
 	dump.str_max = SHELL_LOG_BUF_SIZE;
-	bitmap_set_nolock(pcpu_id, &mask);
+	bitmap_set_non_atomic(pcpu_id, &mask);
 	smp_call_function(mask, dump_vcpu_reg, &dump);
 	shell_puts(shell_log_buf);
 	status = 0;
@@ -1101,7 +1101,7 @@ static int32_t shell_dump_guest_mem(int32_t argc, char **argv)
 		dump.len = length;
 
 		pcpu_id = pcpuid_from_vcpu(vcpu);
-		bitmap_set_nolock(pcpu_id, &mask);
+		bitmap_set_non_atomic(pcpu_id, &mask);
 		smp_call_function(mask, dump_guest_mem, &dump);
 		ret = 0;
 	}

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,7 +7,7 @@
 #ifndef SHELL_PRIV_H
 #define SHELL_PRIV_H
 
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 
 #define SHELL_CMD_MAX_LEN		100U
 #define SHELL_STRING_MAX_LEN		(PAGE_SIZE << 2U)

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <types.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <pci.h>
 #include <uart16550.h>
 #include <asm/io.h>

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -96,14 +96,14 @@ vioapic_set_pinstate(struct acrn_single_vioapic *vioapic, uint32_t pin, uint32_t
 		old_lvl = (uint32_t)bitmap_test((uint16_t)(pin & 0x3FU), &vioapic->pin_state[pin >> 6U]);
 		if (level == 0U) {
 			/* clear pin_state and deliver interrupt according to polarity */
-			bitmap_clear_nolock((uint16_t)(pin & 0x3FU), &vioapic->pin_state[pin >> 6U]);
+			bitmap_clear_non_atomic((uint16_t)(pin & 0x3FU), &vioapic->pin_state[pin >> 6U]);
 			if ((rte.bits.intr_polarity == IOAPIC_RTE_INTPOL_ALO)
 				&& (old_lvl != level)) {
 				vioapic_generate_intr(vioapic, pin);
 			}
 		} else {
 			/* set pin_state and deliver intrrupt according to polarity */
-			bitmap_set_nolock((uint16_t)(pin & 0x3FU), &vioapic->pin_state[pin >> 6U]);
+			bitmap_set_non_atomic((uint16_t)(pin & 0x3FU), &vioapic->pin_state[pin >> 6U]);
 			if ((rte.bits.intr_polarity == IOAPIC_RTE_INTPOL_AHI)
 				&& (old_lvl != level)) {
 				vioapic_generate_intr(vioapic, pin);

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -1,6 +1,6 @@
 /*-
 * Copyright (c) 2011 NetApp, Inc.
-* Copyright (c) 2018-2022 Intel Corporation.
+* Copyright (c) 2018-2025 Intel Corporation.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -38,6 +38,7 @@
 #include <asm/pci_dev.h>
 #include <hash.h>
 #include <board_info.h>
+#include <atomic.h>
 
 
 static int32_t vpci_init_vdevs(struct acrn_vm *vm);

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -719,7 +719,7 @@ struct pci_vdev *vpci_init_vdev(struct acrn_vpci *vpci, struct acrn_vm_pci_dev_c
 	uint32_t id = (uint32_t)ffz64_ex(vpci->vdev_bitmaps, CONFIG_MAX_PCI_DEV_NUM);
 
 	if (id < CONFIG_MAX_PCI_DEV_NUM) {
-		bitmap_set_nolock((id & 0x3FU), &vpci->vdev_bitmaps[id >> 6U]);
+		bitmap_set_non_atomic((id & 0x3FU), &vpci->vdev_bitmaps[id >> 6U]);
 
 		vdev = &vpci->pci_vdevs[id];
 		vdev->id = id;
@@ -758,7 +758,7 @@ void vpci_deinit_vdev(struct pci_vdev *vdev)
 	vdev->vdev_ops->deinit_vdev(vdev);
 
 	hlist_del(&vdev->link);
-	bitmap_clear_nolock((vdev->id & 0x3FU), &vdev->vpci->vdev_bitmaps[vdev->id >> 6U]);
+	bitmap_clear_non_atomic((vdev->id & 0x3FU), &vdev->vpci->vdev_bitmaps[vdev->id >> 6U]);
 	memset(vdev, 0U, sizeof(struct pci_vdev));
 }
 

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
- * Copyright (c) 2017-2022 Intel Corporation.
+ * Copyright (c) 2017-2025 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@
 #include <asm/guest/virq.h>
 #include <irq.h>
 #include <asm/guest/assign.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <logmsg.h>
 #include <asm/ioapic.h>
 #include <asm/irq.h>

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -40,7 +40,7 @@
 #include <logmsg.h>
 #include <asm/pci_dev.h>
 #include <asm/vtd.h>
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <asm/board.h>
 #include <platform_acpi_info.h>
 #include <hash.h>
@@ -433,7 +433,7 @@ static void scan_pci_hierarchy(uint8_t bus, uint64_t buses_visited[BUSES_BITMAP_
 		current_drhd_index = bus_map[s].bus_drhd_index;
 		s = s + 1U;
 
-		bitmap_set_nolock(current_bus_index,
+		bitmap_set_non_atomic(current_bus_index,
 					&buses_visited[current_bus_index >> 6U]);
 
 		pbdf.bits.b = current_bus_index;

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -2,7 +2,7 @@
  * Copyright (c) 1997, Stefan Esser <se@freebsd.org>
  * Copyright (c) 2000, Michael Smith <msmith@freebsd.org>
  * Copyright (c) 2011 NetApp, Inc.
- * Copyright (c) 2018-2022 Intel Corporation.
+ * Copyright (c) 2018-2025 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,7 +31,7 @@
  *
  */
 #include <types.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <asm/io.h>
 #include <asm/pgtable.h>
 #include <asm/mmu.h>

--- a/hypervisor/include/arch/riscv/asm/cpu.h
+++ b/hypervisor/include/arch/riscv/asm/cpu.h
@@ -12,9 +12,9 @@
 #include <lib/util.h>
 #include <debug/logmsg.h>
 #include <board_info.h>
+#include <barrier.h>
 
-#define barrier()	__asm__ __volatile__("fence": : :"memory")
-#define cpu_relax()	barrier() /* TODO: replace with yield instruction */
+#define cpu_relax()	cpu_memory_barrier() /* TODO: replace with yield instruction */
 #define NR_CPUS		MAX_PCPU_NUM
 
 #define LONG_BYTEORDER 3

--- a/hypervisor/include/arch/riscv/asm/lib/atomic.h
+++ b/hypervisor/include/arch/riscv/asm/lib/atomic.h
@@ -1,22 +1,118 @@
 /*
- * Copyright (C) 2025 Intel Corporation.
+ * Copyright (C) 2023-2025 Intel Corporation. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ *   Haoyu Tang <haoyu.tang@intel.com>
  */
 
-#ifndef RISCV_ATOMIC_H
-#define RISCV_ATOMIC_H
+#ifndef RISCV_LIB_ATOMIC_H
+#define RISCV_LIB_ATOMIC_H
 
-#include <types.h>
+#define build_atomic_inc(name, type, size)			\
+static inline void arch_atomic_##name(type *ptr)		\
+{								\
+	type inc = 1;						\
+	asm volatile("amoadd." size " zero, %1, %0"		\
+			: "+A" (*ptr)				\
+			: "r" (inc)				\
+			: "memory");				\
+}
+build_atomic_inc(inc32, uint32_t, "w")
+build_atomic_inc(inc64, uint64_t, "d")
 
-static inline uint64_t atomic_cmpxchg64(__unused volatile uint64_t *ptr, __unused uint64_t old, __unused uint64_t new)
+#define build_atomic_dec(name, type, size)			\
+static inline void arch_atomic_##name(type *ptr)		\
+{								\
+	type dec = -1;						\
+	asm volatile("amoadd." size " zero, %1, %0"		\
+			: "+A" (*ptr)				\
+			: "r" (dec)				\
+			: "memory");				\
+}
+build_atomic_dec(dec32, uint32_t, "w")
+build_atomic_dec(dec64, uint64_t, "d")
+
+#define build_atomic_swap(name, type, size)			\
+static inline type arch_atomic_##name(type *ptr, type v)	\
+{								\
+	asm volatile("amoswap." size " %0, %2, %1"		\
+			: "=r" (v), "+A" (*ptr)			\
+			: "r" (v)				\
+			: "memory");				\
+	return v;						\
+}
+build_atomic_swap(swap32, uint32_t, "w")
+build_atomic_swap(swap64, uint64_t, "d")
+
+#define build_atomic_op(name, size, type, op)				\
+static inline type arch_atomic_##name##_return(type *v, type i)		\
+{									\
+	type ret;							\
+	asm volatile("amoadd." size ".aqrl %1, %2, %0\n\t"		\
+			: "+A"(*v), "=r"(ret)				\
+			: "r"(op i)					\
+			: "memory");					\
+	return ret op i;						\
+}
+build_atomic_op(add, "w", int32_t, +)
+build_atomic_op(add64, "d", int64_t, +)
+build_atomic_op(sub, "w", int32_t, -)
+build_atomic_op(sub64, "d", int64_t, -)
+
+static inline int32_t arch_atomic_inc_return(int32_t *v)
 {
-	/**
-	 * Dummy implementation.
-	 * Official implementations are to be provided in the library patchset (by Haoyu).
-	 */
-	return 0UL;
+	return  arch_atomic_add_return(v, 1);
 }
 
-#endif /* RISCV_ATOMIC_H */
+static inline int32_t arch_atomic_dec_return(int32_t *v)
+{
+	return arch_atomic_sub_return(v, 1);
+}
+
+static inline int64_t arch_atomic_inc64_return(int64_t *v)
+{
+	return arch_atomic_add64_return(v, 1);
+}
+
+static inline int64_t arch_atomic_dec64_return(int64_t *v)
+{
+	return arch_atomic_sub64_return(v, 1);
+}
+
+#ifdef RISCV_ISA_EXT_ZACAS /* extension `zacas' is required */
+#define build_cmpxchg(name, size, type)							\
+static inline type arch_atomic_##name(volatile type *ptr, type old, type new)		\
+{											\
+	type ret;									\
+	ret = old;									\
+	asm volatile("amocas." size ".aqrl %0, %z2, %1\n"				\
+			: "+&r"(ret), "+A"(*ptr)					\
+			: "rJ"(new)							\
+			: "memory");							\
+	return ret;									\
+}
+#else /* RISCV_ISA_EXT_ZACAS not defined */
+#define build_cmpxchg(name, size, type)							\
+static inline type arch_atomic_##name(volatile type *ptr, type old, type new)		\
+{											\
+	type ret;									\
+	register type rc;								\
+	asm volatile("0: lr." size " %0, %2\n"						\
+			" bne %0, %z3, 1f\n"						\
+			" sc." size ".rl %1, %z4, %2\n"					\
+			" bnez %1, 0b\n"						\
+			" fence rw, rw\n"						\
+			"1:\n"								\
+			: "=&r"(ret), "=&r"(rc), "+A"(*ptr)				\
+			: "rJ"(old), "rJ"(new)						\
+			: "memory");							\
+	return ret;									\
+}
+#endif /* RISCV_ISA_EXT_ZACAS */
+build_cmpxchg(cmpxchg32, "w", uint32_t)
+build_cmpxchg(cmpxchg64, "d", uint64_t)
+
+#endif /* RISCV_LIB_ATOMIC_H */

--- a/hypervisor/include/arch/riscv/asm/lib/barrier.h
+++ b/hypervisor/include/arch/riscv/asm/lib/barrier.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023-2025 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+#ifndef RISCV_LIB_BARRIER_H
+#define RISCV_LIB_BARRIER_H
+/* Synchronizes all read accesses to/from memory */
+static inline void arch_cpu_read_memory_barrier(void)
+{
+	asm volatile ("fence r,r" : : : "memory");
+}
+
+static inline void arch_cpu_write_memory_barrier(void)
+{
+	asm volatile ("fence w,w" : : : "memory");
+}
+
+/* Synchronizes all read and write accesses to/from memory */
+static inline void arch_cpu_memory_barrier(void)
+{
+	asm volatile ("fence rw,rw" : : : "memory");
+}
+#endif /* RISCV_LIB_BARRIER_H */

--- a/hypervisor/include/arch/riscv/asm/lib/bits.h
+++ b/hypervisor/include/arch/riscv/asm/lib/bits.h
@@ -1,55 +1,133 @@
 /*
- * Copyright (C) 2025 Intel Corporation.
+ * Copyright (C) 2023-2025 Intel Corporation. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
+ * Haicheng Li <haicheng.li@intel.com>
  */
 
-#ifndef RISCV_BITS_H
-#define RISCV_BITS_H
-
+#ifndef RISCV_LIB_BITS_H
+#define RISCV_LIB_BITS_H
 #include <types.h>
-
-uint16_t ffs64(__unused uint64_t value)
+#include <asm/cpu.h>
+#define INVALID_BIT_INDEX  0xffffU
+static inline uint16_t arch_ffs64(uint64_t x)
 {
-	/**
-	 * Dummy implementation.
-	 * Official implementations are to be provided in the library patchset (by Haoyu).
-	 */
-	return 0U;
+    asm volatile ("ctz %0, %1" : "=r"(x) : "r"(x));
+    return x == BITS_PER_LONG ? INVALID_BIT_INDEX :(uint16_t)x;
 }
 
-bool bitmap_test(__unused uint16_t nr, __unused const volatile uint64_t *addr)
+static inline uint16_t arch_fls64(uint64_t x)
 {
-	/**
-	 * Dummy implementation.
-	 * Official implementations are to be provided in the library patchset (by Haoyu).
-	 */
-	return true;
+    asm volatile ("clz %0, %1" : "=r"(x) : "r"(x));
+    return  x == BITS_PER_LONG ? INVALID_BIT_INDEX :(BITS_PER_LONG - 1U - (uint16_t)x);
 }
 
-void bitmap_set_lock(__unused uint16_t nr_arg, __unused volatile uint64_t *addr)
+static inline int16_t arch_fls32(uint32_t x)
 {
-	/**
-	 * Dummy implementation.
-	 * Official implementations are to be provided in the library patchset (by Haoyu).
-	 */
+    asm volatile ("clzw %0, %1" : "=r" (x) : "r" (x));
+    return  x == 32 ? (int16_t)INVALID_BIT_INDEX :(int16_t)(31 - x);
 }
 
-void bitmap_clear_lock(__unused uint16_t nr_arg, __unused volatile uint64_t *addr)
+/*
+ * return !!((*addr) & (1UL<<nr));
+ * Note:Input parameter nr shall be less than 64. If nr>=64, it will
+ * be truncated.
+ */
+ static inline bool arch_bitmap_test(uint32_t nr, const volatile uint64_t *addr)
 {
-	/**
-	 * Dummy implementation.
-	 * Official implementations are to be provided in the library patchset (by Haoyu).
-	 */
+    uint64_t mask = 1UL << (nr & ((8U * sizeof(uint64_t)) - 1U));
+    return !!(*addr & mask);
 }
 
-void bitmap_clear_nolock(__unused uint16_t nr_arg, __unused volatile uint64_t *addr)
+static inline bool arch_bitmap32_test(uint32_t nr, const volatile uint32_t *addr)
 {
-	/**
-	 * Dummy implementation.
-	 * Official implementations are to be provided in the library patchset (by Haoyu).
-	 */
+    uint32_t mask = 1UL << (nr & ((8U * sizeof(uint32_t)) - 1U));
+    // TODO: Use RISC-V B extension instruction 'bext' to optimize this function
+    return !!(*addr & mask);
 }
 
-#endif /* RISCV_BITS_H */
+/*
+ * (*addr) |= (1UL<<nr);
+ * Note:Input parameter nr shall be less than 64.
+ * If nr>=64, it will be truncated.
+ */
+#define build_bitmap_set(name, op_len, op_type, lock)                   \
+static inline void name(uint32_t nr_arg, volatile op_type *addr)        \
+{                                                                       \
+    op_type mask = 1UL << (nr_arg & ((8U * sizeof(op_type)) - 1U));     \
+    asm volatile (                                                      \
+        "amoor." op_len "." lock " zero, %1, %0"                        \
+        : "+A" (*addr)                                                  \
+        : "r" (mask)                                                    \
+        : "memory"                                                      \
+    );                                                                  \
+}
+build_bitmap_set(arch_bitmap_set, "d", uint64_t, "aqrl")
+build_bitmap_set(arch_bitmap32_set, "w", uint32_t, "aqrl")
+
+/*
+ * (*addr) &= ~(1UL<<nr);
+ * Note:Input parameter nr shall be less than 64.
+ * If nr>=64, it will be truncated.
+ */
+#define build_bitmap_clear(name, op_len, op_type, lock)                 \
+static inline void name(uint32_t nr_arg, volatile op_type *addr)        \
+{                                                                       \
+    op_type mask = ~(1UL << (nr_arg & ((8U * sizeof(op_type)) - 1U)));  \
+    asm volatile (                                                      \
+        "amoand." op_len "." lock " zero, %1, %0"                       \
+        : "+A" (*addr)                                                  \
+        : "r" (mask)                                                    \
+        : "memory"                                                      \
+    );                                                                  \
+}
+build_bitmap_clear(arch_bitmap_clear, "d", uint64_t, "aqrl")
+build_bitmap_clear(arch_bitmap32_clear, "w", uint32_t, "aqrl")
+
+/*
+ * bool ret = (*addr) & (1UL<<nr);
+ * (*addr) |= (1UL<<nr);
+ * return ret;
+ * Note:Input parameter nr shall be less than 64. If nr>=64, it
+ * will be truncated.
+ */
+#define build_bitmap_testandset(name, op_len, op_type, lock)            \
+static inline bool name(uint32_t nr_arg, volatile op_type *addr)        \
+{                                                                       \
+    op_type mask = 1UL << (nr_arg & ((8U * sizeof(op_type)) - 1U));     \
+    op_type old;                                                        \
+    asm volatile (                                                      \
+        "amoor." op_len "." lock " %0, %2, %1"                          \
+        : "=r" (old), "+A" (*addr)                                      \
+        : "r" (mask)                                                    \
+        : "memory"                                                      \
+    );                                                                  \
+    return !!(old & mask);                                              \
+}
+build_bitmap_testandset(arch_bitmap_test_and_set, "d", uint64_t, "aqrl")
+build_bitmap_testandset(arch_bitmap32_test_and_set, "w", uint32_t, "aqrl")
+
+/*
+ * bool ret = (*addr) & (1UL<<nr);
+ * (*addr) &= ~(1UL<<nr);
+ * return ret;
+ * Note:Input parameter nr shall be less than 64. If nr>=64,
+ * it will be truncated.
+ */
+#define build_bitmap_testandclear(name, op_len, op_type, lock)          \
+static inline bool name(uint32_t nr_arg, volatile op_type *addr)        \
+{                                                                       \
+    op_type mask = 1UL << (nr_arg & ((8U * sizeof(op_type)) - 1U));     \
+    op_type old;                                                        \
+    asm volatile (                                                      \
+        "amoand." op_len "." lock " %0, %2, %1"                         \
+        : "=r" (old), "+A" (*addr)                                      \
+        : "r" (~mask)                                                   \
+        : "memory"                                                      \
+    );                                                                  \
+    return !!(old & mask);                                              \
+}
+build_bitmap_testandclear(arch_bitmap_test_and_clear, "d", uint64_t, "aqrl")
+build_bitmap_testandclear(arch_bitmap32_test_and_clear, "w", uint32_t, "aqrl")
+#endif /* RISCV_LIB_BITOPS_H */

--- a/hypervisor/include/arch/riscv/asm/lib/spinlock.h
+++ b/hypervisor/include/arch/riscv/asm/lib/spinlock.h
@@ -6,11 +6,64 @@
  * Authors:
  *   Haicheng Li <haicheng.li@intel.com>
  */
-#ifndef __RISCV_LIB_SPINLOCK_H__
-#define __RISCV_LIB_SPINLOCK_H__
+#ifndef RISCV_LIB_SPINLOCK_H
+#define RISCV_LIB_SPINLOCK_H
+#ifndef ASSEMBLER
+/** The architecture dependent spinlock type. */
+typedef struct _arch_spinlock {
+	uint64_t head;
+	uint64_t tail;
+} arch_spinlock_t;
 
-typedef struct _spinlock {
+static inline void arch_spinlock_obtain(arch_spinlock_t *lock)
+{
+	asm volatile ("   li t0, 0x1\n\t"
+		      "   amoadd.d.aqrl t1, t0, (%[head])\n\t"
+		      "2: ld t0, (%[tail])\n\t"
+		      "   beq t1, t0, 1f\n\t"
+		      "   j 2b\n\t"
+		      "1:\n"
+		      :
+		      :
+		      [head] "r"(&lock->head),
+		      [tail] "r"(&lock->tail)
+		      : "cc", "memory", "t0", "t1");
+}
 
-} spinlock_t;
+static inline void arch_spinlock_release(arch_spinlock_t *lock)
+{
+	asm volatile ("   li t0, 0x1\n\t"
+		      "   amoadd.d.aqrl t1, t0, (%[tail])\n"
+		      :
+		      : [tail] "r" (&lock->tail)
+		      : "cc", "memory", "t0", "t1");
+}
 
-#endif /* __RISCV_LIB_SPINLOCK_H__ */
+#else /* ASSEMBLER */
+/** The offset of the head element. */
+#define SPINLOCK_HEAD_OFFSET       0
+/** The offset of the tail element. */
+#define SPINLOCK_TAIL_OFFSET       8
+
+.macro arch_spinlock_obtain lock_arg
+	li t0, 0x1
+	la t2, \lock_arg
+	addi t3, t2, SPINLOCK_HEAD_OFFSET
+	amoadd.d.aqrl t1, t0, (t3)
+2:	ld t0, SPINLOCK_TAIL_OFFSET(t2)
+	beq t1, t0, 1f
+	j 2b
+1 :
+.endm
+#define arch_spinlock_obtain(x) arch_spinlock_obtain lock_arg = (x)
+
+.macro arch_spinlock_release lock_arg
+	li t0, 0x1
+	la t2, \lock_arg
+	addi t3, t2, SPINLOCK_TAIL_OFFSET
+	amoadd.d.aqrl t1, t0, (t3)
+.endm
+
+#define arch_spinlock_release(x) arch_spinlock_release lock_arg = (x)
+#endif	/* ASSEMBLER */
+#endif /* RISCV_LIB_SPINLOCK_H */

--- a/hypervisor/include/arch/x86/asm/cpu.h
+++ b/hypervisor/include/arch/x86/asm/cpu.h
@@ -41,6 +41,7 @@
 #include <acrn_common.h>
 #include <asm/msr.h>
 #include <errno.h>
+#include <barrier.h>
 
 /* Define CPU stack alignment */
 #define CPU_STACK_ALIGN         16UL
@@ -563,24 +564,6 @@ static inline void cpu_sp_write(uint64_t *stack_ptr)
 	uint64_t rsp = (uint64_t)stack_ptr & ~(CPU_STACK_ALIGN - 1UL);
 
 	asm volatile ("movq %0, %%rsp" : : "r"(rsp));
-}
-
-/* Synchronizes all write accesses to memory */
-static inline void cpu_write_memory_barrier(void)
-{
-	asm volatile ("sfence\n" : : : "memory");
-}
-
-/* Synchronizes all read and write accesses to/from memory */
-static inline void cpu_memory_barrier(void)
-{
-	asm volatile ("mfence\n" : : : "memory");
-}
-
-/* Prevents compilers from reordering read/write access across this barrier */
-static inline void cpu_compiler_barrier(void)
-{
-	asm volatile ("" : : : "memory");
 }
 
 static inline void invlpg(unsigned long addr)

--- a/hypervisor/include/arch/x86/asm/guest/vm.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm.h
@@ -13,7 +13,7 @@
 
 #ifndef ASSEMBLER
 
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <spinlock.h>
 #include <asm/pgtable.h>
 #include <asm/guest/vcpu.h>
@@ -194,7 +194,7 @@ static inline uint64_t vm_active_cpus(const struct acrn_vm *vm)
 	const struct acrn_vcpu *vcpu;
 
 	foreach_vcpu(i, vm, vcpu) {
-		bitmap_set_nolock(vcpu->vcpu_id, &dmask);
+		bitmap_set_non_atomic(vcpu->vcpu_id, &dmask);
 	}
 
 	return dmask;

--- a/hypervisor/include/arch/x86/asm/guest/vm.h
+++ b/hypervisor/include/arch/x86/asm/guest/vm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -14,7 +14,7 @@
 #ifndef ASSEMBLER
 
 #include <asm/lib/bits.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <asm/pgtable.h>
 #include <asm/guest/vcpu.h>
 #include <vioapic.h>

--- a/hypervisor/include/arch/x86/asm/lib/atomic.h
+++ b/hypervisor/include/arch/x86/asm/lib/atomic.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 1998 Doug Rabson
- * Copyright (c) 2018-2022 Intel Corporation.
+ * Copyright (c) 2018-2025 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,10 +26,8 @@
  * $FreeBSD$
  */
 
-#ifndef ATOMIC_H
-#define ATOMIC_H
-#include <types.h>
-
+#ifndef X86_LIB_ATOMIC_H
+#define X86_LIB_ATOMIC_H
 #define	BUS_LOCK	"lock ; "
 
 #define build_atomic_inc(name, size, type)		\
@@ -39,9 +37,9 @@ static inline void name(type *ptr)			\
 			: "=m" (*ptr)			\
 			:  "m" (*ptr));			\
 }
-build_atomic_inc(atomic_inc16, "w", uint16_t)
-build_atomic_inc(atomic_inc32, "l", uint32_t)
-build_atomic_inc(atomic_inc64, "q", uint64_t)
+build_atomic_inc(arch_atomic_inc16, "w", uint16_t)
+build_atomic_inc(arch_atomic_inc32, "l", uint32_t)
+build_atomic_inc(arch_atomic_inc64, "q", uint64_t)
 
 #define build_atomic_dec(name, size, type)		\
 static inline void name(type *ptr)			\
@@ -50,9 +48,9 @@ static inline void name(type *ptr)			\
 			: "=m" (*ptr)			\
 			:  "m" (*ptr));			\
 }
-build_atomic_dec(atomic_dec16, "w", uint16_t)
-build_atomic_dec(atomic_dec32, "l", uint32_t)
-build_atomic_dec(atomic_dec64, "q", uint64_t)
+build_atomic_dec(arch_atomic_dec16, "w", uint16_t)
+build_atomic_dec(arch_atomic_dec32, "l", uint32_t)
+build_atomic_dec(arch_atomic_dec64, "q", uint64_t)
 
 #define build_atomic_swap(name, size, type)		\
 static inline type name(type *ptr, type v)		\
@@ -63,26 +61,8 @@ static inline type name(type *ptr, type v)		\
 			:  "cc", "memory");		\
 	return v;					\
 }
-build_atomic_swap(atomic_swap32, "l", uint32_t)
-build_atomic_swap(atomic_swap64, "q", uint64_t)
-
- /*
- * #define atomic_readandclear32(P) \
- * (return (*(uint32_t *)(P)); *(uint32_t *)(P) = 0U;)
-  */
-static inline uint32_t atomic_readandclear32(uint32_t *p)
-{
-	return atomic_swap32(p, 0U);
-}
-
- /*
- * #define atomic_readandclear64(P) \
- * (return (*(uint64_t *)(P)); *(uint64_t *)(P) = 0UL;)
-  */
-static inline uint64_t atomic_readandclear64(uint64_t *p)
-{
-	return atomic_swap64(p, 0UL);
-}
+build_atomic_swap(arch_atomic_swap32, "l", uint32_t)
+build_atomic_swap(arch_atomic_swap64, "q", uint64_t)
 
 #define build_atomic_cmpxchg(name, size, type)			\
 static inline type name(volatile type *ptr, type old, type new)	\
@@ -94,8 +74,8 @@ static inline type name(volatile type *ptr, type old, type new)	\
 			: "memory");				\
 	return ret;						\
 }
-build_atomic_cmpxchg(atomic_cmpxchg32, "l", uint32_t)
-build_atomic_cmpxchg(atomic_cmpxchg64, "q", uint64_t)
+build_atomic_cmpxchg(arch_atomic_cmpxchg32, "l", uint32_t)
+build_atomic_cmpxchg(arch_atomic_cmpxchg64, "q", uint64_t)
 
 #define build_atomic_xadd(name, size, type)			\
 static inline type name(type *ptr, type v)			\
@@ -106,48 +86,48 @@ static inline type name(type *ptr, type v)			\
 			: "cc", "memory");			\
 	return v;						\
  }
-build_atomic_xadd(atomic_xadd16, "w", uint16_t)
-build_atomic_xadd(atomic_xadd32, "l", int32_t)
-build_atomic_xadd(atomic_xadd64, "q", int64_t)
+build_atomic_xadd(arch_atomic_xadd16, "w", uint16_t)
+build_atomic_xadd(arch_atomic_xadd32, "l", int32_t)
+build_atomic_xadd(arch_atomic_xadd64, "q", int64_t)
 
-static inline int32_t atomic_add_return(int32_t *p, int32_t v)
+static inline int32_t arch_atomic_add_return(int32_t *p, int32_t v)
 {
-	return (atomic_xadd32(p, v) + v);
+	return (arch_atomic_xadd32(p, v) + v);
 }
 
-static inline int32_t atomic_sub_return(int32_t *p, int32_t v)
+static inline int32_t arch_atomic_sub_return(int32_t *p, int32_t v)
 {
-	return (atomic_xadd32(p, -v) - v);
+	return (arch_atomic_xadd32(p, -v) - v);
 }
 
-static inline int32_t atomic_inc_return(int32_t *v)
+static inline int32_t arch_atomic_inc_return(int32_t *v)
 {
-	return atomic_add_return(v, 1);
+	return arch_atomic_add_return(v, 1);
 }
 
-static inline int32_t atomic_dec_return(int32_t *v)
+static inline int32_t arch_atomic_dec_return(int32_t *v)
 {
-	return atomic_sub_return(v, 1);
+	return arch_atomic_sub_return(v, 1);
 }
 
-static inline int64_t atomic_add64_return(int64_t *p, int64_t v)
+static inline int64_t arch_atomic_add64_return(int64_t *p, int64_t v)
 {
-	return (atomic_xadd64(p, v) + v);
+	return (arch_atomic_xadd64(p, v) + v);
 }
 
-static inline int64_t atomic_sub64_return(int64_t *p, int64_t v)
+static inline int64_t arch_atomic_sub64_return(int64_t *p, int64_t v)
 {
-	return (atomic_xadd64(p, -v) - v);
+	return (arch_atomic_xadd64(p, -v) - v);
 }
 
-static inline int64_t atomic_inc64_return(int64_t *v)
+static inline int64_t arch_atomic_inc64_return(int64_t *v)
 {
-	return atomic_add64_return(v, 1);
+	return arch_atomic_add64_return(v, 1);
 }
 
-static inline int64_t atomic_dec64_return(int64_t *v)
+static inline int64_t arch_atomic_dec64_return(int64_t *v)
 {
-	return atomic_sub64_return(v, 1);
+	return arch_atomic_sub64_return(v, 1);
 }
 
-#endif /* ATOMIC_H*/
+#endif /* X86_LIB_ATOMIC_H */

--- a/hypervisor/include/arch/x86/asm/lib/barrier.h
+++ b/hypervisor/include/arch/x86/asm/lib/barrier.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef X86_LIB_BARRIER_H
+#define X86_LIB_BARRIER_H
+/* Synchronizes all read accesses to memory */
+static inline void arch_cpu_read_memory_barrier(void)
+{
+	asm volatile ("lfence\n" : : : "memory");
+}
+
+/* Synchronizes all write accesses to memory */
+static inline void arch_cpu_write_memory_barrier(void)
+{
+	asm volatile ("sfence\n" : : : "memory");
+}
+
+/* Synchronizes all read and write accesses to/from memory */
+static inline void arch_cpu_memory_barrier(void)
+{
+	asm volatile ("mfence\n" : : : "memory");
+}
+#endif /* X86_LIB_BARRIER_H */

--- a/hypervisor/include/arch/x86/asm/lib/bits.h
+++ b/hypervisor/include/arch/x86/asm/lib/bits.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 1998 Doug Rabson
- * Copyright (c) 2017-2022 Intel Corporation.
+ * Copyright (c) 2017-2025 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,7 +28,7 @@
 
 #ifndef BITS_H
 #define BITS_H
-#include <asm/lib/atomic.h>
+#include <atomic.h>
 
 /**
  *

--- a/hypervisor/include/arch/x86/asm/lib/bits.h
+++ b/hypervisor/include/arch/x86/asm/lib/bits.h
@@ -25,20 +25,10 @@
  *
  * $FreeBSD$
  */
-
-#ifndef BITS_H
-#define BITS_H
+#ifndef X86_LIB_BITS_H
+#define X86_LIB_BITS_H
 #include <atomic.h>
-
-/**
- *
- * INVALID_BIT_INDEX means when input paramter is zero,
- * bit operations function can't find bit set and return
- * the invalid bit index directly.
- *
- **/
 #define INVALID_BIT_INDEX  0xffffU
-
 /*
  *
  * fls32 - Find the Last (most significant) bit Set in value and
@@ -62,7 +52,7 @@
  * set and return the invalid bit index directly.
  *
  */
-static inline uint16_t fls32(uint32_t value)
+static inline int16_t arch_fls32(uint32_t value)
 {
 	uint32_t ret;
 	asm volatile("bsrl %1,%0\n\t"
@@ -73,7 +63,7 @@ static inline uint16_t fls32(uint32_t value)
 	return (uint16_t)ret;
 }
 
-static inline uint16_t fls64(uint64_t value)
+static inline uint16_t arch_fls64(uint64_t value)
 {
 	uint64_t ret = 0UL;
 	asm volatile("bsrq %1,%0\n\t"
@@ -109,7 +99,7 @@ static inline uint16_t fls64(uint64_t value)
  * set and return the invalid bit index directly.
  *
  */
-static inline uint16_t ffs64(uint64_t value)
+static inline uint16_t arch_ffs64(uint64_t value)
 {
 	uint64_t ret;
 	asm volatile("bsfq %1,%0\n\t"
@@ -120,109 +110,48 @@ static inline uint16_t ffs64(uint64_t value)
 	return (uint16_t)ret;
 }
 
-/*bit scan forward for the least significant bit '0'*/
-static inline uint16_t ffz64(uint64_t value)
-{
-	return ffs64(~value);
-}
-
-
-/*
- * find the first zero bit in a uint64_t array.
- * @pre: the size must be multiple of 64.
- */
-static inline uint64_t ffz64_ex(const uint64_t *addr, uint64_t size)
-{
-	uint64_t ret = size;
-	uint64_t idx;
-
-	for (idx = 0UL; (idx << 6U) < size; idx++) {
-		if (addr[idx] != ~0UL) {
-			ret = (idx << 6U) + ffz64(addr[idx]);
-			break;
-		}
-	}
-
-	return ret;
-}
-/*
- * Counts leading zeros.
- *
- * The number of leading zeros is defined as the number of
- * most significant bits which are not '1'. E.g.:
- *    clz(0x80000000)==0
- *    clz(0x40000000)==1
- *       ...
- *    clz(0x00000001)==31
- *    clz(0x00000000)==32
- *
- * @param value:The 32 bit value to count the number of leading zeros.
- *
- * @return The number of leading zeros in 'value'.
- */
-static inline uint16_t clz(uint32_t value)
-{
-	return ((value != 0U) ? (31U - fls32(value)) : 32U);
-}
-
-/*
- * Counts leading zeros (64 bit version).
- *
- * @param value:The 64 bit value to count the number of leading zeros.
- *
- * @return The number of leading zeros in 'value'.
- */
-static inline uint16_t clz64(uint64_t value)
-{
-	return ((value != 0UL) ? (63U - fls64(value)) : 64U);
-}
-
 /*
  * (*addr) |= (1UL<<nr);
- * Note:Input parameter nr shall be less than 64. 
+ * Note:Input parameter nr shall be less than 64.
  * If nr>=64, it will be truncated.
  */
 #define build_bitmap_set(name, op_len, op_type, lock)			\
-static inline void name(uint16_t nr_arg, volatile op_type *addr)	\
+static inline void name(uint32_t nr_arg, volatile op_type *addr)	\
 {									\
-	uint16_t nr;							\
+	uint32_t nr;							\
 	nr = nr_arg & ((8U * sizeof(op_type)) - 1U);			\
 	asm volatile(lock "or" op_len " %1,%0"				\
 			:  "+m" (*addr)					\
 			:  "r" ((op_type)(1UL<<nr))			\
 			:  "cc", "memory");				\
 }
-build_bitmap_set(bitmap_set_nolock, "q", uint64_t, "")
-build_bitmap_set(bitmap_set_lock, "q", uint64_t, BUS_LOCK)
-build_bitmap_set(bitmap32_set_nolock, "l", uint32_t, "")
-build_bitmap_set(bitmap32_set_lock, "l", uint32_t, BUS_LOCK)
+build_bitmap_set(arch_bitmap_set, "q", uint64_t, BUS_LOCK)
+build_bitmap_set(arch_bitmap32_set, "l", uint32_t, BUS_LOCK)
 
 /*
  * (*addr) &= ~(1UL<<nr);
- * Note:Input parameter nr shall be less than 64. 
+ * Note:Input parameter nr shall be less than 64.
  * If nr>=64, it will be truncated.
  */
-#define build_bitmap_clear(name, op_len, op_type, lock)			\
-static inline void name(uint16_t nr_arg, volatile op_type *addr)	\
+#define build_bitmap_clear(name, op_len, op_type, lock)		\
+static inline void name(uint32_t nr_arg, volatile op_type *addr)	\
 {									\
-	uint16_t nr;							\
+	uint32_t nr;							\
 	nr = nr_arg & ((8U * sizeof(op_type)) - 1U);			\
 	asm volatile(lock "and" op_len " %1,%0"				\
 			:  "+m" (*addr)					\
 			:  "r" ((op_type)(~(1UL<<(nr))))		\
 			:  "cc", "memory");				\
 }
-build_bitmap_clear(bitmap_clear_nolock, "q", uint64_t, "")
-build_bitmap_clear(bitmap_clear_lock, "q", uint64_t, BUS_LOCK)
-build_bitmap_clear(bitmap32_clear_nolock, "l", uint32_t, "")
-build_bitmap_clear(bitmap32_clear_lock, "l", uint32_t, BUS_LOCK)
+build_bitmap_clear(arch_bitmap_clear, "q", uint64_t, BUS_LOCK)
+build_bitmap_clear(arch_bitmap32_clear, "l", uint32_t, BUS_LOCK)
 
 /*
  * return !!((*addr) & (1UL<<nr));
  * Note:Input parameter nr shall be less than 64. If nr>=64, it will
  * be truncated.
  */
-static inline bool bitmap_test(uint16_t nr, const volatile uint64_t *addr)
+ static inline bool arch_bitmap_test(uint32_t nr, const volatile uint64_t *addr)
 {
 	int32_t ret = 0;
 	asm volatile("btq %q2,%1\n\tsbbl %0, %0"
@@ -232,7 +161,7 @@ static inline bool bitmap_test(uint16_t nr, const volatile uint64_t *addr)
 	return (ret != 0);
 }
 
-static inline bool bitmap32_test(uint16_t nr, const volatile uint32_t *addr)
+static inline bool arch_bitmap32_test(uint32_t nr, const volatile uint32_t *addr)
 {
 	int32_t ret = 0;
 	asm volatile("btl %2,%1\n\tsbbl %0, %0"
@@ -250,9 +179,9 @@ static inline bool bitmap32_test(uint16_t nr, const volatile uint32_t *addr)
  * will be truncated.
  */
 #define build_bitmap_testandset(name, op_len, op_type, lock)		\
-static inline bool name(uint16_t nr_arg, volatile op_type *addr)	\
+static inline bool name(uint32_t nr_arg, volatile op_type *addr)	\
 {									\
-	uint16_t nr;							\
+	uint32_t nr;							\
 	int32_t ret=0;							\
 	nr = nr_arg & ((8U * sizeof(op_type)) - 1U);			\
 	asm volatile(lock "bts" op_len " %2,%1\n\tsbbl %0,%0"		\
@@ -261,10 +190,8 @@ static inline bool name(uint16_t nr_arg, volatile op_type *addr)	\
 			: "cc", "memory");				\
 	return (ret != 0);						\
 }
-build_bitmap_testandset(bitmap_test_and_set_nolock, "q", uint64_t, "")
-build_bitmap_testandset(bitmap_test_and_set_lock, "q", uint64_t, BUS_LOCK)
-build_bitmap_testandset(bitmap32_test_and_set_nolock, "l", uint32_t, "")
-build_bitmap_testandset(bitmap32_test_and_set_lock, "l", uint32_t, BUS_LOCK)
+build_bitmap_testandset(arch_bitmap_test_and_set, "q", uint64_t, BUS_LOCK)
+build_bitmap_testandset(arch_bitmap32_test_and_set, "l", uint32_t, BUS_LOCK)
 
 /*
  * bool ret = (*addr) & (1UL<<nr);
@@ -274,9 +201,9 @@ build_bitmap_testandset(bitmap32_test_and_set_lock, "l", uint32_t, BUS_LOCK)
  * it will be truncated.
  */
 #define build_bitmap_testandclear(name, op_len, op_type, lock)		\
-static inline bool name(uint16_t nr_arg, volatile op_type *addr)	\
+static inline bool name(uint32_t nr_arg, volatile op_type *addr)	\
 {									\
-	uint16_t nr;							\
+	uint32_t nr;							\
 	int32_t ret=0;							\
 	nr = nr_arg & ((8U * sizeof(op_type)) - 1U);			\
 	asm volatile(lock "btr" op_len " %2,%1\n\tsbbl %0,%0"		\
@@ -285,14 +212,6 @@ static inline bool name(uint16_t nr_arg, volatile op_type *addr)	\
 			: "cc", "memory");				\
 	return (ret != 0);						\
 }
-build_bitmap_testandclear(bitmap_test_and_clear_nolock, "q", uint64_t, "")
-build_bitmap_testandclear(bitmap_test_and_clear_lock, "q", uint64_t, BUS_LOCK)
-build_bitmap_testandclear(bitmap32_test_and_clear_nolock, "l", uint32_t, "")
-build_bitmap_testandclear(bitmap32_test_and_clear_lock, "l", uint32_t, BUS_LOCK)
-
-static inline uint16_t bitmap_weight(uint64_t bits)
-{
-	return (uint16_t)__builtin_popcountl(bits);
-}
-
-#endif /* BITS_H*/
+build_bitmap_testandclear(arch_bitmap_test_and_clear, "q", uint64_t, BUS_LOCK)
+build_bitmap_testandclear(arch_bitmap32_test_and_clear, "l", uint32_t, BUS_LOCK)
+#endif /* X86_LIB_BITS_H */

--- a/hypervisor/include/arch/x86/asm/page.h
+++ b/hypervisor/include/arch/x86/asm/page.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,7 +7,7 @@
 #ifndef PAGE_H
 #define PAGE_H
 
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <board_info.h>
 
 /**

--- a/hypervisor/include/common/event.h
+++ b/hypervisor/include/common/event.h
@@ -1,6 +1,11 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #ifndef EVENT_H
 #define EVENT_H
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 
 struct sched_event {
 	spinlock_t lock;

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Intel Corporation.
+ * Copyright (C) 2021-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -8,7 +8,7 @@
 #define COMMON_IRQ_H
 
 #include <lib/util.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 
 /**
  * @file common/irq.h

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,7 +7,7 @@
 #ifndef PTDEV_H
 #define PTDEV_H
 #include <list.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <timer.h>
 #include <vacpi.h>
 

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -1,12 +1,12 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SCHEDULE_H
 #define SCHEDULE_H
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <lib/list.h>
 #include <timer.h>
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -1,6 +1,6 @@
 /*-
 * Copyright (c) 2011 NetApp, Inc.
-* Copyright (c) 2018-2022 Intel Corporation.
+* Copyright (c) 2018-2025 Intel Corporation.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 #ifndef VPCI_H_
 #define VPCI_H_
 
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <lib/util.h>
 #include <pci.h>
 #include <list.h>

--- a/hypervisor/include/dm/vuart.h
+++ b/hypervisor/include/dm/vuart.h
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2013 Neel Natu <neel@freebsd.org>
- * Copyright (c) 2018-2024 Intel Corporation.
+ * Copyright (c) 2018-2025 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 #ifndef VUART_H
 #define VUART_H
 #include <types.h>
-#include <asm/lib/spinlock.h>
+#include <spinlock.h>
 #include <asm/vm_config.h>
 
 /**

--- a/hypervisor/include/lib/atomic.h
+++ b/hypervisor/include/lib/atomic.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef ATOMIC_H
+#define ATOMIC_H
+#include <types.h>
+#include <asm/lib/atomic.h>
+
+/* The mandatory functions should be implemented by arch atomic library */
+static inline void arch_atomic_inc32(uint32_t * ptr);
+static inline void arch_atomic_inc64(uint64_t * ptr);
+static inline void arch_atomic_dec32(uint32_t * ptr);
+static inline void arch_atomic_dec64(uint64_t * ptr);
+static inline uint32_t arch_atomic_cmpxchg32(volatile uint32_t * ptr, uint32_t old, uint32_t new);
+static inline uint64_t arch_atomic_cmpxchg64(volatile uint64_t * ptr, uint64_t old, uint64_t new);
+static inline uint32_t arch_atomic_swap32(uint32_t *p, uint32_t v);
+static inline uint64_t arch_atomic_swap64(uint64_t *p, uint64_t v);
+static inline int32_t arch_atomic_add_return(int32_t *p, int32_t v);
+static inline int32_t arch_atomic_sub_return(int32_t *p, int32_t v);
+static inline int32_t arch_atomic_inc_return(int32_t *v);
+static inline int32_t arch_atomic_dec_return(int32_t *v);
+static inline int64_t arch_atomic_add64_return(int64_t *p, int64_t v);
+static inline int64_t arch_atomic_sub64_return(int64_t *p, int64_t v);
+static inline int64_t arch_atomic_inc64_return(int64_t *v);
+static inline int64_t arch_atomic_dec64_return(int64_t *v);
+
+/* The common functions map to arch implementation */
+static inline void atomic_inc32(uint32_t * ptr)
+{
+	return arch_atomic_inc32(ptr);
+}
+
+static inline void atomic_inc64(uint64_t * ptr)
+{
+	return arch_atomic_inc64(ptr);
+}
+
+static inline void atomic_dec32(uint32_t * ptr)
+{
+	return arch_atomic_dec32(ptr);
+}
+
+static inline void atomic_dec64(uint64_t * ptr)
+{
+	return arch_atomic_dec64(ptr);
+}
+
+static inline uint32_t atomic_cmpxchg32(volatile uint32_t * ptr, uint32_t old, uint32_t new)
+{
+	return arch_atomic_cmpxchg32(ptr, old, new);
+}
+
+static inline uint64_t atomic_cmpxchg64(volatile uint64_t * ptr, uint64_t old, uint64_t new)
+{
+	return arch_atomic_cmpxchg64(ptr, old, new);
+}
+
+static inline uint32_t atomic_readandclear32(uint32_t *p)
+{
+	return arch_atomic_swap32(p, 0U);
+}
+
+static inline uint64_t atomic_readandclear64(uint64_t *p)
+{
+	return arch_atomic_swap64(p, 0UL);
+}
+
+static inline int32_t atomic_add_return(int32_t *p, int32_t v)
+{
+	return arch_atomic_add_return(p, v);
+}
+
+static inline int32_t atomic_sub_return(int32_t *p, int32_t v)
+{
+	return arch_atomic_sub_return(p, v);
+}
+
+static inline int32_t atomic_inc_return(int32_t *v)
+{
+	return arch_atomic_inc_return(v);
+}
+
+static inline int32_t atomic_dec_return(int32_t *v)
+{
+	return arch_atomic_dec_return(v);
+}
+
+static inline int64_t atomic_add64_return(int64_t *p, int64_t v)
+{
+	return arch_atomic_add64_return(p, v);
+}
+
+static inline int64_t atomic_sub64_return(int64_t *p, int64_t v)
+{
+	return arch_atomic_sub64_return(p, v);
+}
+
+static inline int64_t atomic_inc64_return(int64_t *v)
+{
+	return arch_atomic_inc64_return(v);
+}
+
+static inline int64_t atomic_dec64_return(int64_t *v)
+{
+	return arch_atomic_dec64_return(v);
+}
+
+#endif /* ATOMIC_H*/

--- a/hypervisor/include/lib/barrier.h
+++ b/hypervisor/include/lib/barrier.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef BARRIER_H
+#define BARRIER_H
+
+#include <types.h>
+#include <asm/lib/barrier.h>
+
+/* The mandatory functions should be implemented by arch barrier library */
+static inline void arch_cpu_read_memory_barrier(void);
+static inline void arch_cpu_write_memory_barrier(void);
+static inline void arch_cpu_memory_barrier(void);
+
+/* The common functions map to arch implementation */
+/* Synchronizes all write accesses to memory */
+static inline void cpu_write_memory_barrier(void)
+{
+        return arch_cpu_write_memory_barrier();
+}
+/* Synchronizes all read accesses from memory */
+static inline void cpu_read_memory_barrier(void)
+{
+        return arch_cpu_read_memory_barrier();
+}
+/* Synchronizes all read and write accesses to/from memory */
+static inline void cpu_memory_barrier(void)
+{
+        return arch_cpu_memory_barrier();
+}
+
+/* Prevents compilers from reordering read/write access across this barrier */
+static inline void cpu_compiler_barrier(void)
+{
+        asm volatile ("" : : : "memory");
+}
+#endif /* BARRIER_H */

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haoyu Tang <haoyu.tang@intel.com>
+ */
+
+#ifndef BITS_H
+#define BITS_H
+#include <types.h>
+#include <asm/lib/bits.h>
+
+/**
+ *
+ * INVALID_BIT_INDEX means when input paramter is zero,
+ * bit operations function can't find bit set and return
+ * the invalid bit index directly.
+ *
+ **/
+#ifndef INVALID_BIT_INDEX
+#define INVALID_BIT_INDEX  0xffffU
+#endif
+
+/* The mandatory functions should be implemented by arch bits library */
+static inline int16_t arch_fls32(uint32_t value);
+static inline uint16_t arch_fls64(uint64_t value);
+static inline uint16_t arch_ffs64(uint64_t value);
+static inline void arch_bitmap_set(uint32_t nr_arg, volatile uint64_t *addr);
+static inline void arch_bitmap32_set(uint32_t nr_arg, volatile uint32_t *addr);
+static inline void arch_bitmap_clear(uint32_t nr_arg, volatile uint64_t *addr);
+static inline void arch_bitmap32_clear(uint32_t nr_arg, volatile uint32_t *addr);
+static inline bool arch_bitmap_test_and_set(uint32_t nr_arg, volatile uint64_t *addr);
+static inline bool arch_bitmap32_test_and_set(uint32_t nr_arg, volatile uint32_t *addr);
+static inline bool arch_bitmap_test_and_clear(uint32_t nr_arg, volatile uint64_t *addr);
+static inline bool arch_bitmap32_test_and_clear(uint32_t nr_arg, volatile uint32_t *addr);
+static inline bool arch_bitmap_test(uint32_t nr, const volatile uint64_t *addr);
+static inline bool arch_bitmap32_test(uint32_t nr, const volatile uint32_t *addr);
+
+/* The common functions map to arch implementation */
+static inline int16_t fls32(uint32_t value)
+{
+	return arch_fls32(value);
+}
+
+static inline uint16_t fls64(uint64_t value)
+{
+	return arch_fls64(value);
+}
+
+static inline uint16_t ffs64(uint64_t value)
+{
+	return arch_ffs64(value);
+}
+
+static inline uint16_t ffz64(uint64_t value)
+{
+	return arch_ffs64(~value);
+}
+
+static inline void bitmap_set(uint32_t nr_arg, volatile uint64_t *addr)
+{
+	arch_bitmap_set(nr_arg, addr);
+}
+
+static inline void bitmap32_set(uint32_t nr_arg, volatile uint32_t *addr)
+{
+	arch_bitmap32_set(nr_arg, addr);
+}
+
+static inline void bitmap_clear(uint32_t nr_arg, volatile uint64_t *addr)
+{
+	arch_bitmap_clear(nr_arg, addr);
+}
+
+static inline void bitmap32_clear(uint32_t nr_arg, volatile uint32_t *addr)
+{
+	arch_bitmap32_clear(nr_arg, addr);
+}
+
+static inline bool bitmap_test_and_set(uint32_t nr_arg, volatile uint64_t *addr)
+{
+	return arch_bitmap_test_and_set(nr_arg, addr);
+}
+
+static inline bool bitmap32_test_and_set(uint32_t nr_arg, volatile uint32_t *addr)
+{
+	return arch_bitmap32_test_and_set(nr_arg, addr);
+}
+
+static inline bool bitmap_test_and_clear(uint32_t nr_arg, volatile uint64_t *addr)
+{
+	return arch_bitmap_test_and_clear(nr_arg, addr);
+}
+
+static inline bool bitmap32_test_and_clear(uint32_t nr_arg, volatile uint32_t *addr)
+{
+	return arch_bitmap32_test_and_clear(nr_arg, addr);
+}
+
+static inline bool bitmap_test(uint32_t nr, const volatile uint64_t *addr)
+{
+	return arch_bitmap_test(nr, addr);
+}
+
+static inline bool bitmap32_test(uint32_t nr, const volatile uint32_t *addr)
+{
+	return arch_bitmap32_test(nr, addr);
+}
+
+/* The funcitons are implemented in common bits library */
+uint64_t ffz64_ex(const uint64_t *addr, uint64_t size);
+uint16_t clz32(uint32_t value);
+uint16_t clz64(uint64_t value);
+uint16_t bitmap_weight(uint64_t bits);
+void bitmap_set_non_atomic(uint32_t nr_arg, volatile uint64_t *addr);
+void bitmap32_set_non_atomic(uint32_t nr_arg, volatile uint32_t *addr);
+void bitmap_clear_non_atomic(uint32_t nr_arg, volatile uint64_t *addr);
+void bitmap32_clear_non_atomic(uint32_t nr_arg, volatile uint32_t *addr);
+bool bitmap_test_and_set_non_atomic(uint32_t nr_arg, volatile uint64_t *addr);
+bool bitmap32_test_and_set_non_atomic(uint32_t nr_arg, volatile uint32_t *addr);
+bool bitmap_test_and_clear_non_atomic(uint32_t nr_arg, volatile uint64_t *addr);
+bool bitmap32_test_and_clear_non_atomic(uint32_t nr_arg, volatile uint32_t *addr);
+
+#endif /* BITS_H*/

--- a/hypervisor/include/lib/spinlock.h
+++ b/hypervisor/include/lib/spinlock.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef SPINLOCK_H
+#define SPINLOCK_H
+
+#ifndef ASSEMBLER
+#include <types.h>
+#include <rtl.h>
+#include <asm/cpu.h>
+#include <asm/lib/spinlock.h>
+
+/* The common spinlock type */
+typedef arch_spinlock_t spinlock_t;
+
+/* The mandatory functions should be implemented by arch spinlock library */
+static inline void arch_spinlock_obtain(arch_spinlock_t *lock);
+static inline void arch_spinlock_release(arch_spinlock_t *lock);
+
+/* Function prototypes */
+static inline void spinlock_init(spinlock_t *lock)
+{
+	(void)memset(lock, 0U, sizeof(spinlock_t));
+}
+
+static inline void spinlock_irqsave_obtain(spinlock_t *lock, uint64_t * flags)
+{
+	CPU_INT_ALL_DISABLE(flags);
+	arch_spinlock_obtain(lock);
+}
+
+static inline void spinlock_irqrestore_release(spinlock_t *lock, uint64_t flags)
+{
+	arch_spinlock_release(lock);
+	CPU_INT_ALL_RESTORE(flags);
+}
+
+static inline void spinlock_obtain(spinlock_t *lock)
+{
+    return arch_spinlock_obtain(lock);
+}
+
+static inline void spinlock_release(spinlock_t *lock)
+{
+    return arch_spinlock_release(lock);
+}
+
+#else /* ASSEMBLER */
+#include <asm/lib/spinlock.h>
+#define spinlock_obtain arch_spinlock_obtain
+#define spinlock_release arch_spinlock_release
+#endif /* ASSEMBLER */
+
+#endif /* SPINLOCK_H */

--- a/hypervisor/lib/bits.c
+++ b/hypervisor/lib/bits.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haoyu Tang <haoyu.tang@intel.com>
+ */
+
+#include <bits.h>
+
+/* common functions implementation */
+uint64_t ffz64_ex(const uint64_t *addr, uint64_t size)
+{
+	uint64_t ret = size;
+	uint64_t idx;
+
+	for (idx = 0UL; (idx << 6U) < size; idx++) {
+		if (addr[idx] != ~0UL) {
+			ret = (idx << 6U) + ffz64(addr[idx]);
+			break;
+		}
+	}
+
+	return ret;
+}
+
+uint16_t clz32(uint32_t value)
+{
+	return ((value != 0U) ? (31U - fls32(value)) : 32U);
+}
+
+uint16_t clz64(uint64_t value)
+{
+	return ((value != 0UL) ? (63U - fls64(value)) : 64U);
+}
+
+void bitmap_set_non_atomic(uint32_t nr_arg, volatile uint64_t *addr)
+{
+	uint64_t mask = 1UL << (nr_arg & ((8U * sizeof(uint64_t)) - 1U));
+	*addr |= mask;
+}
+
+void bitmap32_set_non_atomic(uint32_t nr_arg, volatile uint32_t *addr)
+{
+	uint32_t mask = 1U << (nr_arg & ((8U * sizeof(uint32_t)) - 1U));
+	*addr |= mask;
+}
+
+void bitmap_clear_non_atomic(uint32_t nr_arg, volatile uint64_t *addr)
+ {
+	uint64_t mask = 1UL << (nr_arg & ((8U * sizeof(uint64_t)) - 1U));
+	*addr &= ~mask;
+}
+
+void bitmap32_clear_non_atomic(uint32_t nr_arg, volatile uint32_t *addr)
+{
+	uint32_t mask = 1U << (nr_arg & ((8U * sizeof(uint32_t)) - 1U));
+	*addr &= ~mask;
+}
+
+bool bitmap_test_and_set_non_atomic(uint32_t nr_arg, volatile uint64_t *addr)
+{
+	uint64_t mask = 1UL << (nr_arg & ((8U * sizeof(uint64_t)) - 1U));
+	bool old = !!(*addr & mask);
+	*addr |= mask;
+	return old;
+}
+
+bool bitmap32_test_and_set_non_atomic(uint32_t nr_arg, volatile uint32_t *addr)
+{
+	uint32_t mask = 1U << (nr_arg & ((8U * sizeof(uint32_t)) - 1U));
+	bool old = !!(*addr & mask);
+	*addr |= mask;
+	return old;
+}
+
+bool bitmap_test_and_clear_non_atomic(uint32_t nr_arg, volatile uint64_t *addr)
+{
+	uint64_t mask = 1UL << (nr_arg & ((8U * sizeof(uint64_t)) - 1U));
+	bool old = !!(*addr & mask);
+	*addr &= ~mask;
+	return old;
+}
+
+bool bitmap32_test_and_clear_non_atomic(uint32_t nr_arg, volatile uint32_t *addr)
+{
+	uint32_t mask = 1U << (nr_arg & ((8U * sizeof(uint32_t)) - 1U));
+	bool old = !!(*addr & mask);
+	*addr &= ~mask;
+	return old;
+}
+
+uint16_t bitmap_weight(uint64_t bits)
+{
+	return (uint16_t)__builtin_popcountl(bits);
+}

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -99,7 +99,7 @@ static const char *get_flags(const char *s_arg, uint32_t *flags)
 {
 	const char *s = s_arg;
 	/* contains the flag characters */
-	static const char flagchars[5] = "#0- +";
+	static const char flagchars[6] = "#0- +";
 	/* contains the numeric flags for the characters above */
 	static const uint32_t fl[sizeof(flagchars)] = {
 		PRINT_FLAG_ALTERNATE_FORM,	/* # */

--- a/misc/hv_prebuild/vm_cfg_checks.c
+++ b/misc/hv_prebuild/vm_cfg_checks.c
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2020-2022 Intel Corporation.
+ * Copyright (C) 2020-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <asm/lib/bits.h>
+#include <bits.h>
 #include <asm/page.h>
 #include <asm/vm_config.h>
 #include <asm/rdt.h>


### PR DESCRIPTION
This patchset is for library reconstruction of multi-arch to add RISC-V support.

Added library: arch dependent (barrier, spinlock, bits, atomic) and common (string, sprintf, crypto, stack_protector).

Changelog:
v5->v6:
  1)update spinlock codes of supporting ASSEMBLER defined case, allow the assemble code invoke spinlock_obtain and spinlock_release, per test and comments in https://lists.projectacrn.org/g/acrn-dev/topic/patch_v5_03_10_hv/115287318.
  2)align with kernel, refine risc-v irq save/restore implementation in cpu.h per comments in https://lists.projectacrn.org/g/acrn-dev/topic/patch_v5_02_10_hv_risc_v/115287317.
  3)change arch_ffs64,arch_fls64,arch_fls32 to single-return per comments in https://lists.projectacrn.org/g/acrn-dev/topic/patch_v5_09_10_hv/115287326.

v4->v5:
  1)exclude memory library as the patch merged.
  2)intruduce a patch to add common libraries into risc-v build.
  3)change arch implementation back to static inline per code-scan and comment in https://lists.projectacrn.org/g/acrn-dev/topic/patch_v4_09_10_hv/115166085.
  4)rename bitmap funcitons per discussion.
  5)implement compiler barrier in common as arch-independence per comment in https://lists.projectacrn.org/g/acrn-dev/topic/patch_v4_09_10_hv/115166085.
  6)risc-v bits library: align semantic with x86, change bitmap_test to C code per comments in https://lists.projectacrn.org/g/acrn-dev/topic/patch_v4_05_10_hv/115166080.
  7)split the depended implementation in risc-v cpu.h to a new patch.

v3 -> v4:
  Refer to multi-arch-coding-guideline.rst to reorganize code, per discussion in https://lists.projectacrn.org/g/acrn-dev/topic/patch_v3_01_10_hv/115110637.

v2 -> v3:
  Change the way that library to support multi-arch, per discussion in https://lists.projectacrn.org/g/acrn-dev/topic/patch_v2_1_6_hv_rename_x86/115042027.

v1->v2:
  Introduce hypervisor/arch/riscv/lib/memory.c to implement common memory functions for RISC-V specific, per discussion in https://lists.projectacrn.org/g/acrn-dev/topic/patch_v1_1_2_hv_rename_x86/115002853.