### PR TITLE
multi-arch add risc-v io interface

### DIFF
--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -6,7 +6,7 @@
 
 #include <types.h>
 #include <logmsg.h>
-#include <asm/io.h>
+#include <io.h>
 #include <spinlock.h>
 #include <asm/cpu_caps.h>
 #include <pci.h>

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -7,7 +7,7 @@
 #include <types.h>
 #include <asm/host_pm.h>
 #include <asm/guest/vm.h>
-#include <asm/io.h>
+#include <io.h>
 #include <logmsg.h>
 #include <platform_acpi_info.h>
 #include <asm/guest/guest_pm.h>

--- a/hypervisor/arch/x86/guest/vm_reset.c
+++ b/hypervisor/arch/x86/guest/vm_reset.c
@@ -5,7 +5,7 @@
  */
 
 #include <asm/guest/vm.h>
-#include <asm/io.h>
+#include <io.h>
 #include <asm/host_pm.h>
 #include <logmsg.h>
 #include <per_cpu.h>

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -12,7 +12,7 @@
 #include <asm/ioapic.h>
 #include <asm/irq.h>
 #include <asm/pgtable.h>
-#include <asm/io.h>
+#include <io.h>
 #include <asm/mmu.h>
 #include <acpi.h>
 #include <logmsg.h>

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -8,7 +8,7 @@
 #include <bits.h>
 #include <spinlock.h>
 #include <per_cpu.h>
-#include <asm/io.h>
+#include <io.h>
 #include <asm/irq.h>
 #include <asm/idt.h>
 #include <asm/ioapic.h>

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -7,7 +7,7 @@
 #include <asm/default_acpi_info.h>
 #include <platform_acpi_info.h>
 #include <per_cpu.h>
-#include <asm/io.h>
+#include <io.h>
 #include <asm/msr.h>
 #include <asm/pgtable.h>
 #include <asm/host_pm.h>

--- a/hypervisor/arch/x86/tsc.c
+++ b/hypervisor/arch/x86/tsc.c
@@ -8,7 +8,7 @@
 #include <util.h>
 #include <asm/cpuid.h>
 #include <asm/cpu_caps.h>
-#include <asm/io.h>
+#include <io.h>
 #include <asm/tsc.h>
 #include <cpu.h>
 #include <logmsg.h>

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -13,7 +13,7 @@
 #include <asm/cpu_caps.h>
 #include <irq.h>
 #include <asm/irq.h>
-#include <asm/io.h>
+#include <io.h>
 #include <asm/mmu.h>
 #include <asm/lapic.h>
 #include <asm/vtd.h>

--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -6,8 +6,8 @@
 #include <types.h>
 #include <atomic.h>
 #include <acrn_hv_defs.h>
-#include <asm/io.h>
 #include <per_cpu.h>
+#include <io.h>
 #include <asm/mmu.h>
 #include <logmsg.h>
 #include <npk_log.h>

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -8,7 +8,7 @@
 #include <spinlock.h>
 #include <pci.h>
 #include <uart16550.h>
-#include <asm/io.h>
+#include <io.h>
 #include <asm/cpu.h>
 #include <asm/mmu.h>
 

--- a/hypervisor/dm/vgpio.c
+++ b/hypervisor/dm/vgpio.c
@@ -41,7 +41,7 @@
 #include <asm/guest/vm.h>
 #include <asm/guest/ept.h>
 #include <asm/guest/assign.h>
-#include <asm/io.h>
+#include <io.h>
 #include <asm/mmu.h>
 
 #ifdef P2SB_VGPIO_DM_ENABLED

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -32,7 +32,7 @@
 #include <asm/vtd.h>
 #include <asm/guest/ept.h>
 #include <asm/mmu.h>
-#include <asm/io.h>
+#include <io.h>
 #include <logmsg.h>
 #include <config.h>
 #include "vpci_priv.h"

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -27,7 +27,7 @@
  */
 
 #include <asm/guest/vm.h>
-#include <asm/io.h>
+#include <io.h>
 #include <errno.h>
 #include <vpci.h>
 #include <asm/guest/ept.h>

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -30,7 +30,7 @@
 #include <ptdev.h>
 #include <asm/guest/vm.h>
 #include <asm/vtd.h>
-#include <asm/io.h>
+#include <io.h>
 #include <asm/mmu.h>
 #include <vacpi.h>
 #include <logmsg.h>

--- a/hypervisor/dm/vrtc.c
+++ b/hypervisor/dm/vrtc.c
@@ -26,7 +26,7 @@
  */
 
 #include <asm/guest/vm.h>
-#include <asm/io.h>
+#include <io.h>
 #include <asm/tsc.h>
 #include <vrtc.h>
 #include <logmsg.h>

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -32,7 +32,7 @@
  */
 #include <types.h>
 #include <spinlock.h>
-#include <asm/io.h>
+#include <io.h>
 #include <asm/pgtable.h>
 #include <asm/mmu.h>
 #include <pci.h>

--- a/hypervisor/include/arch/riscv/asm/io.h
+++ b/hypervisor/include/arch/riscv/asm/io.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2023-2025 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+#ifndef RISCV_IO_H
+#define RISCV_IO_H
+
+#include <barrier.h>
+
+#define HAS_ARCH_MMIO
+/*
+ * Generic I/O memory access primitives.
+ */
+static inline void writeb(uint8_t val, volatile void *addr)
+{
+        asm volatile("sb %0, 0(%1)" : : "r" (val), "r" (addr) : "memory");
+}
+
+static inline void writew(uint16_t val, volatile void *addr)
+{
+        asm volatile("sh %w0, 0(%1)" : : "r" (val), "r" (addr) : "memory");
+}
+
+static inline void writel(uint32_t val, volatile void *addr)
+{
+        asm volatile("sw %0, 0(%1)" : : "r" (val), "r" (addr) : "memory");
+}
+
+static inline void writeq(uint64_t val, volatile void *addr)
+{
+        asm volatile("sd %0, 0(%1)" : : "r" (val), "r" (addr) : "memory");
+}
+
+static inline uint8_t readb(const volatile void *addr)
+{
+        uint8_t val;
+
+        asm volatile("lb %0, 0(%1)": "=r" (val) : "r" (addr) : "memory");
+        return val;
+}
+
+static inline uint16_t readw(const volatile void *addr)
+{
+        uint16_t val;
+
+        asm volatile("lh %0, 0(%1)": "=r" (val) : "r" (addr) : "memory");
+        return val;
+}
+
+static inline uint32_t readl(const volatile void *addr)
+{
+        uint32_t val;
+
+        asm volatile("lw %0, 0(%1)": "=r" (val) : "r" (addr) : "memory");
+        return val;
+}
+
+static inline uint64_t readq(const volatile void *addr)
+{
+        uint64_t val;
+
+        asm volatile("ld %0, 0(%1)": "=r" (val) : "r" (addr) : "memory");
+        return val;
+}
+
+/*
+ * Strictly ordered I/O memory access primitives.
+ */
+static inline uint8_t arch_mmio_read8(const volatile void *addr)
+{
+        uint8_t val = readb(addr);
+        cpu_read_memory_barrier();
+        return val;
+}
+
+static inline uint16_t arch_mmio_read16(const volatile void *addr)
+{
+        uint16_t val = readw(addr);
+        cpu_read_memory_barrier();
+        return val;
+}
+
+static inline uint32_t arch_mmio_read32(const volatile void *addr)
+{
+        uint32_t val = readl(addr);
+        cpu_read_memory_barrier();
+        return val;
+}
+
+static inline uint64_t arch_mmio_read64(const volatile void *addr)
+{
+        uint64_t val = readq(addr);
+        cpu_read_memory_barrier();
+        return val;
+}
+
+static inline void arch_mmio_write8(uint8_t val, volatile void *addr)
+{
+        cpu_write_memory_barrier();
+        writeb(val, addr);
+}
+
+static inline void arch_mmio_write16(uint16_t val, volatile void *addr)
+{
+        cpu_write_memory_barrier();
+        writew(val, addr);
+}
+
+static inline void arch_mmio_write32(uint32_t val, volatile void *addr)
+{
+        cpu_write_memory_barrier();
+        writel(val, addr);
+}
+
+static inline void arch_mmio_write64(uint64_t val, volatile void *addr)
+{
+        cpu_write_memory_barrier();
+        writeq(val, addr);
+}
+
+#endif /* RISCV_IO_H */

--- a/hypervisor/include/arch/x86/asm/io.h
+++ b/hypervisor/include/arch/x86/asm/io.h
@@ -1,25 +1,26 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation.
+ * Copyright (C) 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef IO_H
-#define IO_H
+#ifndef X86_IO_H
+#define X86_IO_H
 
 #include <types.h>
 
+#define HAS_ARCH_PIO
 /* X86 architecture only supports 16 bits IO space */
 #define IO_SPACE_BITMASK 0xffffU
 
 /* Write 1 byte to specified I/O port */
-static inline void pio_write8(uint8_t value, uint16_t port)
+static inline void arch_pio_write8(uint8_t value, uint16_t port)
 {
 	asm volatile ("outb %0,%1"::"a" (value), "dN"(port));
 }
 
 /* Read 1 byte from specified I/O port */
-static inline uint8_t pio_read8(uint16_t port)
+static inline uint8_t arch_pio_read8(uint16_t port)
 {
 	uint8_t value;
 
@@ -28,13 +29,13 @@ static inline uint8_t pio_read8(uint16_t port)
 }
 
 /* Write 2 bytes to specified I/O port */
-static inline void pio_write16(uint16_t value, uint16_t port)
+static inline void arch_pio_write16(uint16_t value, uint16_t port)
 {
 	asm volatile ("outw %0,%1"::"a" (value), "dN"(port));
 }
 
 /* Read 2 bytes from specified I/O port */
-static inline uint16_t pio_read16(uint16_t port)
+static inline uint16_t arch_pio_read16(uint16_t port)
 {
 	uint16_t value;
 
@@ -43,13 +44,13 @@ static inline uint16_t pio_read16(uint16_t port)
 }
 
 /* Write 4 bytes to specified I/O port */
-static inline void pio_write32(uint32_t value, uint16_t port)
+static inline void arch_pio_write32(uint32_t value, uint16_t port)
 {
 	asm volatile ("outl %0,%1"::"a" (value), "dN"(port));
 }
 
 /* Read 4 bytes from specified I/O port */
-static inline uint32_t pio_read32(uint16_t port)
+static inline uint32_t arch_pio_read32(uint16_t port)
 {
 	uint32_t value;
 
@@ -57,154 +58,4 @@ static inline uint32_t pio_read32(uint16_t port)
 	return value;
 }
 
-static inline void pio_write(uint32_t v, uint16_t addr, size_t sz)
-{
-	if (sz == 1U) {
-		pio_write8((uint8_t)v, addr);
-	} else if (sz == 2U) {
-		pio_write16((uint16_t)v, addr);
-	} else {
-		pio_write32(v, addr);
-	}
-}
-
-static inline uint32_t pio_read(uint16_t addr, size_t sz)
-{
-	uint32_t ret;
-	if (sz == 1U) {
-		ret = pio_read8(addr);
-	} else if (sz == 2U) {
-		ret = pio_read16(addr);
-	} else {
-		ret = pio_read32(addr);
-	}
-	return ret;
-}
-
-/** Writes a 64 bit value to a memory mapped IO device.
- *
- *  @param value The 64 bit value to write.
- *  @param addr The memory address to write to.
- */
-static inline void mmio_write64(uint64_t value, void *addr)
-{
-	volatile uint64_t *addr64 = (volatile uint64_t *)addr;
-	*addr64 = value;
-}
-
-/** Writes a 32 bit value to a memory mapped IO device.
- *
- *  @param value The 32 bit value to write.
- *  @param addr The memory address to write to.
- */
-static inline void mmio_write32(uint32_t value, void *addr)
-{
-	volatile uint32_t *addr32 = (volatile uint32_t *)addr;
-	*addr32 = value;
-}
-
-/** Writes a 16 bit value to a memory mapped IO device.
- *
- *  @param value The 16 bit value to write.
- *  @param addr The memory address to write to.
- */
-static inline void mmio_write16(uint16_t value, void *addr)
-{
-	volatile uint16_t *addr16 = (volatile uint16_t *)addr;
-	*addr16 = value;
-}
-
-/** Writes an 8 bit value to a memory mapped IO device.
- *
- *  @param value The 8 bit value to write.
- *  @param addr The memory address to write to.
- */
-static inline void mmio_write8(uint8_t value, void *addr)
-{
-	volatile uint8_t *addr8 = (volatile uint8_t *)addr;
-	*addr8 = value;
-}
-
-/** Reads a 64 bit value from a memory mapped IO device.
- *
- *  @param addr The memory address to read from.
- *
- *  @return The 64 bit value read from the given address.
- */
-static inline uint64_t mmio_read64(const void *addr)
-{
-	return *((volatile const uint64_t *)addr);
-}
-
-/** Reads a 32 bit value from a memory mapped IO device.
- *
- *  @param addr The memory address to read from.
- *
- *  @return The 32 bit value read from the given address.
- */
-static inline uint32_t mmio_read32(const void *addr)
-{
-	return *((volatile const uint32_t *)addr);
-}
-
-/** Reads a 16 bit value from a memory mapped IO device.
- *
- *  @param addr The memory address to read from.
- *
- *  @return The 16 bit value read from the given address.
- */
-static inline uint16_t mmio_read16(const void *addr)
-{
-	return *((volatile const uint16_t *)addr);
-}
-
-/** Reads an 8 bit value from a memory mapped IO device.
- *
- *  @param addr The memory address to read from.
- *
- *  @return The 8 bit  value read from the given address.
- */
-static inline uint8_t mmio_read8(const void *addr)
-{
-	return *((volatile const uint8_t *)addr);
-}
-
-static inline uint64_t mmio_read(const void *addr, uint64_t sz)
-{
-	uint64_t val;
-	switch (sz) {
-	case 1U:
-		val = (uint64_t)mmio_read8(addr);
-		break;
-	case 2U:
-		val = (uint64_t)mmio_read16(addr);
-		break;
-	case 4U:
-		val = (uint64_t)mmio_read32(addr);
-		break;
-	default:
-		val = mmio_read64(addr);
-		break;
-	}
-	return val;
-}
-
-static inline void mmio_write(void *addr, uint64_t sz, uint64_t val)
-{
-	switch (sz) {
-	case 1U:
-		mmio_write8((uint8_t)val, addr);
-		break;
-	case 2U:
-		mmio_write16((uint16_t)val, addr);
-		break;
-	case 4U:
-		mmio_write32((uint32_t)val, addr);
-		break;
-	default:
-		mmio_write64(val, addr);
-		break;
-	}
-}
-
-#endif /* _IO_H defined */
+#endif /* X86_IO_H defined */

--- a/hypervisor/include/common/io.h
+++ b/hypervisor/include/common/io.h
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef IO_H
+#define IO_H
+
+#include <types.h>
+#include <asm/io.h>
+
+#ifndef HAS_ARCH_PIO
+/* Write 1 byte to specified I/O port */
+static inline void arch_pio_write8(__unused uint8_t value, __unused uint16_t port){}
+
+/* Read 1 byte from specified I/O port */
+static inline uint8_t arch_pio_read8(__unused uint16_t port) { return 0xffU;}
+
+/* Write 2 bytes to specified I/O port */
+static inline void arch_pio_write16(__unused uint16_t value, __unused uint16_t port) {}
+
+/* Read 2 bytes from specified I/O port */
+static inline uint16_t arch_pio_read16(__unused uint16_t port) { return 0xffffU;}
+
+/* Write 4 bytes to specified I/O port */
+static inline void arch_pio_write32(__unused uint32_t value, __unused uint16_t port) {}
+
+/* Read 4 bytes to specified I/O port */
+static inline uint32_t arch_pio_read32(__unused uint16_t port) { return 0xffffffffU;}
+
+/* Write 8 bytes to specified I/O port */
+static inline void arch_pio_write(__unused uint64_t v, __unused uint16_t addr, __unused size_t sz) {}
+
+/* Read 8 bytes to specified I/O port */
+static inline uint64_t arch_pio_read(__unused uint16_t addr, __unused size_t sz) { return 0xffffffffU;}
+#endif /* HAS_ARCH_PIO */
+
+#ifndef HAS_ARCH_MMIO
+/** Writes a 64 bit value to a memory mapped IO device.
+ *
+ *  @param value The 64 bit value to write.
+ *  @param addr The memory address to write to.
+ */
+static inline void arch_mmio_write64(uint64_t value, void *addr)
+{
+	volatile uint64_t *addr64 = (volatile uint64_t *)addr;
+	*addr64 = value;
+}
+
+/** Writes a 32 bit value to a memory mapped IO device.
+ *
+ *  @param value The 32 bit value to write.
+ *  @param addr The memory address to write to.
+ */
+static inline void arch_mmio_write32(uint32_t value, void *addr)
+{
+	volatile uint32_t *addr32 = (volatile uint32_t *)addr;
+	*addr32 = value;
+}
+
+/** Writes a 16 bit value to a memory mapped IO device.
+ *
+ *  @param value The 16 bit value to write.
+ *  @param addr The memory address to write to.
+ */
+static inline void arch_mmio_write16(uint16_t value, void *addr)
+{
+	volatile uint16_t *addr16 = (volatile uint16_t *)addr;
+	*addr16 = value;
+}
+
+/** Writes an 8 bit value to a memory mapped IO device.
+ *
+ *  @param value The 8 bit value to write.
+ *  @param addr The memory address to write to.
+ */
+static inline void arch_mmio_write8(uint8_t value, void *addr)
+{
+	volatile uint8_t *addr8 = (volatile uint8_t *)addr;
+	*addr8 = value;
+}
+
+/** Reads a 64 bit value from a memory mapped IO device.
+ *
+ *  @param addr The memory address to read from.
+ *
+ *  @return The 64 bit value read from the given address.
+ */
+static inline uint64_t arch_mmio_read64(const void *addr)
+{
+	return *((volatile const uint64_t *)addr);
+}
+
+/** Reads a 32 bit value from a memory mapped IO device.
+ *
+ *  @param addr The memory address to read from.
+ *
+ *  @return The 32 bit value read from the given address.
+ */
+static inline uint32_t arch_mmio_read32(const void *addr)
+{
+	return *((volatile const uint32_t *)addr);
+}
+
+/** Reads a 16 bit value from a memory mapped IO device.
+ *
+ *  @param addr The memory address to read from.
+ *
+ *  @return The 16 bit value read from the given address.
+ */
+static inline uint16_t arch_mmio_read16(const void *addr)
+{
+	return *((volatile const uint16_t *)addr);
+}
+
+/** Reads an 8 bit value from a memory mapped IO device.
+ *
+ *  @param addr The memory address to read from.
+ *
+ *  @return The 8 bit  value read from the given address.
+ */
+static inline uint8_t arch_mmio_read8(const void *addr)
+{
+	return *((volatile const uint8_t *)addr);
+}
+#endif /* HAS_ARCH_MMIO */
+
+static inline uint8_t mmio_read8(const void *addr)
+{
+	return arch_mmio_read8(addr);
+}
+
+static inline uint16_t mmio_read16(const void *addr)
+{
+	return arch_mmio_read16(addr);
+}
+
+static inline uint32_t mmio_read32(const void *addr)
+{
+	return arch_mmio_read32(addr);
+}
+
+static inline uint64_t mmio_read64(const void *addr)
+{
+	return arch_mmio_read64(addr);
+}
+
+static inline uint64_t mmio_read(const void *addr, uint64_t sz)
+{
+	uint64_t val;
+	switch (sz) {
+	case 1U:
+		val = (uint64_t)arch_mmio_read8(addr);
+		break;
+	case 2U:
+		val = (uint64_t)arch_mmio_read16(addr);
+		break;
+	case 4U:
+		val = (uint64_t)arch_mmio_read32(addr);
+		break;
+	default:
+		val = arch_mmio_read64(addr);
+		break;
+	}
+	return val;
+}
+
+static inline void mmio_write8(uint8_t v, void *addr)
+{
+	arch_mmio_write8(v, addr);
+}
+
+static inline void mmio_write16(uint16_t v, void *addr)
+{
+	arch_mmio_write16(v, addr);
+}
+
+static inline void mmio_write32(uint32_t v, void *addr)
+{
+	arch_mmio_write32(v, addr);
+}
+
+static inline void mmio_write64(uint64_t v, void *addr)
+{
+	arch_mmio_write64(v, addr);
+}
+
+static inline void mmio_write(void *addr, uint64_t sz, uint64_t val)
+{
+	switch (sz) {
+	case 1U:
+		mmio_write8((uint8_t)val, addr);
+		break;
+	case 2U:
+		mmio_write16((uint16_t)val, addr);
+		break;
+	case 4U:
+		mmio_write32((uint32_t)val, addr);
+		break;
+	default:
+		mmio_write64(val, addr);
+		break;
+	}
+}
+
+static inline void pio_write8(uint8_t v, uint16_t addr)
+{
+	arch_pio_write8(v, addr);
+}
+
+static inline void pio_write16(uint16_t v, uint16_t addr)
+{
+	arch_pio_write16(v, addr);
+}
+
+static inline void pio_write32(uint32_t v, uint16_t addr)
+{
+	arch_pio_write32(v, addr);
+}
+
+static inline void pio_write(uint32_t v, uint16_t addr, size_t sz)
+{
+	if (sz == 1U) {
+		pio_write8((uint8_t)v, addr);
+	} else if (sz == 2U) {
+		pio_write16((uint16_t)v, addr);
+	} else {
+		pio_write32(v, addr);
+	}
+}
+
+static inline uint8_t pio_read8(uint16_t addr)
+{
+	return arch_pio_read8(addr);
+}
+
+static inline uint16_t pio_read16(uint16_t addr)
+{
+	return arch_pio_read16(addr);
+}
+
+static inline uint32_t pio_read32(uint16_t addr)
+{
+	return arch_pio_read32(addr);
+}
+
+static inline uint32_t pio_read(uint16_t addr, size_t sz)
+{
+	uint32_t ret;
+	if (sz == 1U) {
+		ret = pio_read8(addr);
+	} else if (sz == 2U) {
+		ret = pio_read16(addr);
+	} else {
+		ret = pio_read32(addr);
+	}
+	return ret;
+}
+
+#endif /* IO_H defined */


### PR DESCRIPTION
MMIO read/write without memory order should be common. 
ARCH without PIO support shouldn't use PIO APIs, so implement them as empty. 
Add RISC-V MMIO APIs with memory order.