### PR TITLE
smp boot support

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -153,6 +153,8 @@ COMMON_C_SRCS += common/percpu.c
 COMMON_C_SRCS += common/cpu.c
 COMMON_C_SRCS += lib/memory.c
 COMMON_C_SRCS += lib/bits.c
+COMMON_C_SRCS += common/ticks.c
+COMMON_C_SRCS += common/delay.c
 
 # library componment
 COMMON_C_SRCS += lib/string.c
@@ -167,8 +169,6 @@ COMMON_C_SRCS += lib/stack_protector.c
 endif
 
 ifeq ($(ARCH),x86)
-COMMON_C_SRCS += common/ticks.c
-COMMON_C_SRCS += common/delay.c
 COMMON_C_SRCS += common/timer.c
 COMMON_C_SRCS += common/irq.c
 COMMON_C_SRCS += common/softirq.c

--- a/hypervisor/arch/riscv/Makefile
+++ b/hypervisor/arch/riscv/Makefile
@@ -36,6 +36,7 @@ HOST_C_SRCS += arch/riscv/notify.c
 HOST_C_SRCS += arch/riscv/timer.c
 HOST_C_SRCS += arch/riscv/trap.c
 HOST_C_SRCS += arch/riscv/cpu.c
+HOST_C_SRCS += arch/riscv/logmsg.c
 
 # Virtual platform assembly sources
 VP_S_SRCS +=

--- a/hypervisor/arch/riscv/Makefile
+++ b/hypervisor/arch/riscv/Makefile
@@ -19,6 +19,7 @@ LDFLAGS += -Wl,--no-warn-rwx-segments
 RV_ISA += gh
 RV_ISA += zbb
 RV_ISA += zicbom
+RV_ISA += zihintpause
 
 ARCH_CFLAGS += -march=rv64$(subst $() $(),_,$(RV_ISA))
 ARCH_CFLAGS += -mabi=lp64d

--- a/hypervisor/arch/riscv/Makefile
+++ b/hypervisor/arch/riscv/Makefile
@@ -14,6 +14,15 @@ ASFLAGS +=
 
 LDFLAGS += -Wl,--no-warn-rwx-segments
 
+ifeq (y, $(CONFIG_RELOC))
+# -fpie is already added into CFLAGS in common Makefile
+#CFLAGS += -fpie
+ASFLAGS += -fpie
+else
+CFLAGS += -fno-pie
+ASFLAGS += -fno-pie
+endif
+
 # g expands to i, m, a, f, d, zicsr and zifencei.
 # h for hypervisor extension
 RV_ISA += gh

--- a/hypervisor/arch/riscv/cpu.c
+++ b/hypervisor/arch/riscv/cpu.c
@@ -10,7 +10,13 @@
 
 
 #include <types.h>
+#include <per_cpu.h>
 #include <cpu.h>
+#include <delay.h>
+#include <asm/sbi.h>
+#include <asm/pgtable.h>
+
+extern void _start_secondary_sbi(uint64_t phy_stack_addr);
 
 /* wait until *sync == wake_sync */
 void wait_sync_change(volatile const uint64_t *sync, uint64_t wake_sync)
@@ -23,4 +29,21 @@ void wait_sync_change(volatile const uint64_t *sync, uint64_t wake_sync)
 uint16_t arch_get_pcpu_num(void)
 {
 	return NR_CPUS;
+}
+
+void arch_start_pcpu(uint16_t pcpu_id)
+{
+	int64_t ret;
+	uint64_t pcpu_sp, phy_stack_addr;
+	uint32_t hart_id = per_cpu(arch.hart_id, pcpu_id);
+	uint64_t phy_start_addr = hva2hpa((void *)_start_secondary_sbi);
+
+	pcpu_sp = (uint64_t)&per_cpu(stack, pcpu_id)[CONFIG_STACK_SIZE - 1];
+	pcpu_sp &= ~(CPU_STACK_ALIGN - 1UL);
+	phy_stack_addr = hva2hpa((void *)pcpu_sp);
+
+	ret = sbi_hsm_start_hart(hart_id, phy_start_addr, phy_stack_addr);
+	if (ret != SBI_SUCCESS) {
+		pr_fatal("Failed to start cpu%hu by SBI HSM", pcpu_id);
+	}
 }

--- a/hypervisor/arch/riscv/init.c
+++ b/hypervisor/arch/riscv/init.c
@@ -8,22 +8,83 @@
  */
 
 #include <types.h>
+#include <cpu.h>
+#include <per_cpu.h>
+#include <debug/logmsg.h>
+
+static void init_pcpu_comm_post(void);
+
+/* Push sp magic to top of stack for call trace */
+#define SWITCH_TO(sp, to)							\
+{										\
+	asm volatile ( 								\
+		"mv sp, %0\n"           /* Set stack pointer */			\
+		"addi sp, sp, -8\n"     /* Make room for magic value */		\
+		"sd %1, 0(sp)\n"        /* Store magic value */			\
+		"jalr %2\n"             /* Jump to function pointer */		\
+		:								\
+		: "r"(sp), "r"(SP_BOTTOM_MAGIC), "r"(to)			\
+	);									\
+}
 
 /* C entry point for boot CPU */
 void init_primary_pcpu(uint64_t hart_id, uint64_t fdt_paddr)
 {
-	(void)hart_id;
+	uint16_t pcpu_id = BSP_CPU_ID;
+	uint64_t pcpu_sp;
 	(void)fdt_paddr;
 
-	while (1) {
-		asm volatile("wfi" : : : "memory");
+	init_percpu_hart_id(hart_id);
+	set_pcpu_active(pcpu_id);
+
+	/*
+	 * Set state for this CPU to initializing, the current pcpu_id
+	 * is set to a per-cpu register tp from now on.
+	 */
+	pcpu_set_current_state(pcpu_id, PCPU_STATE_INITIALIZING);
+
+	if (!start_pcpus(AP_MASK)) {
+		panic("Failed to start all secondary cores!");
 	}
+
+	/* Switch to run-time stack */
+	pcpu_sp = (uint64_t)(&get_cpu_var(stack)[CONFIG_STACK_SIZE - 1]);
+	pcpu_sp &= ~(CPU_STACK_ALIGN - 1UL);
+	SWITCH_TO(pcpu_sp, init_pcpu_comm_post);
 }
 
 /* C entry point for AP */
 void init_secondary_pcpu(uint64_t hart_id)
 {
-	(void)hart_id;
+	uint16_t pcpu_id;
+
+	pcpu_id = get_pcpu_id_from_hart_id(hart_id);
+	if (pcpu_id >= MAX_PCPU_NUM) {
+		panic("Invalid pCPU ID!");
+	}
+
+	set_pcpu_active(pcpu_id);
+
+	/*
+	 * Set state for this CPU to initializing, the current pcpu_id
+	 * is set to a per-cpu register tp from now on.
+	 */
+	pcpu_set_current_state(pcpu_id, PCPU_STATE_INITIALIZING);
+
+	/* This function shall never return */
+	init_pcpu_comm_post();
+}
+
+static void init_pcpu_comm_post(void)
+{
+	uint16_t pcpu_id;
+
+	pcpu_id = get_pcpu_id();
 
 	/* to be implemented */
+	(void)pcpu_id;
+
+	while (1) {
+		asm volatile("wfi" : : : "memory");
+	}
 }

--- a/hypervisor/arch/riscv/logmsg.c
+++ b/hypervisor/arch/riscv/logmsg.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2018-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <types.h>
+
+/* FIXME: Temporary RISC-V build workaround
+ * This file provides pr_xxx function stubs to satisfy existing
+ * code dependencies. Remove this file and migrate to the common
+ * logmsg.c implementation once the debug module is properly
+ * integrated.
+ */
+void do_logmsg(uint32_t severity, const char *fmt, ...)
+{
+	(void)severity;
+	(void)fmt;
+}

--- a/hypervisor/arch/riscv/sbi.c
+++ b/hypervisor/arch/riscv/sbi.c
@@ -75,6 +75,31 @@ static int64_t sbi_send_ipi(uint64_t mask, uint64_t mask_base)
 }
 
 /**
+ * sbi_hsm_start_hart - Start a RISC-V hart using SBI HSM extension
+ * @hartid: The hardware thread (hart) ID to start
+ * @addr: The start address for the hart
+ * @arg: Argument to pass to the hart at startup
+ *
+ * This function invokes the SBI HSM extension to start a specified hart
+ * at the given address with the provided argument.
+ *
+ * Returns the SBI error code from the operation.
+ */
+int64_t sbi_hsm_start_hart(uint64_t hartid, uint64_t addr, uint64_t arg)
+{
+	sbiret ret;
+
+	ret = sbi_ecall(hartid, addr, arg, 0, 0, 0, SBI_HSM_FID_HART_START,
+		SBI_EID_HSM);
+	if (ret.error != SBI_SUCCESS) {
+		pr_err("%s: Failed to start hart (%x) by SBI, error code: %lx",
+			__func__, hartid, ret.error);
+	}
+
+	return ret.error;
+}
+
+/**
  * msg_type is currently unused.
  *
  * At present, only IPI_NOTIFY_CPU is supported, covering two use cases:

--- a/hypervisor/arch/x86/exception.c
+++ b/hypervisor/arch/x86/exception.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <asm/cpu.h>
 #include <asm/irq.h>
 #include <debug/dump.h>
+#include <cpu.h>
 
 void dispatch_exception(struct intr_excp_ctx *ctx)
 {

--- a/hypervisor/arch/x86/hw_thermal.c
+++ b/hypervisor/arch/x86/hw_thermal.c
@@ -8,7 +8,7 @@
 #include <softirq.h>
 #include <irq.h>
 #include <logmsg.h>
-#include <asm/cpu.h>
+#include <cpu.h>
 #include <asm/msr.h>
 #include <asm/irq.h>
 #include <asm/apicreg.h>

--- a/hypervisor/arch/x86/nmi.c
+++ b/hypervisor/arch/x86/nmi.c
@@ -9,6 +9,7 @@
 
 #include <asm/guest/vcpu.h>
 #include <asm/guest/virq.h>
+#include <cpu.h>
 
 void handle_nmi(__unused struct intr_excp_ctx *ctx)
 {

--- a/hypervisor/arch/x86/tsc_deadline_timer.c
+++ b/hypervisor/arch/x86/tsc_deadline_timer.c
@@ -9,7 +9,7 @@
 #include <irq.h>
 #include <logmsg.h>
 #include <timer.h>
-#include <asm/cpu.h>
+#include <cpu.h>
 #include <asm/msr.h>
 #include <asm/irq.h>
 #include <asm/apicreg.h>

--- a/hypervisor/common/cpu.c
+++ b/hypervisor/common/cpu.c
@@ -3,7 +3,10 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <per_cpu.h>
 #include <cpu.h>
+#include <delay.h>
+#include <logmsg.h>
 #include <bits.h>
 
 
@@ -46,4 +49,66 @@ bool check_pcpus_inactive(uint64_t mask)
 uint64_t get_active_pcpu_bitmap(void)
 {
 	return pcpu_active_bitmap;
+}
+
+void pcpu_set_current_state(uint16_t pcpu_id, enum pcpu_boot_state state)
+{
+	/* Check if state is initializing */
+	if (state == PCPU_STATE_INITIALIZING) {
+
+		/* Save this CPU's logical ID to arch specific per-cpu reg */
+		set_current_pcpu_id(pcpu_id);
+	}
+
+	/* Set state for the specified CPU */
+	per_cpu(boot_state, pcpu_id) = state;
+}
+
+/**
+ * @brief Start all cpus if the bit is set in mask except itself
+ *
+ * @param[in] mask bits mask of cpus which should be started
+ *
+ * @return true if all cpus set in mask are started
+ * @return false if there are any cpus set in mask aren't started
+ */
+bool start_pcpus(uint64_t mask)
+{
+	uint16_t i;
+	uint16_t pcpu_id = get_pcpu_id();
+	uint64_t expected_start_mask = mask;
+	uint32_t timeout;
+
+	i = ffs64(expected_start_mask);
+	while (i != INVALID_BIT_INDEX) {
+		bitmap_clear_non_atomic(i, &expected_start_mask);
+
+		if (pcpu_id == i) {
+			continue; /* Avoid start itself */
+		}
+
+		arch_start_pcpu(i);
+
+		/* Wait until the pcpu with pcpu_id is running and set
+		 * the active bitmap or configured time-out has expired
+		 */
+		timeout = CPU_UP_TIMEOUT * 1000U;
+		while (!is_pcpu_active(i) && (timeout != 0U)) {
+			/* Delay 10us */
+			udelay(10U);
+
+			/* Decrement timeout value */
+			timeout -= 10U;
+		}
+
+		/* Check to see if expected CPU is actually up */
+		if (!is_pcpu_active(i)) {
+			pr_fatal("Secondary CPU%hu failed to come up", i);
+			pcpu_set_current_state(i, PCPU_STATE_DEAD);
+		}
+
+		i = ffs64(expected_start_mask);
+	}
+
+	return check_pcpus_active(mask);
 }

--- a/hypervisor/common/event.c
+++ b/hypervisor/common/event.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#include <asm/cpu.h>
 #include <schedule.h>
 #include <event.h>
 #include <logmsg.h>
+#include <cpu.h>
 
 void init_event(struct sched_event *event)
 {

--- a/hypervisor/include/arch/riscv/asm/cpu.h
+++ b/hypervisor/include/arch/riscv/asm/cpu.h
@@ -77,5 +77,7 @@ static inline void arch_asm_pause(void)
 #define CPU_INT_ALL_RESTORE(x) local_irq_restore(x)
 
 void wait_sync_change(volatile const uint64_t *sync, uint64_t wake_sync);
+void init_percpu_hart_id(uint32_t bsp_hart_id);
+uint16_t get_pcpu_id_from_hart_id(uint32_t hart_id);
 
 #endif /* RISCV_CPU_H */

--- a/hypervisor/include/arch/riscv/asm/cpu.h
+++ b/hypervisor/include/arch/riscv/asm/cpu.h
@@ -23,13 +23,27 @@
 /* Define the interrupt enable bit mask */
 #define SSTATUS_SIE 0x2
 
-static inline uint16_t get_pcpu_id(void)
+/* Define CPU stack alignment */
+#define CPU_STACK_ALIGN	16UL
+
+/* In ACRN, struct per_cpu_region is a critical data structure
+ * containing key per-CPU data frequently accessed via get_cpu_var().
+ * We use the tp register to store the current logical pCPU ID to
+ * facilitate efficient per-CPU data access. This design mirrors
+ * the x86 implementation, which uses the dedicated MSR_IA32_SYSENTER_CS
+ * MSR (unused by the hypervisor) for the same purpose.
+ */
+static inline uint16_t arch_get_pcpu_id(void)
 {
-	/**
-	 * Dummy implementation.
-	 * Official implementations are to be provided in the platform initialization patchset (by Hang).
-	 */
-	return 0U;
+	uint16_t pcpu_id;
+
+	asm volatile ("mv %0, tp" : "=r" (pcpu_id) : : );
+	return pcpu_id;
+}
+
+static inline void arch_set_current_pcpu_id(uint16_t pcpu_id)
+{
+	asm volatile ("mv tp, %0" : : "r" (pcpu_id) : "tp");
 }
 
 /* Write CSR */

--- a/hypervisor/include/arch/riscv/asm/cpu.h
+++ b/hypervisor/include/arch/riscv/asm/cpu.h
@@ -46,6 +46,11 @@ static inline void arch_set_current_pcpu_id(uint16_t pcpu_id)
 	asm volatile ("mv tp, %0" : : "r" (pcpu_id) : "tp");
 }
 
+static inline void arch_asm_pause(void)
+{
+	asm volatile ("pause" ::: "memory");
+}
+
 /* Write CSR */
 #define cpu_csr_write(reg, csr_val)                                                                                    \
 	({                                                                                                             \

--- a/hypervisor/include/arch/riscv/asm/per_cpu.h
+++ b/hypervisor/include/arch/riscv/asm/per_cpu.h
@@ -14,7 +14,7 @@
 #include <asm/page.h>
 
 struct per_cpu_arch {
-
+	uint32_t hart_id;
 } __aligned(PAGE_SIZE); /* per_cpu_region size aligned with PAGE_SIZE */
 
 

--- a/hypervisor/include/arch/riscv/asm/pgtable.h
+++ b/hypervisor/include/arch/riscv/asm/pgtable.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2018-2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef PGTABLE_H
+#define PGTABLE_H
+
+/* FIXME: Temporary RISC-V build workaround
+ * This file provides hva2hpa function stubs to satisfy existing
+ * code dependencies. Remove this file and migrate to the common
+ * pgtable.h implementation once the MMU module is properly
+ * integrated.
+ */
+static inline uint64_t hva2hpa(const void *x)
+{
+	return (uint64_t)x;
+}
+
+#endif /* PGTABLE_H */

--- a/hypervisor/include/arch/riscv/asm/sbi.h
+++ b/hypervisor/include/arch/riscv/asm/sbi.h
@@ -97,6 +97,7 @@ typedef struct {
 	};
 } sbiret;
 
+int64_t sbi_hsm_start_hart(uint64_t hartid, uint64_t addr, uint64_t arg);
 void send_single_ipi(uint16_t pcpu_id, __unused uint32_t msg_type);
 void send_dest_ipi_mask(uint64_t dest_mask, __unused uint32_t msg_type);
 

--- a/hypervisor/include/arch/x86/asm/cpu.h
+++ b/hypervisor/include/arch/x86/asm/cpu.h
@@ -502,7 +502,7 @@ static inline void cpu_msr_write(uint32_t reg, uint64_t msr_val)
 	asm volatile (" wrmsr " : : "c" (reg), "a" ((uint32_t)msr_val), "d" ((uint32_t)(msr_val >> 32U)));
 }
 
-static inline void asm_pause(void)
+static inline void arch_asm_pause(void)
 {
 	asm volatile ("pause" ::: "memory");
 }

--- a/hypervisor/include/arch/x86/asm/cpu.h
+++ b/hypervisor/include/arch/x86/asm/cpu.h
@@ -287,16 +287,6 @@ extern uint64_t               secondary_cpu_stack[1];
  * to locate the per cpu data.
  */
 
-/* Boot CPU ID */
-#define BSP_CPU_ID             0U
-
-/**
- *The invalid cpu_id (INVALID_CPU_ID) is error
- *code for error handling, this means that
- *caller can't find a valid physical cpu
- *or virtual cpu.
- */
-#define INVALID_CPU_ID 0xffffU
 /**
  *The broadcast id (BROADCAST_CPU_ID)
  *used to notify all valid phyiscal cpu
@@ -447,7 +437,6 @@ void init_pcpu_pre(bool is_bsp);
  * hereby, pcpu_id is actually the current physcial cpu id.
  */
 void init_pcpu_post(uint16_t pcpu_id);
-bool start_pcpus(uint64_t mask);
 void wait_pcpus_offline(uint64_t mask);
 void stop_pcpus(void);
 void wait_sync_change(volatile const uint64_t *sync, uint64_t wake_sync);
@@ -651,9 +640,14 @@ cpu_rdtscp_execute(uint64_t *timestamp_ptr, uint32_t *cpu_id_ptr)
  * Macro to get CPU ID
  * @pre: the return CPU ID would never equal or large than phys_cpu_num.
  */
-static inline uint16_t get_pcpu_id(void)
+static inline uint16_t arch_get_pcpu_id(void)
 {
 	return (uint16_t)cpu_msr_read(ACRN_PSEUDO_PCPUID_MSR);
+}
+
+static inline void arch_set_current_pcpu_id(uint16_t pcpu_id)
+{
+	cpu_msr_write(ACRN_PSEUDO_PCPUID_MSR, (uint32_t)pcpu_id);
 }
 
 static inline uint64_t cpu_rsp_get(void)

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -24,8 +24,8 @@
 #include <schedule.h>
 #include <event.h>
 #include <io_req.h>
+#include <cpu.h>
 #include <asm/msr.h>
-#include <asm/cpu.h>
 #include <asm/guest/instr_emul.h>
 #include <asm/guest/nested.h>
 #include <asm/vmx.h>

--- a/hypervisor/include/arch/x86/asm/init.h
+++ b/hypervisor/include/arch/x86/asm/init.h
@@ -6,9 +6,6 @@
 #ifndef INIT_H
 #define INIT_H
 
-/* hypervisor stack bottom magic('intl') */
-#define SP_BOTTOM_MAGIC    0x696e746cUL
-
 void init_primary_pcpu(void);
 void init_secondary_pcpu(void);
 

--- a/hypervisor/include/common/cpu.h
+++ b/hypervisor/include/common/cpu.h
@@ -10,6 +10,17 @@
 #include <types.h>
 #include <asm/cpu.h>
 
+#define CPU_UP_TIMEOUT		100U /* millisecond */
+#define CPU_DOWN_TIMEOUT	100U /* millisecond */
+
+#define BSP_CPU_ID		0U /* Boot CPU ID */
+
+/**
+ * The invalid cpu_id (INVALID_CPU_ID) is error code for error handling,
+ * this means that caller can't find a valid physical cpu or virtual cpu.
+ */
+#define INVALID_CPU_ID		0xffffU
+
 /* CPU states defined */
 enum pcpu_boot_state {
         PCPU_STATE_RESET = 0U,
@@ -18,6 +29,10 @@ enum pcpu_boot_state {
         PCPU_STATE_HALTED,
         PCPU_STATE_DEAD,
 };
+
+static inline uint16_t arch_get_pcpu_id(void);
+static inline void arch_set_current_pcpu_id(uint16_t pcpu_id);
+void arch_start_pcpu(uint16_t pcpu_id);
 uint16_t arch_get_pcpu_num(void);
 uint16_t get_pcpu_nums(void);
 bool is_pcpu_active(uint16_t pcpu_id);
@@ -26,8 +41,20 @@ void clear_pcpu_active(uint16_t pcpu_id);
 bool check_pcpus_active(uint64_t mask);
 bool check_pcpus_inactive(uint64_t mask);
 uint64_t get_active_pcpu_bitmap(void);
+void pcpu_set_current_state(uint16_t pcpu_id, enum pcpu_boot_state state);
+bool start_pcpus(uint64_t mask);
 
 #define ALL_CPUS_MASK		((1UL << get_pcpu_nums()) - 1UL)
 #define AP_MASK			(ALL_CPUS_MASK & ~(1UL << BSP_CPU_ID))
+
+static inline uint16_t get_pcpu_id(void)
+{
+	return arch_get_pcpu_id();
+}
+
+static inline void set_current_pcpu_id(uint16_t pcpu_id)
+{
+	arch_set_current_pcpu_id(pcpu_id);
+}
 
 #endif /* COMMON_CPU_H */

--- a/hypervisor/include/common/cpu.h
+++ b/hypervisor/include/common/cpu.h
@@ -33,6 +33,7 @@ enum pcpu_boot_state {
 static inline uint16_t arch_get_pcpu_id(void);
 static inline void arch_set_current_pcpu_id(uint16_t pcpu_id);
 void arch_start_pcpu(uint16_t pcpu_id);
+static inline void arch_asm_pause(void);
 uint16_t arch_get_pcpu_num(void);
 uint16_t get_pcpu_nums(void);
 bool is_pcpu_active(uint16_t pcpu_id);
@@ -55,6 +56,11 @@ static inline uint16_t get_pcpu_id(void)
 static inline void set_current_pcpu_id(uint16_t pcpu_id)
 {
 	arch_set_current_pcpu_id(pcpu_id);
+}
+
+static inline void asm_pause(void)
+{
+	arch_asm_pause();
 }
 
 #endif /* COMMON_CPU_H */

--- a/hypervisor/include/common/cpu.h
+++ b/hypervisor/include/common/cpu.h
@@ -21,6 +21,9 @@
  */
 #define INVALID_CPU_ID		0xffffU
 
+/* hypervisor stack bottom magic('intl') */
+#define SP_BOTTOM_MAGIC    0x696e746cUL
+
 /* CPU states defined */
 enum pcpu_boot_state {
         PCPU_STATE_RESET = 0U,

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -6,7 +6,7 @@
 
 #ifndef LOGMSG_H
 #define LOGMSG_H
-#include <asm/cpu.h>
+#include <cpu.h>
 
 /* Logging severity levels */
 #define LOG_FATAL		1U


### PR DESCRIPTION
 This patchset adds the smp boot support for risc-v.

 v2 -> v3:
 - Rebase to the latest of the multi-arch-dev and remove some dependencies
   in "[FIXME] hv: riscv: add build dependencies temporarily"
 - Rename dts_hart_ids to dt_hart_ids
 - When duplicated BSP hart ID, just panic and add comments for it

 v1 -> v2:
 - Rebase to the latest of the multi-arch-dev
 - Move the timeout handling from arch_start_pcpu to start_pcpus
 - Squash the patch "hv: multi-arch: move pcpu_set_current_state to common"
   to "hv: multi-arch: abstract some pcpu related interfaces"
 - Add comments for init_percpu_hart_id

Acked-by: Wang, Yu1 <yu1.wang@intel.com>
