### PR TITLE
hv: riscv: Initialize timer when boot

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -155,6 +155,8 @@ COMMON_C_SRCS += lib/memory.c
 COMMON_C_SRCS += lib/bits.c
 COMMON_C_SRCS += common/ticks.c
 COMMON_C_SRCS += common/delay.c
+COMMON_C_SRCS += common/timer.c
+COMMON_C_SRCS += common/softirq.c
 
 # library componment
 COMMON_C_SRCS += lib/string.c
@@ -169,9 +171,7 @@ COMMON_C_SRCS += lib/stack_protector.c
 endif
 
 ifeq ($(ARCH),x86)
-COMMON_C_SRCS += common/timer.c
 COMMON_C_SRCS += common/irq.c
-COMMON_C_SRCS += common/softirq.c
 COMMON_C_SRCS += common/schedule.c
 COMMON_C_SRCS += common/event.c
 COMMON_C_SRCS += common/efi_mmap.c

--- a/hypervisor/arch/riscv/init.c
+++ b/hypervisor/arch/riscv/init.c
@@ -11,6 +11,7 @@
 #include <cpu.h>
 #include <per_cpu.h>
 #include <logmsg.h>
+#include <timer.h>
 
 static void init_pcpu_comm_post(void);
 
@@ -80,6 +81,8 @@ static void init_pcpu_comm_post(void)
 	uint16_t pcpu_id;
 
 	pcpu_id = get_pcpu_id();
+
+	timer_init();
 
 	/* to be implemented */
 	(void)pcpu_id;

--- a/hypervisor/common/timer.c
+++ b/hypervisor/common/timer.c
@@ -7,11 +7,6 @@
 #include <types.h>
 #include <errno.h>
 #include <per_cpu.h>
-#include <asm/io.h>
-#include <asm/msr.h>
-#include <asm/apicreg.h>
-#include <asm/cpuid.h>
-#include <asm/cpu_caps.h>
 #include <softirq.h>
 #include <trace.h>
 #include <asm/irq.h>


### PR DESCRIPTION
This patch calls timer_init() to initialize timer when boot and moves timer.c and softirq.c out from x86 to make them be built for risc-v too.

To pass the compilation, it has some dependencies.
1. In softirq.c, it calls CPU_IRQ_DISABLE_ON_CONFIG/CPU_IRQ_ENABLE_ON_CONFIG which will be implemented by https://lists.projectacrn.org/g/acrn-dev/topic/patch_v2_3_5_hv_riscv/115408231
2. In timer.c, it calls TRACE_2L which will be implemented by https://github.com/projectacrn/acrn-hypervisor/pull/8806
3. In timer.c, it calls ASSERT()->asm_assert() which has not been available for debug build.
4. In local_irq_save(), "*(uint32_t *)(x) = val" cannot pass compilation. Shiqing will fix it in https://lists.projectacrn.org/g/acrn-dev/topic/patch_v2_3_5_hv_riscv/115408231

Tracked-On: #8816
