### PR TITLE
hv schedule and idle thread module multiarch support

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -158,6 +158,10 @@ COMMON_C_SRCS += common/delay.c
 COMMON_C_SRCS += common/timer.c
 COMMON_C_SRCS += common/softirq.c
 COMMON_C_SRCS += common/trace.c
+COMMON_C_SRCS += common/schedule.c
+ifeq ($(CONFIG_SCHED_NOOP),y)
+COMMON_C_SRCS += common/sched_noop.c
+endif
 
 # library componment
 COMMON_C_SRCS += lib/string.c
@@ -173,7 +177,6 @@ endif
 
 ifeq ($(ARCH),x86)
 COMMON_C_SRCS += common/irq.c
-COMMON_C_SRCS += common/schedule.c
 COMMON_C_SRCS += common/event.c
 COMMON_C_SRCS += common/efi_mmap.c
 COMMON_C_SRCS += common/sbuf.c
@@ -200,9 +203,6 @@ COMMON_C_SRCS += dm/vpci/vsriov.c
 COMMON_C_SRCS += dm/vpci/vmcs9900.c
 COMMON_C_SRCS += dm/mmio_dev.c
 COMMON_C_SRCS += dm/vgpio.c
-ifeq ($(CONFIG_SCHED_NOOP),y)
-COMMON_C_SRCS += common/sched_noop.c
-endif
 ifeq ($(CONFIG_SCHED_IORR),y)
 COMMON_C_SRCS += common/sched_iorr.c
 endif

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -157,6 +157,7 @@ COMMON_C_SRCS += common/ticks.c
 COMMON_C_SRCS += common/delay.c
 COMMON_C_SRCS += common/timer.c
 COMMON_C_SRCS += common/softirq.c
+COMMON_C_SRCS += common/trace.c
 
 # library componment
 COMMON_C_SRCS += lib/string.c
@@ -199,7 +200,6 @@ COMMON_C_SRCS += dm/vpci/vsriov.c
 COMMON_C_SRCS += dm/vpci/vmcs9900.c
 COMMON_C_SRCS += dm/mmio_dev.c
 COMMON_C_SRCS += dm/vgpio.c
-COMMON_C_SRCS += common/trace.c
 ifeq ($(CONFIG_SCHED_NOOP),y)
 COMMON_C_SRCS += common/sched_noop.c
 endif

--- a/hypervisor/arch/riscv/Makefile
+++ b/hypervisor/arch/riscv/Makefile
@@ -39,6 +39,7 @@ ARCH_ASFLAGS += -march=rv64$(subst $() $(),_,$(RV_ISA))
 # HV host assembly sources
 HOST_S_SRCS += arch/riscv/boot/cpu_entry.S
 HOST_S_SRCS += arch/riscv/intr.S
+HOST_S_SRCS += arch/riscv/sched.S
 
 # HV host C sources
 HOST_C_SRCS += arch/riscv/init.c

--- a/hypervisor/arch/riscv/cpu.c
+++ b/hypervisor/arch/riscv/cpu.c
@@ -15,6 +15,7 @@
 #include <delay.h>
 #include <asm/sbi.h>
 #include <asm/pgtable.h>
+#include <schedule.h>
 
 /*
  * This array contains the hart IDs for each physial cpu.
@@ -113,4 +114,17 @@ void arch_start_pcpu(uint16_t pcpu_id)
 	if (ret != SBI_SUCCESS) {
 		pr_fatal("Failed to start cpu%hu by SBI HSM", pcpu_id);
 	}
+}
+
+void arch_cpu_do_idle(void)
+{
+        asm volatile ("wfi"::);
+}
+
+/**
+ * FIXME: This is a temp solution for now. The formal solution should clear up and put pcpu into a low power state.
+ */
+void arch_cpu_dead(void)
+{
+	while (true) {};
 }

--- a/hypervisor/arch/riscv/init.c
+++ b/hypervisor/arch/riscv/init.c
@@ -85,9 +85,7 @@ static void init_pcpu_comm_post(void)
 	timer_init();
 
 	/* to be implemented */
-	(void)pcpu_id;
+	init_sched(pcpu_id);
 
-	while (1) {
-		asm volatile("wfi" : : : "memory");
-	}
+	run_idle_thread();
 }

--- a/hypervisor/arch/riscv/notify.c
+++ b/hypervisor/arch/riscv/notify.c
@@ -10,6 +10,7 @@
 #include <types.h>
 #include <asm/irq.h>
 #include <asm/sbi.h>
+#include <schedule.h>
 
 void arch_init_smp_call(void)
 {
@@ -17,6 +18,11 @@ void arch_init_smp_call(void)
 }
 
 void arch_smp_call_kick_pcpu(uint16_t pcpu_id)
+{
+	send_single_ipi(pcpu_id, IPI_NOTIFY_CPU);
+}
+
+void arch_send_reschedule_request(uint16_t pcpu_id)
 {
 	send_single_ipi(pcpu_id, IPI_NOTIFY_CPU);
 }

--- a/hypervisor/arch/riscv/sched.S
+++ b/hypervisor/arch/riscv/sched.S
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2023-2025 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Authors:
+ *   Haicheng Li <haicheng.li@intel.com>
+ */
+
+	.text
+
+	.align 8
+	.global arch_switch_to
+arch_switch_to:
+
+/* refer to struct stack_frame */
+	addi sp, sp, -0x80
+	/*
+	 * 0x0=STACK_FRAME_OFFSET_RA
+	 * 0x8=STACK_FRAME_OFFSET_S0
+	 * 0x10=STACK_FRAME_OFFSET_S1
+	 * 0x18=STACK_FRAME_OFFSET_S2
+	 * 0x20=STACK_FRAME_OFFSET_S3
+	 * 0x28=STACK_FRAME_OFFSET_S4
+	 * 0x30=STACK_FRAME_OFFSET_S5
+	 * 0x38=STACK_FRAME_OFFSET_S6
+	 * 0x40=STACK_FRAME_OFFSET_S7
+	 * 0x48=STACK_FRAME_OFFSET_S8
+	 * 0x50=STACK_FRAME_OFFSET_S9
+	 * 0x58=STACK_FRAME_OFFSET_S10
+	 * 0x60=STACK_FRAME_OFFSET_S11
+	 * 0x68=STACK_FRAME_OFFSET_A0
+	 */
+	sd ra, 0x0(sp)
+	sd s0, 0x8(sp)
+	sd s1, 0x10(sp)
+	sd s2, 0x18(sp)
+	sd s3, 0x20(sp)
+	sd s4, 0x28(sp)
+	sd s5, 0x30(sp)
+	sd s6, 0x38(sp)
+	sd s7, 0x40(sp)
+	sd s8, 0x48(sp)
+	sd s9, 0x50(sp)
+	sd s10, 0x58(sp)
+	sd s11, 0x60(sp)
+	sd a0, 0x68(sp)
+	sd sp, 0(a0)
+
+	ld sp, 0(a1)
+	/*
+	 * 0x0=STACK_FRAME_OFFSET_RA
+	 * 0x8=STACK_FRAME_OFFSET_S0
+	 * 0x10=STACK_FRAME_OFFSET_S1
+	 * 0x18=STACK_FRAME_OFFSET_S2
+	 * 0x20=STACK_FRAME_OFFSET_S3
+	 * 0x28=STACK_FRAME_OFFSET_S4
+	 * 0x30=STACK_FRAME_OFFSET_S5
+	 * 0x38=STACK_FRAME_OFFSET_S6
+	 * 0x40=STACK_FRAME_OFFSET_S7
+	 * 0x48=STACK_FRAME_OFFSET_S8
+	 * 0x50=STACK_FRAME_OFFSET_S9
+	 * 0x58=STACK_FRAME_OFFSET_S10
+	 * 0x60=STACK_FRAME_OFFSET_S11
+	 * 0x68=STACK_FRAME_OFFSET_A0
+	 */
+	ld ra, 0x0(sp)
+	ld s0, 0x8(sp)
+	ld s1, 0x10(sp)
+	ld s2, 0x18(sp)
+	ld s3, 0x20(sp)
+	ld s4, 0x28(sp)
+	ld s5, 0x30(sp)
+	ld s6, 0x38(sp)
+	ld s7, 0x40(sp)
+	ld s8, 0x48(sp)
+	ld s9, 0x50(sp)
+	ld s10, 0x58(sp)
+	ld s11, 0x60(sp)
+	ld a0, 0x68(sp)
+	addi sp, sp, 0x80
+
+	ret

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -392,7 +392,7 @@ void stop_pcpus(void)
 	wait_pcpus_offline(mask);
 }
 
-void cpu_do_idle(void)
+void arch_cpu_do_idle(void)
 {
 #ifdef CONFIG_KEEP_IRQ_DISABLED
 	asm_pause();
@@ -418,7 +418,7 @@ void cpu_do_idle(void)
 /**
  * only run on current pcpu
  */
-void cpu_dead(void)
+void arch_cpu_dead(void)
 {
 	/* For debug purposes, using a stack variable in the while loop enables
 	 * us to modify the value using a JTAG probe and resume if needed.
@@ -426,7 +426,6 @@ void cpu_dead(void)
 	int32_t halt = 1;
 	uint16_t pcpu_id = get_pcpu_id();
 
-	deinit_sched(pcpu_id);
 	if (is_pcpu_active(pcpu_id)) {
 		/* clean up native stuff */
 		vmx_off();

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -536,17 +536,17 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 			 * idle, the kick mode is certainly ipi kick) will change
 			 * it to PAUSE idle right away.
 			 */
-			if (per_cpu(mode_to_idle, pcpu_id) == IDLE_MODE_HLT) {
-				per_cpu(mode_to_idle, pcpu_id) = IDLE_MODE_PAUSE;
+			if (per_cpu(arch.idle_mode, pcpu_id) == IDLE_MODE_HLT) {
+				per_cpu(arch.idle_mode, pcpu_id) = IDLE_MODE_PAUSE;
 				kick_pcpu(pcpu_id);
 			}
-			per_cpu(mode_to_kick_pcpu, pcpu_id) = DEL_MODE_INIT;
+			per_cpu(arch.kick_pcpu_mode, pcpu_id) = DEL_MODE_INIT;
 		} else {
-			per_cpu(mode_to_kick_pcpu, pcpu_id) = DEL_MODE_IPI;
-			per_cpu(mode_to_idle, pcpu_id) = IDLE_MODE_HLT;
+			per_cpu(arch.kick_pcpu_mode, pcpu_id) = DEL_MODE_IPI;
+			per_cpu(arch.idle_mode, pcpu_id) = IDLE_MODE_HLT;
 		}
 		pr_info("pcpu=%d, kick-mode=%d, use_init_flag=%d", pcpu_id,
-			per_cpu(mode_to_kick_pcpu, pcpu_id), is_using_init_ipi());
+			per_cpu(arch.kick_pcpu_mode, pcpu_id), is_using_init_ipi());
 
 		/* Initialize the parent VM reference */
 		vcpu->vm = vm;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -23,20 +23,6 @@
 #include <asm/irq.h>
 #include <console.h>
 
-/* stack_frame is linked with the sequence of stack operation in arch_switch_to() */
-struct stack_frame {
-	uint64_t rdi;
-	uint64_t r15;
-	uint64_t r14;
-	uint64_t r13;
-	uint64_t r12;
-	uint64_t rbp;
-	uint64_t rbx;
-	uint64_t rflag;
-	uint64_t rip;
-	uint64_t magic;
-};
-
 uint64_t vcpu_get_gpreg(const struct acrn_vcpu *vcpu, uint32_t reg)
 {
 	const struct run_context *ctx =

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -297,7 +297,7 @@ void send_single_init(uint16_t pcpu_id)
 
 void kick_pcpu(uint16_t pcpu_id)
 {
-	if (per_cpu(mode_to_kick_pcpu, pcpu_id) == DEL_MODE_INIT) {
+	if (per_cpu(arch.kick_pcpu_mode, pcpu_id) == DEL_MODE_INIT) {
 		send_single_init(pcpu_id);
 	} else {
 		send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -15,6 +15,7 @@
 #include <asm/guest/vm.h>
 #include <asm/guest/virq.h>
 #include <common/notify.h>
+#include <schedule.h>
 #include <irq.h>
 #include <logmsg.h>
 
@@ -95,4 +96,9 @@ void arch_smp_call_kick_pcpu(uint16_t pcpu_id)
 	} else {
 		send_single_ipi(pcpu_id, NOTIFY_VCPU_VECTOR);
 	}
+}
+
+void arch_send_reschedule_request(uint16_t pcpu_id)
+{
+	kick_pcpu(pcpu_id);
 }

--- a/hypervisor/common/cpu.c
+++ b/hypervisor/common/cpu.c
@@ -8,7 +8,7 @@
 #include <delay.h>
 #include <logmsg.h>
 #include <bits.h>
-
+#include <schedule.h>
 
 static volatile uint64_t pcpu_active_bitmap = 0UL;
 
@@ -111,4 +111,12 @@ bool start_pcpus(uint64_t mask)
 	}
 
 	return check_pcpus_active(mask);
+}
+
+void cpu_dead(void)
+{
+	uint16_t pcpu_id = get_pcpu_id();
+
+	deinit_sched(pcpu_id);
+	arch_cpu_dead();
 }

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -5,7 +5,6 @@
  */
 
 #include <asm/guest/vm.h>
-#include <asm/guest/vm_reset.h>
 #include <asm/guest/vmcs.h>
 #include <asm/guest/vmexit.h>
 #include <asm/guest/virq.h>
@@ -73,43 +72,4 @@ void vcpu_thread(struct thread_object *obj)
 
 		profiling_post_vmexit_handler(vcpu);
 	} while (1);
-}
-
-void default_idle(__unused struct thread_object *obj)
-{
-	uint16_t pcpu_id = get_pcpu_id();
-
-	while (1) {
-		if (need_reschedule(pcpu_id)) {
-			schedule();
-		} else if (need_offline(pcpu_id)) {
-			cpu_dead();
-		} else if (need_shutdown_vm(pcpu_id)) {
-			shutdown_vm_from_idle(pcpu_id);
-		} else {
-			cpu_do_idle();
-		}
-	}
-}
-
-void run_idle_thread(void)
-{
-	uint16_t pcpu_id = get_pcpu_id();
-	struct thread_object *idle = &per_cpu(idle, pcpu_id);
-	struct sched_params idle_params = {0};
-	char idle_name[16];
-
-	snprintf(idle_name, 16U, "idle%hu", pcpu_id);
-	(void)strncpy_s(idle->name, 16U, idle_name, 16U);
-	idle->pcpu_id = pcpu_id;
-	idle->thread_entry = default_idle;
-	idle->switch_out = NULL;
-	idle->switch_in = NULL;
-	idle_params.prio = PRIO_IDLE;
-	init_thread_data(idle, &idle_params);
-
-	run_thread(idle);
-
-	/* Control should not come here */
-	cpu_dead();
 }

--- a/hypervisor/common/sched_iorr.c
+++ b/hypervisor/common/sched_iorr.c
@@ -118,7 +118,7 @@ int sched_iorr_add_timer(struct sched_control *ctl)
 	return ret;
 }
 
-static int sched_iorr_del_timer(struct sched_control *ctl)
+static void sched_iorr_del_timer(struct sched_control *ctl)
 {
 	struct sched_iorr_control *iorr_ctl = (struct sched_iorr_control *)ctl->priv;
 	del_timer(&iorr_ctl->tick_timer);

--- a/hypervisor/common/sched_noop.c
+++ b/hypervisor/common/sched_noop.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <schedule.h>
 
 static int32_t sched_noop_init(struct sched_control *ctl)

--- a/hypervisor/common/sched_prio.c
+++ b/hypervisor/common/sched_prio.c
@@ -5,7 +5,7 @@
  */
 
 #include <list.h>
-#include <asm/per_cpu.h>
+#include <per_cpu.h>
 #include <schedule.h>
 
 struct sched_prio_data {

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -65,9 +65,6 @@ void init_sched(uint16_t pcpu_id)
 {
 	struct sched_control *ctl = &per_cpu(sched_ctl, pcpu_id);
 
-	per_cpu(mode_to_idle, pcpu_id) = IDLE_MODE_HLT;
-	per_cpu(mode_to_kick_pcpu, pcpu_id) = DEL_MODE_IPI;
-
 	spinlock_init(&ctl->scheduler_lock);
 	ctl->flags = 0UL;
 	ctl->curr_obj = NULL;
@@ -145,9 +142,6 @@ struct thread_object *sched_get_current(uint16_t pcpu_id)
 	return ctl->curr_obj;
 }
 
-/**
- * @pre delmode == DEL_MODE_IPI || delmode == DEL_MODE_INIT
- */
 void make_reschedule_request(uint16_t pcpu_id)
 {
 	struct sched_control *ctl = &per_cpu(sched_ctl, pcpu_id);

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -13,6 +13,7 @@
 #include <sprintf.h>
 #include <irq.h>
 #include <trace.h>
+#include <asm/guest/vm_reset.h>
 
 bool is_idle_thread(const struct thread_object *obj)
 {
@@ -266,4 +267,43 @@ void run_thread(struct thread_object *obj)
 	if (obj->thread_entry != NULL) {
 		obj->thread_entry(obj);
 	}
+}
+
+void default_idle(__unused struct thread_object *obj)
+{
+	uint16_t pcpu_id = get_pcpu_id();
+
+	while (1) {
+		if (need_reschedule(pcpu_id)) {
+			schedule();
+		} else if (need_offline(pcpu_id)) {
+			cpu_dead();
+		} else if (need_shutdown_vm(pcpu_id)) {
+			shutdown_vm_from_idle(pcpu_id);
+		} else {
+			cpu_do_idle();
+		}
+	}
+}
+
+void run_idle_thread(void)
+{
+	uint16_t pcpu_id = get_pcpu_id();
+	struct thread_object *idle = &per_cpu(idle, pcpu_id);
+	struct sched_params idle_params = {0};
+	char idle_name[16];
+
+	snprintf(idle_name, 16U, "idle%hu", pcpu_id);
+	(void)strncpy_s(idle->name, 16U, idle_name, 16U);
+	idle->pcpu_id = pcpu_id;
+	idle->thread_entry = default_idle;
+	idle->switch_out = NULL;
+	idle->switch_in = NULL;
+	idle_params.prio = PRIO_IDLE;
+	init_thread_data(idle, &idle_params);
+
+	run_thread(idle);
+
+	/* Control should not come here */
+	cpu_dead();
 }

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -7,12 +7,11 @@
 #include <rtl.h>
 #include <list.h>
 #include <bits.h>
-#include <asm/cpu.h>
+#include <cpu.h>
 #include <per_cpu.h>
-#include <asm/lapic.h>
 #include <schedule.h>
 #include <sprintf.h>
-#include <asm/irq.h>
+#include <irq.h>
 #include <trace.h>
 
 bool is_idle_thread(const struct thread_object *obj)
@@ -155,7 +154,7 @@ void make_reschedule_request(uint16_t pcpu_id)
 
 	bitmap_set(NEED_RESCHEDULE, &ctl->flags);
 	if (get_pcpu_id() != pcpu_id) {
-		kick_pcpu(pcpu_id);
+		arch_send_reschedule_request(pcpu_id);
 	}
 }
 

--- a/hypervisor/include/arch/riscv/asm/cpu.h
+++ b/hypervisor/include/arch/riscv/asm/cpu.h
@@ -63,6 +63,39 @@ struct cpu_regs {
 	uint64_t scratch;
 };
 
+/* stack_frame is linked with the sequence of stack operation in arch_switch_to() */
+#define STACK_FRAME_OFFSET_RA        0x0
+#define STACK_FRAME_OFFSET_S0        0x8
+#define STACK_FRAME_OFFSET_S1        0x10
+#define STACK_FRAME_OFFSET_S2        0x18
+#define STACK_FRAME_OFFSET_S3        0x20
+#define STACK_FRAME_OFFSET_S4        0x28
+#define STACK_FRAME_OFFSET_S5        0x30
+#define STACK_FRAME_OFFSET_S6        0x38
+#define STACK_FRAME_OFFSET_S7        0x40
+#define STACK_FRAME_OFFSET_S8        0x48
+#define STACK_FRAME_OFFSET_S9        0x50
+#define STACK_FRAME_OFFSET_S10       0x58
+#define STACK_FRAME_OFFSET_S11       0x60
+#define STACK_FRAME_OFFSET_A0        0x68
+struct stack_frame {
+	uint64_t ra;
+	uint64_t s0;
+	uint64_t s1;
+	uint64_t s2;
+	uint64_t s3;
+	uint64_t s4;
+	uint64_t s5;
+	uint64_t s6;
+	uint64_t s7;
+	uint64_t s8;
+	uint64_t s9;
+	uint64_t s10;
+	uint64_t s11;
+	uint64_t a0; /* thread_object parameter */
+	uint64_t magic;
+};
+
 #define cpu_relax()	cpu_memory_barrier() /* TODO: replace with yield instruction */
 #define NR_CPUS		MAX_PCPU_NUM
 

--- a/hypervisor/include/arch/riscv/asm/cpu.h
+++ b/hypervisor/include/arch/riscv/asm/cpu.h
@@ -182,6 +182,13 @@ void wait_sync_change(volatile const uint64_t *sync, uint64_t wake_sync);
 void init_percpu_hart_id(uint32_t bsp_hart_id);
 uint16_t get_pcpu_id_from_hart_id(uint32_t hart_id);
 
+/* FIXME: riscv dummy function */
+static inline bool need_offline(uint16_t pcpu_id)
+{
+	(void)pcpu_id;
+	return false;
+}
+
 #else /* ASSEMBLER */
 #include <asm/offset.h>
 

--- a/hypervisor/include/arch/riscv/asm/cpu.h
+++ b/hypervisor/include/arch/riscv/asm/cpu.h
@@ -108,14 +108,6 @@ struct stack_frame {
 /* Define CPU stack alignment */
 #define CPU_STACK_ALIGN	16UL
 
-/**
- * FIXME: This is a temp solution for now. The formal solution should clear up and put pcpu into a low power state.
- */
-static inline void cpu_dead(void)
-{
-	while (true) {};
-}
-
 /* In ACRN, struct per_cpu_region is a critical data structure
  * containing key per-CPU data frequently accessed via get_cpu_var().
  * We use the tp register to store the current logical pCPU ID to

--- a/hypervisor/include/arch/riscv/asm/guest/vm.h
+++ b/hypervisor/include/arch/riscv/asm/guest/vm.h
@@ -11,4 +11,10 @@ struct acrn_vm {
 
 };
 
+/* FIXME: riscv dummy function */
+static inline bool need_shutdown_vm(uint16_t pcpu_id)
+{
+	(void)pcpu_id;
+	return false;
+}
 #endif /* VM_H_ */

--- a/hypervisor/include/arch/riscv/asm/guest/vm_reset.h
+++ b/hypervisor/include/arch/riscv/asm/guest/vm_reset.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef RISCV_VM_RESET_H_
+#define RISCV_VM_RESET_H_
+
+/* FIXME: riscv dummy function */
+static inline void shutdown_vm_from_idle(uint16_t pcpu_id)
+{
+	(void)pcpu_id;
+}
+
+#endif /* RISCV_VM_RESET_H_ */

--- a/hypervisor/include/arch/x86/asm/cpu.h
+++ b/hypervisor/include/arch/x86/asm/cpu.h
@@ -294,6 +294,12 @@ extern uint64_t               secondary_cpu_stack[1];
  */
 #define BROADCAST_CPU_ID 0xfffeU
 
+#define DEL_MODE_INIT		(1U)
+#define DEL_MODE_IPI		(2U)
+
+#define IDLE_MODE_PAUSE		(1U)
+#define IDLE_MODE_HLT		(2U)
+
 struct descriptor_table {
 	uint16_t limit;
 	uint64_t base;

--- a/hypervisor/include/arch/x86/asm/cpu.h
+++ b/hypervisor/include/arch/x86/asm/cpu.h
@@ -448,8 +448,6 @@ void dispatch_exception(struct intr_excp_ctx *ctx);
 void handle_nmi(__unused struct intr_excp_ctx *ctx);
 
 /* Function prototypes */
-void cpu_do_idle(void);
-void cpu_dead(void);
 void trampoline_start16(void);
 void load_pcpu_state_data(void);
 void init_pcpu_pre(bool is_bsp);

--- a/hypervisor/include/arch/x86/asm/cpu.h
+++ b/hypervisor/include/arch/x86/asm/cpu.h
@@ -261,6 +261,20 @@ enum cpu_reg_name {
 	/*CPU_REG_LAST*/
 };
 
+/* stack_frame is linked with the sequence of stack operation in arch_switch_to() */
+struct stack_frame {
+	uint64_t rdi;
+	uint64_t r15;
+	uint64_t r14;
+	uint64_t r13;
+	uint64_t r12;
+	uint64_t rbp;
+	uint64_t rbx;
+	uint64_t rflag;
+	uint64_t rip;
+	uint64_t magic;
+};
+
 /**********************************/
 /* EXTERNAL VARIABLES             */
 /**********************************/

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -373,7 +373,6 @@ static inline struct pi_desc *get_pi_desc(struct acrn_vcpu *vcpu)
 }
 
 uint16_t pcpuid_from_vcpu(const struct acrn_vcpu *vcpu);
-void default_idle(__unused struct thread_object *obj);
 void vcpu_thread(struct thread_object *obj);
 
 int32_t vmx_vmrun(struct run_context *context, int32_t ops, int32_t ibrs);

--- a/hypervisor/include/arch/x86/asm/per_cpu.h
+++ b/hypervisor/include/arch/x86/asm/per_cpu.h
@@ -30,6 +30,8 @@ struct per_cpu_arch {
 #endif
 	uint64_t tsc_suspend;
 	struct acrn_vcpu *whose_iwkey;
+	uint32_t kick_pcpu_mode;
+	uint32_t idle_mode;
 
 } __aligned(PAGE_SIZE); /* per_cpu_region size aligned with PAGE_SIZE */
 

--- a/hypervisor/include/common/cpu.h
+++ b/hypervisor/include/common/cpu.h
@@ -49,6 +49,9 @@ bool check_pcpus_inactive(uint64_t mask);
 uint64_t get_active_pcpu_bitmap(void);
 void pcpu_set_current_state(uint16_t pcpu_id, enum pcpu_boot_state state);
 bool start_pcpus(uint64_t mask);
+void arch_cpu_dead(void);
+void cpu_dead(void);
+void arch_cpu_do_idle(void);
 
 #define ALL_CPUS_MASK		((1UL << get_pcpu_nums()) - 1UL)
 #define AP_MASK			(ALL_CPUS_MASK & ~(1UL << BSP_CPU_ID))
@@ -66,6 +69,11 @@ static inline void set_current_pcpu_id(uint16_t pcpu_id)
 static inline void asm_pause(void)
 {
 	arch_asm_pause();
+}
+
+static inline void cpu_do_idle(void)
+{
+	arch_cpu_do_idle();
 }
 
 /* The mandatory functions should be implemented by arch. */

--- a/hypervisor/include/common/per_cpu.h
+++ b/hypervisor/include/common/per_cpu.h
@@ -47,8 +47,6 @@ struct per_cpu_region {
 	struct thread_object idle;
 	uint64_t pcpu_flag;
 	uint32_t softirq_servicing;
-	uint32_t mode_to_kick_pcpu;
-	uint32_t mode_to_idle;
 	struct smp_call_info_data smp_call_info;
 	struct list_head softirq_dev_entry_list;
 	enum pcpu_boot_state boot_state;

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -148,6 +148,7 @@ void yield_current(void);
 void schedule(void);
 
 void arch_send_reschedule_request(uint16_t pcpu_id);
+void arch_default_idle(__unused struct thread_object *obj);
 void arch_switch_to(void *prev_sp, void *next_sp);
 void run_idle_thread(void);
 #endif /* SCHEDULE_H */

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -12,12 +12,6 @@
 
 #define	NEED_RESCHEDULE		(1U)
 
-#define DEL_MODE_INIT		(1U)
-#define DEL_MODE_IPI		(2U)
-
-#define IDLE_MODE_PAUSE		(1U)
-#define IDLE_MODE_HLT		(2U)
-
 #define THREAD_DATA_SIZE	(256U)
 
 enum thread_object_state {

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -153,6 +153,7 @@ void wake_thread(struct thread_object *obj);
 void yield_current(void);
 void schedule(void);
 
+void arch_send_reschedule_request(uint16_t pcpu_id);
 void arch_switch_to(void *prev_sp, void *next_sp);
 void run_idle_thread(void);
 #endif /* SCHEDULE_H */


### PR DESCRIPTION
this patchset is for schedule and idle thread  module multiarch support and riscv implementation.

change log:
v3->v4
renaming(mode_to_idle->idle_mode , mode_to_kick_pcpu->kick_pcpu_mode)
renaming(arch_cpu_idle->arch_cpu_do_idle), keep cpu_do_idle naming.
v2->v3
1, rename init_percpu_mode to init_pcpu_idle_and_kick
2, keep kick_pcpu to be x86 specific api, add arch_send_reschedule_request to kick cpu.
3, remove tp save/restore in arch_switch_to.
v1->v2
1, arch_kick_pcpu calls send_single_ipi directly instead of arch_smp_call_kick_pcpu
2, move stack_frame definition from stack_frame.h to cpu.h
3，abstract default_idle thread, add dummy function(need_offline,need_shutdown_vm,shutdown_vm_from_idle)
4, add fixme for riscv cpu_dead
5, add some build fix for sched_*.c
6, drop trace dummy function implementation patch
7, move trace.c out of x86, it already implements dummy api with ACRNTRACE_ENABLED = n
8, only move schedule.c and sched_noop.c out of x86.
9, add init_sched in ap initialization.
