### PR TITLE
config: Remove AVAILABLE_IRQ_INFO values from RISC-V board XML

### DIFF
--- a/misc/config_tools/data/qemu-riscv/qemu-riscv.xml
+++ b/misc/config_tools/data/qemu-riscv/qemu-riscv.xml
@@ -15,7 +15,6 @@
        - Hart IDs instead of APIC IDs for CPU identification
     
     3. Some fields contain x86-specific concepts that need to be replaced with RISC-V equivalents:
-       - AVAILABLE_IRQ_INFO: Currently shows x86 ISA IRQs (0-15), should show PLIC IRQ range (1-95+)
        - apic_id: Should be replaced with hart_id for RISC-V processors
        - IOAPIC, DRHD: Not applicable to RISC-V architecture
     
@@ -140,7 +139,6 @@ ff71b000-ffffffff : System RAM
         seri:/dev/ttyS0 type:mmio base:0x10000000 irq:14
         </TTYS_INFO>
   <AVAILABLE_IRQ_INFO>
-        3, 4, 5, 6, 7, 8, 9, 11
         </AVAILABLE_IRQ_INFO>
   <TOTAL_MEM_INFO>
         4038724 kB


### PR DESCRIPTION
Clear AVAILABLE_IRQ_INFO content in qemu-riscv.xml as the x86 ISA IRQ values (3, 4, 5, 6, 7, 8, 9, 11) are not applicable to RISC-V architecture.

Note: This leaves AVAILABLE_IRQ_INFO empty as a placeholder. A proper RISC-V implementation should populate this field and fill the device tree for VM.

Tracked-On: #8814
Reviewed-by: Fei Li <fei1.li@intel.com>