### PR TITLE
misc: Add scenario file and change board file for QEMU virt platform

### DIFF
--- a/misc/config_tools/data/qemu-riscv/qemu-riscv.xml
+++ b/misc/config_tools/data/qemu-riscv/qemu-riscv.xml
@@ -27,7 +27,7 @@
     
     This file serves as a template and reference for RISC-V platform support development.
 -->
-<acrn-config board="riscv_board">
+<acrn-config board="qemu-riscv">
   <BIOS_INFO>
         BIOS Information
         Vendor: U-Boot
@@ -140,6 +140,10 @@ ff71b000-ffffffff : System RAM
         </TTYS_INFO>
   <AVAILABLE_IRQ_INFO>
         </AVAILABLE_IRQ_INFO>
+  <!-- Add memory range to pass xmlschema check -->
+  <memory>
+        <range start="0x80060000" end="0x100000000" size="2147090432"/>
+  </memory>
   <TOTAL_MEM_INFO>
         4038724 kB
         </TOTAL_MEM_INFO>

--- a/misc/config_tools/data/qemu-riscv/shared.xml
+++ b/misc/config_tools/data/qemu-riscv/shared.xml
@@ -1,0 +1,24 @@
+<acrn-config>
+  <hv>
+    <BUILD_TYPE>debug</BUILD_TYPE>
+    <DEBUG_OPTIONS>
+      <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+      <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+      <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+      <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+    </DEBUG_OPTIONS>
+    <FEATURES>
+      <RELOC_ENABLED>n</RELOC_ENABLED>
+      <SCHEDULER>SCHED_NOOP</SCHEDULER>
+      <ACRNTRACE_ENABLED>n</ACRNTRACE_ENABLED>
+    </FEATURES>
+    <MEMORY>
+      <STACK_SIZE>0x2000</STACK_SIZE>
+      <HV_RAM_START>0x81000000</HV_RAM_START>
+    </MEMORY>
+  </hv>
+  <vm id="0">
+    <load_order>SERVICE_VM</load_order>
+    <name>ACRN_Service_VM</name>
+  </vm>
+</acrn-config>


### PR DESCRIPTION
key scenario configuration for qemu-riscv board:
SCHEDULER:SCHED_NOOP
RELOC_ENABLED:n
HV_RAM_START:0x81000000
ACRNTRACE_ENABLED:n
make changes for riscv qemu board file.
change board name to be qemu-riscv to align with folder name, add memory ranage.

Tracked-On: #8814