### PR TITLE
Use tp register directly for arch_get_pcpu_id

### DIFF
--- a/hypervisor/include/arch/riscv/asm/cpu.h
+++ b/hypervisor/include/arch/riscv/asm/cpu.h
@@ -117,9 +117,7 @@ struct stack_frame {
  */
 static inline uint16_t arch_get_pcpu_id(void)
 {
-	uint16_t pcpu_id;
-
-	asm volatile ("mv %0, tp" : "=r" (pcpu_id) : : );
+	register uint16_t pcpu_id asm ("tp");
 	return pcpu_id;
 }
 


### PR DESCRIPTION
    Use tp register directly for arch_get_pcpu_id. This can eliminate the unnecessary mv instruction.
    Acked-by: Wang, Yu1 <yu1.wang@intel.com>