### PR TITLE
hv: riscv: fix stack allocation in cpu_ctx_save/cpu_ctx_restore

### DIFF
--- a/hypervisor/include/arch/riscv/asm/offset.h
+++ b/hypervisor/include/arch/riscv/asm/offset.h
@@ -56,6 +56,7 @@
 #define CPU_REGS_OFFSET_TVAL			0x118
 #define CPU_REGS_OFFSET_SCRATCH			0x120
 
-#define CPU_REGS_OFFSET_LAST 			CPU_REGS_OFFSET_SCRATCH
+/* Total context area size (struct cpu_regs). */
+#define CPU_REGS_OFFSET_LAST			(CPU_REGS_OFFSET_SCRATCH + 8)
 
 #endif /* RISCV_OFFSET_H */


### PR DESCRIPTION
The RISC-V calling convention defines a full descending stack, where 'sp' points to the last used stack address. The current implementation of cpu_ctx_save() subtracts only CPU_REGS_OFFSET_SCRATCH from 'sp', which allocates 8 bytes too few and may overwrite the caller's stack contents.

Fix this by adjusting CPU_REGS_OFFSET_LAST to include the last slot, ensuring the full context save/restore area is properly reserved.

Fixes: 6276763cd (hv: riscv: implement cpu_ctx_save and cpu_ctx_restore)

Tracked-On: #8827

Acked-by: Wang, Yu1 <yu1.wang@intel.com>