### PR TITLE
dump: dump hv image delta for risc-v

### DIFF
--- a/hypervisor/debug/riscv/dump.c
+++ b/hypervisor/debug/riscv/dump.c
@@ -5,6 +5,7 @@
  */
 
 #include <types.h>
+#include <reloc.h>
 #include <asm/irq.h>
 #include <asm/page.h>
 
@@ -21,8 +22,7 @@ static void show_host_call_trace(uint64_t stack_phy, uint64_t s0, uint16_t pcpu_
 	uint64_t *sp = (uint64_t *)stack_phy;
 	uint64_t dump_size = min(roundup(stack_phy, PAGE_SIZE) - stack_phy, DUMP_STACK_SIZE);
 
-	/* TODO: pritf the delta between the actual load address and the config load address here */
-	//pr_acrnlog("\r\n delta = (actual_load_address - CONFIG_HV_RAM_START) = 0x%llx\r\n", get_hv_image_delta());
+	pr_acrnlog("\r\n delta = (actual_load_address - CONFIG_HV_RAM_START) = 0x%llx\r\n", get_hv_image_delta());
 	pr_acrnlog("Host Stack: CPU_ID = %hu\r\n", pcpu_id);
 	for (i = 0U; i < (dump_size >> 5U); i++) {
 		pr_acrnlog("addr(0x%lx)	0x%016lx  0x%016lx  0x%016lx  0x%016lx\r\n",


### PR DESCRIPTION
dump hypervisor image load address delta for risc-v.

Note: using the riscv64-linux-gnu-addr2line to parse the `Host Call Trace` may not accurate when the complier using `O2` to build the hypervisor. In this case, it'd better to use riscv64-linux-gnu-objdump to `disassemble -D acrn.out` to parse the `Host Call Trace` manually to change the complier to use `O1` to build the hypervisor.

Tracked-On: #8805

Reviewed-by: Jian Jun Chen <jian.jun.chen@intel.com>