### PR TITLE
Enable riscv stack protector

### DIFF
--- a/hypervisor/arch/riscv/Makefile
+++ b/hypervisor/arch/riscv/Makefile
@@ -60,6 +60,7 @@ HOST_C_SRCS += arch/riscv/cpu.c
 HOST_C_SRCS += arch/riscv/mmu.c
 HOST_C_SRCS += arch/riscv/irq.c
 HOST_C_SRCS += arch/riscv/pgtable.c
+HOST_C_SRCS += arch/riscv/security.c
 
 #HV guest C source
 HOST_C_SRCS += arch/riscv/guest/vm.c

--- a/hypervisor/arch/riscv/Makefile
+++ b/hypervisor/arch/riscv/Makefile
@@ -50,6 +50,7 @@ HOST_S_SRCS += arch/riscv/sched.S
 
 # HV host C sources
 HOST_C_SRCS += arch/riscv/boot/reloc.c
+HOST_C_SRCS += arch/riscv/lib/random.c
 HOST_C_SRCS += arch/riscv/init.c
 HOST_C_SRCS += arch/riscv/sbi.c
 HOST_C_SRCS += arch/riscv/notify.c

--- a/hypervisor/arch/riscv/init.c
+++ b/hypervisor/arch/riscv/init.c
@@ -16,6 +16,9 @@
 #include <console.h>
 #include <shell.h>
 #include <uart16550.h>
+#ifdef STACK_PROTECTOR
+#include <asm/security.h>
+#endif
 
 static void init_pcpu_comm_post(void);
 
@@ -54,10 +57,14 @@ void init_primary_pcpu(uint64_t hart_id, uint64_t fdt_paddr)
 {
 	uint16_t pcpu_id = BSP_CPU_ID;
 	uint64_t pcpu_sp;
+
 	(void)fdt_paddr;
 
 	init_percpu_hart_id(hart_id);
 	set_pcpu_active(pcpu_id);
+#ifdef STACK_PROTECTOR
+	init_stack_canary();
+#endif
 
 	/*
 	 * Set state for this CPU to initializing, the current pcpu_id
@@ -120,7 +127,6 @@ static void init_pcpu_comm_post(void)
 	init_interrupt(pcpu_id);
 	timer_init();
 
-	/* to be implemented */
 	init_sched(pcpu_id);
 
 	init_debug_post(pcpu_id);

--- a/hypervisor/arch/riscv/lib/random.c
+++ b/hypervisor/arch/riscv/lib/random.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <types.h>
+
+/**
+ * @brief Generate a random 64-bit value using RISC-V timing counters
+ *
+ * This function provides a portable random number generation mechanism for
+ * RISC-V systems by combining entropy from hardware timing counters. Since
+ * the Zkr (Entropy Source) extension is optional in RVA23 profile and not
+ * universally available, this implementation uses standard timing counters
+ * that are present in all RISC-V systems.
+ *
+ * The implementation combines two entropy sources:
+ * - rdcycle: CPU cycle counter (high frequency, fast changing)
+ * - rdtime: Real-time counter (lower frequency, slower changing)
+ *
+ * The time counter value is left-shifted by 13 bits before XORing with the
+ * cycle counter. The shift value 13 is chosen to compensate for the frequency
+ * difference between counters.
+ *
+ * @return uint64_t A 64-bit pseudo-random value
+ *
+ * @fixme TODO: Detect Zkr extension availability and use CSR_SEED (0x015)
+ *        when hardware entropy source is present for better randomness quality.
+ */
+uint64_t arch_get_random_value(void)
+{
+	uint64_t cycle, time;
+
+	asm volatile ("rdcycle %0" : "=r"(cycle));
+	asm volatile ("rdtime %0" : "=r"(time));
+
+	return cycle ^ (time << 13U);
+}

--- a/hypervisor/arch/riscv/security.c
+++ b/hypervisor/arch/riscv/security.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <types.h>
+#include <asm/security.h>
+
+#ifdef STACK_PROTECTOR
+unsigned long __stack_chk_guard;
+#endif

--- a/hypervisor/arch/x86/Makefile
+++ b/hypervisor/arch/x86/Makefile
@@ -52,6 +52,7 @@ ASFLAGS += -m64 -nostdinc -nostdlib
 
 # library componment
 LIB_C_SRCS += arch/x86/lib/memory.c
+LIB_C_SRCS += arch/x86/lib/random.c
 
 # retpoline support
 ifeq (true, $(shell [ $(GCC_MAJOR) -eq 7 ] && [ $(GCC_MINOR) -ge 3 ] && echo true))

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -14,6 +14,7 @@
 #include <asm/cpufeatures.h>
 #include <asm/cpu_caps.h>
 #include <per_cpu.h>
+#include <random.h>
 #include <asm/init.h>
 #include <asm/guest/vm.h>
 #include <asm/guest/vmcs.h>

--- a/hypervisor/arch/x86/lib/random.c
+++ b/hypervisor/arch/x86/lib/random.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <types.h>
+
+uint64_t arch_get_random_value(void)
+{
+	uint64_t random;
+
+	asm volatile ("1: rdrand %%rax\n"
+			"jnc 1b\n"
+			"mov %%rax, %0\n"
+			: "=r"(random)
+			:
+			:"%rax");
+	return random;
+}

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -94,7 +94,7 @@ struct acpi_reset_reg *get_host_reset_reg_data(void)
 void restore_msrs(void)
 {
 #ifdef STACK_PROTECTOR
-	struct stack_canary *psc = &get_cpu_var(stk_canary);
+	struct stack_canary *psc = &get_cpu_var(arch.stk_canary);
 
 	msr_write(MSR_IA32_FS_BASE, (uint64_t)psc);
 #endif

--- a/hypervisor/arch/x86/security.c
+++ b/hypervisor/arch/x86/security.c
@@ -215,7 +215,7 @@ uint64_t get_random_value(void)
 void set_fs_base(void)
 {
 	int retry;
-	struct stack_canary *psc = &get_cpu_var(stk_canary);
+	struct stack_canary *psc = &get_cpu_var(arch.stk_canary);
 
 	/*
 	 *  1) Leave initialized canary untouched when this function

--- a/hypervisor/arch/x86/security.c
+++ b/hypervisor/arch/x86/security.c
@@ -12,6 +12,7 @@
 #include <asm/cpu_caps.h>
 #include <asm/security.h>
 #include <logmsg.h>
+#include <random.h>
 
 static bool skip_l1dfl_vmentry;
 static bool cpu_md_clear;
@@ -196,19 +197,6 @@ void cpu_internal_buffers_clear(void)
 	if (cpu_md_clear) {
 		verw_buffer_overwriting();
 	}
-}
-
-uint64_t get_random_value(void)
-{
-	uint64_t random;
-
-	asm volatile ("1: rdrand %%rax\n"
-			"jnc 1b\n"
-			"mov %%rax, %0\n"
-			: "=r"(random)
-			:
-			:"%rax");
-	return random;
 }
 
 #ifdef STACK_PROTECTOR

--- a/hypervisor/include/arch/riscv/asm/security.h
+++ b/hypervisor/include/arch/riscv/asm/security.h
@@ -4,14 +4,29 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef SECURITY_H
-#define SECURITY_H
+#ifndef RISCV_SECURITY_H
+#define RISCV_SECURITY_H
 
+#ifdef STACK_PROTECTOR
+#include <random.h>
+#endif
 
-struct stack_canary {
+#ifdef STACK_PROTECTOR
 
-};
+extern unsigned long __stack_chk_guard;
 
+/*
+ * Initialize the stack protector __stack_chk_guard.
+ *
+ * NOTE: this function changes the __stack_chk_guard,
+ *  - It must only be called from functions that never return
+ *  - It must always be inlined itself
+ */
+static inline __attribute__((__always_inline__)) void init_stack_canary(void)
+{
+	__stack_chk_guard = get_random_value();
+}
 
+#endif /* STACK_PROTECTOR */
 
-#endif /* SECURITY_H */
+#endif /* RISCV_SECURITY_H */

--- a/hypervisor/include/arch/x86/asm/per_cpu.h
+++ b/hypervisor/include/arch/x86/asm/per_cpu.h
@@ -25,6 +25,9 @@ struct per_cpu_arch {
 	uint8_t sf_stack[CONFIG_STACK_SIZE] __aligned(16);
 	uint32_t lapic_id;
 	uint32_t lapic_ldr;
+#ifdef STACK_PROTECTOR
+	struct stack_canary stk_canary;
+#endif
 #ifdef PROFILING_ON
 	struct profiling_info_wrapper profiling_info;
 #endif

--- a/hypervisor/include/arch/x86/asm/security.h
+++ b/hypervisor/include/arch/x86/asm/security.h
@@ -22,7 +22,6 @@ void cpu_l1d_flush(void);
 bool check_cpu_security_cap(void);
 void cpu_internal_buffers_clear(void);
 bool is_ept_force_4k_ipage(void);
-uint64_t get_random_value(void);
 void disable_rrsba(void);
 
 #ifdef STACK_PROTECTOR

--- a/hypervisor/include/arch/x86/asm/security.h
+++ b/hypervisor/include/arch/x86/asm/security.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef SECURITY_H
-#define SECURITY_H
+#ifndef X86_SECURITY_H
+#define X86_SECURITY_H
 
 /* type of speculation control
  * 0 - no speculation control support
@@ -35,4 +35,4 @@ void set_fs_base(void);
 
 #endif /* ASSEMBLER */
 
-#endif /* SECURITY_H */
+#endif /* X86_SECURITY_H */

--- a/hypervisor/include/common/per_cpu.h
+++ b/hypervisor/include/common/per_cpu.h
@@ -33,9 +33,6 @@ struct per_cpu_region {
 	uint64_t softirq_pending;
 	uint64_t spurious;
 	struct acrn_vcpu *ever_run_vcpu;
-#ifdef STACK_PROTECTOR
-	struct stack_canary stk_canary;
-#endif
 	struct per_cpu_timers cpu_timers;
 	/*TODO: we only need sched_ctl as configured,
 	  not neccessarily to have them all */

--- a/hypervisor/include/common/random.h
+++ b/hypervisor/include/common/random.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef COMMON_RANDOM_H
+#define COMMON_RANDOM_H
+
+uint64_t arch_get_random_value(void);
+
+static inline uint64_t get_random_value(void)
+{
+	return arch_get_random_value();
+}
+
+#endif /* COMMON_RANDOM_H */


### PR DESCRIPTION
This patchset enables the stack protector for risc-v.

Reviewed-by: Fei Li <fei1.li@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>